### PR TITLE
feat(kubernetes-schemas): add Prometheus scrape annotations

### DIFF
--- a/apps/kubernetes-schemas/manifests/deployment.yaml
+++ b/apps/kubernetes-schemas/manifests/deployment.yaml
@@ -17,6 +17,10 @@ spec:
     metadata:
       labels:
         app: kubernetes-schemas
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: kubernetes-schemas
       securityContext:


### PR DESCRIPTION
## Summary

- Adds `prometheus.io/scrape`, `port`, and `path` annotations to the crd-schema-publisher pod template
- Enables automatic Prometheus discovery for the `/metrics` endpoint added in sholdee/crd-schema-publisher#17

## Test plan

- [ ] CI gate passes
- [ ] ArgoCD syncs successfully
- [ ] `curl` the `/metrics` endpoint via port-forward to verify scraping works

🤖 Generated with [Claude Code](https://claude.com/claude-code)