### PR TITLE
refactor: rename kubernetes-schemas to crd-schema-publisher

### DIFF
--- a/apps/crd-schema-publisher/kustomization.yaml
+++ b/apps/crd-schema-publisher/kustomization.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kubernetes-schemas
+namespace: crd-schema-publisher
 components:
   - ../../components/namespace
 resources:

--- a/apps/crd-schema-publisher/manifests/clusterrole.yaml
+++ b/apps/crd-schema-publisher/manifests/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kubernetes-schemas
+  name: crd-schema-publisher
 rules:
   - apiGroups:
       - apiextensions.k8s.io

--- a/apps/crd-schema-publisher/manifests/clusterrolebinding.yaml
+++ b/apps/crd-schema-publisher/manifests/clusterrolebinding.yaml
@@ -2,12 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kubernetes-schemas
+  name: crd-schema-publisher
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubernetes-schemas
+  name: crd-schema-publisher
 subjects:
   - kind: ServiceAccount
-    name: kubernetes-schemas
-    namespace: kubernetes-schemas
+    name: crd-schema-publisher
+    namespace: crd-schema-publisher

--- a/apps/crd-schema-publisher/manifests/deployment.yaml
+++ b/apps/crd-schema-publisher/manifests/deployment.yaml
@@ -2,8 +2,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kubernetes-schemas
-  namespace: kubernetes-schemas
+  name: crd-schema-publisher
+  namespace: crd-schema-publisher
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
@@ -12,13 +12,13 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: kubernetes-schemas
+      app: crd-schema-publisher
   template:
     metadata:
       labels:
-        app: kubernetes-schemas
+        app: crd-schema-publisher
     spec:
-      serviceAccountName: kubernetes-schemas
+      serviceAccountName: crd-schema-publisher
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/apps/crd-schema-publisher/manifests/externalsecret.yaml
+++ b/apps/crd-schema-publisher/manifests/externalsecret.yaml
@@ -4,7 +4,7 @@ apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: cloudflare-credentials
-  namespace: kubernetes-schemas
+  namespace: crd-schema-publisher
 spec:
   refreshInterval: 1h
   secretStoreRef:
@@ -15,9 +15,9 @@ spec:
   data:
     - secretKey: CLOUDFLARE_API_TOKEN
       remoteRef:
-        key: kubernetes-schemas
+        key: crd-schema-publisher
         property: CLOUDFLARE_API_TOKEN
     - secretKey: CLOUDFLARE_ACCOUNT_ID
       remoteRef:
-        key: kubernetes-schemas
+        key: crd-schema-publisher
         property: CLOUDFLARE_ACCOUNT_ID

--- a/apps/crd-schema-publisher/manifests/namespace.yaml
+++ b/apps/crd-schema-publisher/manifests/namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kubernetes-schemas
+  name: crd-schema-publisher

--- a/apps/crd-schema-publisher/manifests/podmonitor.yaml
+++ b/apps/crd-schema-publisher/manifests/podmonitor.yaml
@@ -3,14 +3,14 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: kubernetes-schemas
-  namespace: kubernetes-schemas
+  name: crd-schema-publisher
+  namespace: crd-schema-publisher
   labels:
-    app: kubernetes-schemas
+    app: crd-schema-publisher
 spec:
   selector:
     matchLabels:
-      app: kubernetes-schemas
+      app: crd-schema-publisher
   podMetricsEndpoints:
     - port: health
       path: /metrics

--- a/apps/crd-schema-publisher/manifests/role.yaml
+++ b/apps/crd-schema-publisher/manifests/role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: crd-schema-publisher-leader-election
-  namespace: kubernetes-schemas
+  namespace: crd-schema-publisher
 rules:
   - apiGroups:
       - coordination.k8s.io

--- a/apps/crd-schema-publisher/manifests/rolebinding.yaml
+++ b/apps/crd-schema-publisher/manifests/rolebinding.yaml
@@ -3,12 +3,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: crd-schema-publisher-leader-election
-  namespace: kubernetes-schemas
+  namespace: crd-schema-publisher
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: crd-schema-publisher-leader-election
 subjects:
   - kind: ServiceAccount
-    name: kubernetes-schemas
-    namespace: kubernetes-schemas
+    name: crd-schema-publisher
+    namespace: crd-schema-publisher

--- a/apps/crd-schema-publisher/manifests/serviceaccount.yaml
+++ b/apps/crd-schema-publisher/manifests/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crd-schema-publisher
+  namespace: crd-schema-publisher

--- a/apps/kubernetes-schemas/manifests/serviceaccount.yaml
+++ b/apps/kubernetes-schemas/manifests/serviceaccount.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kubernetes-schemas
-  namespace: kubernetes-schemas


### PR DESCRIPTION
## Summary

- Renames app directory `kubernetes-schemas/` → `crd-schema-publisher/` to match the upstream project name
- Updates namespace, ServiceAccount, ClusterRole, ClusterRoleBinding, Role, RoleBinding, Deployment, PodMonitor, and ExternalSecret resource names
- `CF_PAGES_PROJECT` remains `kubernetes-schemas` (Cloudflare Pages site name, separate concern)
- 1Password item already renamed to `crd-schema-publisher`

ArgoCD will prune the old `kubernetes-schemas` app and create `crd-schema-publisher` automatically via the ApplicationSet directory generator.

## Test plan

- [ ] CI gate passes
- [ ] ArgoCD creates new `crd-schema-publisher` app and prunes old `kubernetes-schemas`
- [ ] ExternalSecret syncs successfully with renamed 1Password item
- [ ] Pod starts and publishes to Cloudflare Pages
- [ ] Prometheus scrapes via PodMonitor in new namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)