### PR TITLE
feat(renovate): add crd-schema-publisher to discovery filters

### DIFF
--- a/apps/renovate/manifests/renovatejob.yaml
+++ b/apps/renovate/manifests/renovatejob.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   discoveryFilters:
     [
-      "/sholdee/(docker-compose|caddy-proxy-cloudflare|adguard-exporter|home-ops)/",
+      "/sholdee/(docker-compose|caddy-proxy-cloudflare|adguard-exporter|crd-schema-publisher|home-ops)/",
     ]
   extraEnv:
     - name: LOG_LEVEL


### PR DESCRIPTION
## Summary

- Add `crd-schema-publisher` to Renovate discovery filters so it manages Go module, Docker image, and GitHub Actions updates for that repo

## Test plan

- [ ] Renovate discovers `sholdee/crd-schema-publisher` on next run
- [ ] Dependency dashboard appears on the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)