### PR TITLE
feat(argocd): add grafana operator application

### DIFF
--- a/apps/argocd/manifests/apps.yaml
+++ b/apps/argocd/manifests/apps.yaml
@@ -138,6 +138,50 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  name: grafana-operator
+spec:
+  destination:
+    name: in-cluster
+    namespace: monitoring
+  project: k3s
+  source:
+    chart: grafana-operator
+    repoURL: ghcr.io/grafana/helm-charts
+    targetRevision: 5.22.2
+    helm:
+      releaseName: grafana-operator
+      valuesObject:
+        crds:
+          immutable: false
+        dashboard:
+          enabled: true
+        serviceMonitor:
+          enabled: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 256Mi
+        podSecurityContext:
+          runAsNonRoot: true
+          runAsUser: 65534
+          runAsGroup: 65534
+          fsGroup: 65534
+          seccompProfile:
+            type: RuntimeDefault
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+      - ApplyOutOfSyncOnly=true
+      - CreateNamespace=true
+      - ServerSideApply=true
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/argoproj.io/application_v1alpha1.json
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
   name: longhorn
 spec:
   destination:

--- a/apps/argocd/manifests/repos.yaml
+++ b/apps/argocd/manifests/repos.yaml
@@ -14,6 +14,20 @@ type: Opaque
 ---
 apiVersion: v1
 stringData:
+  name: grafana-charts
+  project: k3s
+  type: helm
+  url: ghcr.io/grafana/helm-charts
+  enableOCI: "true"
+kind: Secret
+metadata:
+  labels:
+    argocd.argoproj.io/secret-type: repository
+  name: grafana-charts
+type: Opaque
+---
+apiVersion: v1
+stringData:
   name: longhorn
   project: k3s
   type: helm

--- a/docs/grafana-operator-migration.md
+++ b/docs/grafana-operator-migration.md
@@ -1,0 +1,23 @@
+# Grafana Operator Migration Notes
+
+The first Grafana Operator change only installs the operator and CRDs through ArgoCD.
+
+The active Grafana instance remains managed by kube-prometheus-stack:
+
+- Route backend: `kube-prometheus-stack-grafana`
+- Existing VolSync source PVC: `storage-kube-prometheus-stack-grafana-0`
+- Existing backup repository: `grafana-volsync-b2`
+
+Do not disable kube-prometheus-stack Grafana, change the Grafana HTTPRoute, or alter VolSync PVC references until an operator-managed Grafana instance has been deployed and validated side by side.
+
+Follow-up migration should be planned separately and include:
+
+1. Add a `Grafana` CR in `apps/monitoring/grafana`.
+2. Add an `ExternalSecret` for admin credentials if UI login is retained.
+3. Inventory dashboards from the current Grafana API and from dashboard ConfigMaps labeled for the kube-prometheus-stack sidecar.
+4. Decide which UI-created dashboards need first-class `GrafanaDashboard` CRs.
+5. For kube-prometheus-stack default dashboards, prefer enabling `grafana.operator.dashboardsConfigMapRefEnabled` and setting `grafana.operator.matchLabels` to the labels on the operator-managed `Grafana` instance instead of hand-converting every default dashboard.
+6. Add datasource CRs, including a Prometheus datasource that matches the names expected by migrated dashboards.
+7. Restore or migrate persistent data to the operator-managed PVC.
+8. Switch `apps/monitoring/grafana/manifests/httproute.yaml` to the operator-managed service.
+9. Disable kube-prometheus-stack Grafana only after the operator-managed instance is healthy and reachable.


### PR DESCRIPTION
## Summary
- Register the Grafana OCI Helm repository for ArgoCD.
- Add a standalone ArgoCD Application for Grafana Operator 5.22.2.
- Keep the existing kube-prometheus-stack Grafana route, PVC, and VolSync path unchanged.
- Document the boundary for a later operator-managed Grafana instance migration.

## Test plan
- [x] `kustomize build --enable-helm apps/argocd`
- [x] `helm template grafana-operator oci://ghcr.io/grafana/helm-charts/grafana-operator --version 5.22.2 --namespace monitoring ...`
- [x] `docker buildx imagetools inspect ghcr.io/grafana/grafana-operator:v5.22.2` includes `linux/arm64`
- [x] `pre-commit run --files apps/argocd/manifests/repos.yaml apps/argocd/manifests/apps.yaml docs/grafana-operator-migration.md`

## Rollout
- Merge to `master` after CI passes.
- Let ArgoCD sync from `master`.
- Verify `grafana-operator` is Synced and Healthy after merge.