### PR TITLE
feat(kubernetes-schemas): replace prometheus annotations with PodMonitor

### DIFF
--- a/apps/kubernetes-schemas/kustomization.yaml
+++ b/apps/kubernetes-schemas/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - manifests/rolebinding.yaml
   - manifests/externalsecret.yaml
   - manifests/deployment.yaml
+  - manifests/podmonitor.yaml

--- a/apps/kubernetes-schemas/manifests/deployment.yaml
+++ b/apps/kubernetes-schemas/manifests/deployment.yaml
@@ -17,10 +17,6 @@ spec:
     metadata:
       labels:
         app: kubernetes-schemas
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "8080"
-        prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: kubernetes-schemas
       securityContext:

--- a/apps/kubernetes-schemas/manifests/podmonitor.yaml
+++ b/apps/kubernetes-schemas/manifests/podmonitor.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kubernetes-schemas
+  namespace: kubernetes-schemas
+  labels:
+    app: kubernetes-schemas
+spec:
+  selector:
+    matchLabels:
+      app: kubernetes-schemas
+  podMetricsEndpoints:
+    - port: health
+      path: /metrics


### PR DESCRIPTION
## Summary

- Removes `prometheus.io/*` pod annotations (not used by Prometheus Operator)
- Adds PodMonitor CRD targeting the `health` port at `/metrics`
- Adds podmonitor.yaml to kustomization resources

## Test plan

- [ ] CI gate passes
- [ ] ArgoCD syncs PodMonitor + updated Deployment
- [ ] Prometheus discovers the target and scrapes `crdpublisher_*` metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)