### PR TITLE
fix(renovate): increase memory limits to 2048Mi

### DIFF
--- a/apps/renovate/manifests/renovatejob.yaml
+++ b/apps/renovate/manifests/renovatejob.yaml
@@ -15,7 +15,7 @@ spec:
     - name: RENOVATE_PLATFORM_COMMIT
       value: "true"
     - name: NODE_OPTIONS
-      value: "--max-old-space-size=1024"
+      value: "--max-old-space-size=1536"
     - name: RENOVATE_REDIS_URL
       value: "redis://renovate-redis.renovate.svc.cluster.local:6379"
     - name: RENOVATE_REPOSITORY_CACHE
@@ -37,10 +37,10 @@ spec:
   resources:
     requests:
       cpu: 500m
-      memory: 1280Mi
+      memory: 2048Mi
     limits:
       cpu: 500m
-      memory: 1280Mi
+      memory: 2048Mi
   webhook:
     enabled: true
     authentication:


### PR DESCRIPTION
## Summary
- Bumps Renovate job pod memory from 1280Mi to 2048Mi
- Bumps Node.js heap (`--max-old-space-size`) from 1024Mi to 1536Mi
- Fixes OOMKill when resolving `client-go` transitive dependency tree for `crd-schema-publisher`

## Test plan
- [ ] Verify Renovate job pod no longer OOMKilled
- [ ] Confirm Renovate successfully processes crd-schema-publisher repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)