### PR TITLE
fix(renovate): disable automerge for main cilium helm release

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,6 +35,7 @@
       ],
       additionalBranchPrefix: 'cilium-',
       commitMessageSuffix: ' [cilium]',
+      automerge: false,
     },
     {
       description: 'Separate PRs for cilium-preflight',


### PR DESCRIPTION
## Summary
- Adds explicit `automerge: false` to the main Cilium packageRule in Renovate config
- The broad "automerge all helm minor/patch/digest" rule was matching the main Cilium chart (PR #2673) because the Cilium-specific rule never disabled automerge
- Only `cilium-preflight` should automerge; the full `cilium` release requires manual review

## Test plan
- [x] Verify Renovate validates config successfully (pre-commit `check-renovate` passed)
- [x] Next Cilium helm release PR should not have automerge enabled