### PR TITLE
feat(grafana): add operator-managed instance

### DIFF
--- a/.github/scripts/helm_diff.sh
+++ b/.github/scripts/helm_diff.sh
@@ -17,6 +17,14 @@ PLAN_FILE="apps/system-upgrade/manifests/plan.yaml"
 BASE_WORKTREE_DIR="../base-worktree"
 ARGO_APPLICATION_KIND="Application"
 ARGO_APPLICATION_API_VERSIONS=("argoproj.io/v1alpha1")
+HELM_API_VERSIONS=("grafana.integreatly.org/v1beta1/GrafanaDashboard")
+HELM_API_VERSION_ARGS=()
+KUSTOMIZE_HELM_API_VERSION_ARGS=()
+
+for API_VERSION in "${HELM_API_VERSIONS[@]}"; do
+    HELM_API_VERSION_ARGS+=("--api-versions" "$API_VERSION")
+    KUSTOMIZE_HELM_API_VERSION_ARGS+=("--helm-api-versions" "$API_VERSION")
+done
 
 EXCLUDE_FIELDS='.metadata.labels."helm.sh/chart"'
 EXCLUDE_FIELDS+=',.metadata.labels.chart'
@@ -290,6 +298,7 @@ helm_template_and_diff() {
             --version "$OLD_VERSION" \
             --namespace "$OLD_NAMESPACE" \
             --kube-version "$KUBE_VERSION" \
+            "${HELM_API_VERSION_ARGS[@]}" \
             "${HELM_ARGS_OLD[@]}" > "${workdir}/old.yaml"; then
             echo "❌ Helm template failed for old version"
             rm -rf "$workdir"
@@ -307,6 +316,7 @@ helm_template_and_diff() {
         --version "$NEW_VERSION" \
         --namespace "$NEW_NAMESPACE" \
         --kube-version "$KUBE_VERSION" \
+        "${HELM_API_VERSION_ARGS[@]}" \
         "${HELM_ARGS_NEW[@]}" > "${workdir}/new.yaml"; then
         echo "❌ Helm template failed for new version"
         rm -rf "$workdir"
@@ -722,10 +732,10 @@ process_kustomization() {
     tmpdir="$(mktemp -d "kustomize_${kustomize_dir##*/}_XXXX")"
 
     echo "🎭 Rendering Helm kustomizations"
-    (cd "$kustomize_dir" && kustomize build . --enable-helm) > "${tmpdir}/new.yaml"
+    (cd "$kustomize_dir" && kustomize build . --enable-helm "${KUSTOMIZE_HELM_API_VERSION_ARGS[@]}") > "${tmpdir}/new.yaml"
 
     if (( HAS_BASE_KUSTOMIZATION == 1 )) && [[ -d "$BASE_WORKTREE_DIR/$kustomize_dir" ]]; then
-        (cd "$BASE_WORKTREE_DIR/$kustomize_dir" && kustomize build . --enable-helm) > "${tmpdir}/old.yaml"
+        (cd "$BASE_WORKTREE_DIR/$kustomize_dir" && kustomize build . --enable-helm "${KUSTOMIZE_HELM_API_VERSION_ARGS[@]}") > "${tmpdir}/old.yaml"
     else
         echo "" > "${tmpdir}/old.yaml"
     fi

--- a/.github/scripts/kustomize_build_check.sh
+++ b/.github/scripts/kustomize_build_check.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 # Pre-commit passes changed file paths as arguments.
 
 declare -A KUSTOMIZE_DIRS
+KUSTOMIZE_BUILD_ARGS=(
+  --enable-helm
+  --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard
+)
 
 for file in "$@"; do
   # Only process files under apps/
@@ -33,8 +37,8 @@ for dir in "${!KUSTOMIZE_DIRS[@]}"; do
   fi
 
   echo "Building $dir ..."
-  output=$(kustomize build --enable-helm "$dir" 2>&1 > /dev/null) || {
-    echo "FAIL: kustomize build --enable-helm $dir"
+  output=$(kustomize build "${KUSTOMIZE_BUILD_ARGS[@]}" "$dir" 2>&1 > /dev/null) || {
+    echo "FAIL: kustomize build ${KUSTOMIZE_BUILD_ARGS[*]} $dir"
     echo "$output"
     FAILED=1
   }

--- a/apps/argocd/manifests/apps.yaml
+++ b/apps/argocd/manifests/apps.yaml
@@ -124,7 +124,13 @@ spec:
             enabled: true
         grafana:
           dashboard:
-            enabled: true
+            enabled: false
+            operator:
+              enabled: true
+              allowCrossNamespaceImport: true
+              datasources:
+                - inputName: DS_PROMETHEUS
+                  datasourceName: Prometheus
     repoURL: ghcr.io/sholdee/charts
     targetRevision: 2026.429.153650
   syncPolicy:

--- a/apps/argocd/manifests/values.yaml
+++ b/apps/argocd/manifests/values.yaml
@@ -29,7 +29,7 @@ repoServer:
       enabled: true
 configs:
   cm:
-    kustomize.buildOptions: --enable-helm
+    kustomize.buildOptions: --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard
     resource.exclusions: |
      - apiGroups:
          - cilium.io

--- a/apps/monitoring/grafana/kustomization.yaml
+++ b/apps/monitoring/grafana/kustomization.yaml
@@ -3,6 +3,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - manifests/dashboards.yaml
+  - manifests/datasources.yaml
+  - manifests/grafana.yaml
   - manifests/httproute.yaml
 components:
   - ../../../components/volsync/b2

--- a/apps/monitoring/grafana/manifests/dashboards.yaml
+++ b/apps/monitoring/grafana/manifests/dashboards.yaml
@@ -1,0 +1,54 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: external-secrets-dashboard
+  namespace: external-secrets
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - inputName: datasource
+      datasourceName: Prometheus
+  configMapRef:
+    name: external-secrets-dashboard
+    key: external-secrets.json
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cilium-dashboard
+  namespace: kube-system
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Prometheus
+  configMapRef:
+    name: cilium-dashboard
+    key: cilium-dashboard.json
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cilium-operator-dashboard
+  namespace: kube-system
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Prometheus
+  configMapRef:
+    name: cilium-operator-dashboard
+    key: cilium-operator-dashboard.json

--- a/apps/monitoring/grafana/manifests/datasources.yaml
+++ b/apps/monitoring/grafana/manifests/datasources.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadatasource_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasource:
+    name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://kube-prometheus-stack-prometheus.monitoring:9090/
+    isDefault: true
+    jsonData:
+      httpMethod: POST
+      timeInterval: 30s
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadatasource_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: alertmanager
+  namespace: monitoring
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasource:
+    name: Alertmanager
+    uid: alertmanager
+    type: alertmanager
+    access: proxy
+    url: http://kube-prometheus-stack-alertmanager.monitoring:9093/
+    isDefault: false
+    jsonData:
+      handleGrafanaManagedAlerts: false
+      implementation: prometheus

--- a/apps/monitoring/grafana/manifests/grafana.yaml
+++ b/apps/monitoring/grafana/manifests/grafana.yaml
@@ -1,0 +1,82 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafana_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name: grafana
+  namespace: monitoring
+  labels:
+    dashboards: grafana
+spec:
+  version: docker.io/grafana/grafana:13.0.1@sha256:0f86bada30d65ef9d0183b90c1e2682ac92d53d95da8bed322b984ea78a4a73a
+  persistentVolumeClaim:
+    spec:
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Gi
+  config:
+    analytics:
+      check_for_plugin_updates: "false"
+      check_for_updates: "false"
+      reporting_enabled: "false"
+    log:
+      mode: console
+    metrics:
+      enabled: "true"
+    news:
+      news_feed_enabled: "false"
+    server:
+      domain: grafana.mgmt.sholdee.net
+      enable_gzip: "true"
+      root_url: https://grafana.mgmt.sholdee.net
+  deployment:
+    metadata:
+      annotations:
+        reloader.stakater.com/auto: "true"
+    spec:
+      replicas: 1
+      strategy:
+        type: Recreate
+      template:
+        spec:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 1
+                  preference:
+                    matchExpressions:
+                      - key: node-role.kubernetes.io/control-plane
+                        operator: DoesNotExist
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 472
+            runAsGroup: 472
+            fsGroup: 472
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: grafana
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 256Mi
+                limits:
+                  memory: 512Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+              volumeMounts:
+                - name: grafana-tmp
+                  mountPath: /tmp
+          volumes:
+            - name: grafana-data
+              persistentVolumeClaim:
+                claimName: grafana-pvc
+            - name: grafana-tmp
+              emptyDir: {}

--- a/apps/monitoring/values.yaml
+++ b/apps/monitoring/values.yaml
@@ -46,6 +46,10 @@ alertmanager:
             requests:
               storage: 10Gi
 grafana:
+  operator:
+    dashboardsConfigMapRefEnabled: true
+    matchLabels:
+      dashboards: grafana
   persistence:
     enabled: true
     type: sts

--- a/apps/renovate/kustomization.yaml
+++ b/apps/renovate/kustomization.yaml
@@ -18,3 +18,16 @@ helmCharts:
     releaseName: renovate-operator
     namespace: renovate
     valuesFile: manifests/values.yaml
+patches:
+  - target:
+      kind: GrafanaDashboard
+      name: renovate-operator-dashboard
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: renovate-operator-dashboard-grafana
+      - op: replace
+        path: /spec/instanceSelector
+        value:
+          matchLabels:
+            dashboards: grafana

--- a/apps/renovate/manifests/values.yaml
+++ b/apps/renovate/manifests/values.yaml
@@ -9,3 +9,11 @@ metrics:
     enabled: true
   dashboard:
     enabled: true
+    grafanaDashboard:
+      allowCrossNamespaceImport: true
+      instanceSelector:
+        matchLabels:
+          dashboards: grafana
+      datasources:
+        - inputName: datasource
+          datasourceName: Prometheus

--- a/docs/grafana-operator-migration.md
+++ b/docs/grafana-operator-migration.md
@@ -1,6 +1,6 @@
 # Grafana Operator Migration Notes
 
-The first Grafana Operator change only installs the operator and CRDs through ArgoCD.
+The migration is being done in phases so the existing kube-prometheus-stack Grafana remains the live service until the operator-managed instance is validated.
 
 The active Grafana instance remains managed by kube-prometheus-stack:
 
@@ -8,16 +8,22 @@ The active Grafana instance remains managed by kube-prometheus-stack:
 - Existing VolSync source PVC: `storage-kube-prometheus-stack-grafana-0`
 - Existing backup repository: `grafana-volsync-b2`
 
-Do not disable kube-prometheus-stack Grafana, change the Grafana HTTPRoute, or alter VolSync PVC references until an operator-managed Grafana instance has been deployed and validated side by side.
+The side-by-side operator-managed Grafana phase adds:
 
-Follow-up migration should be planned separately and include:
+- `Grafana` CR `monitoring/grafana`
+- `GrafanaDatasource` CRs for Prometheus and Alertmanager
+- kube-prometheus-stack generated `GrafanaDashboard` CRs via `grafana.operator.dashboardsConfigMapRefEnabled`
+- native chart `GrafanaDashboard` CRs for crd-schema-publisher and renovate-operator
+- manual bridge `GrafanaDashboard` CRs for external-secrets and Cilium dashboard ConfigMaps, since those charts only emit ConfigMaps
 
-1. Add a `Grafana` CR in `apps/monitoring/grafana`.
-2. Add an `ExternalSecret` for admin credentials if UI login is retained.
-3. Inventory dashboards from the current Grafana API and from dashboard ConfigMaps labeled for the kube-prometheus-stack sidecar.
-4. Decide which UI-created dashboards need first-class `GrafanaDashboard` CRs.
-5. For kube-prometheus-stack default dashboards, prefer enabling `grafana.operator.dashboardsConfigMapRefEnabled` and setting `grafana.operator.matchLabels` to the labels on the operator-managed `Grafana` instance instead of hand-converting every default dashboard.
-6. Add datasource CRs, including a Prometheus datasource that matches the names expected by migrated dashboards.
-7. Restore or migrate persistent data to the operator-managed PVC.
-8. Switch `apps/monitoring/grafana/manifests/httproute.yaml` to the operator-managed service.
-9. Disable kube-prometheus-stack Grafana only after the operator-managed instance is healthy and reachable.
+Do not disable kube-prometheus-stack Grafana, change the Grafana HTTPRoute, or alter VolSync PVC references until the operator-managed Grafana instance has been deployed and validated side by side.
+
+Remaining follow-up migration work:
+
+1. Add an `ExternalSecret` for admin credentials if UI login is retained.
+2. Export and review the UI-created dashboards that are not currently provisioned.
+3. Convert retained UI-created dashboards to first-class `GrafanaDashboard` CRs.
+4. Restore or migrate persistent data to the operator-managed PVC if the side-by-side instance needs existing state.
+5. Switch `apps/monitoring/grafana/manifests/httproute.yaml` to the operator-managed service.
+6. Disable kube-prometheus-stack Grafana only after the operator-managed instance is healthy and reachable.
+7. Update VolSync to back up the operator-managed Grafana PVC after cutover.


### PR DESCRIPTION
## Summary
- add a side-by-side Grafana Operator-managed Grafana instance with a 20Gi Longhorn PVC, pinned Grafana 13.0.1 image digest, resources, and hardened runtime settings
- add GrafanaDatasource CRs for Prometheus and Alertmanager
- import provisioned dashboards through native chart support where available: kube-prometheus-stack, crd-schema-publisher, and renovate-operator
- keep manual GrafanaDashboard bridge CRs only for charts that emit ConfigMaps but no operator CRs: external-secrets and Cilium
- switch the selector convention to `dashboards: grafana` and align Argo/CI kustomize Helm API-version rendering for gated GrafanaDashboard templates

## Notes
- no traffic cutover in this PR; `grafana.mgmt.sholdee.net` still routes to `kube-prometheus-stack-grafana`
- kube-prometheus-stack Grafana and VolSync references remain unchanged
- 15 UI-created dashboards from the current Grafana remain deferred for a later migration phase
- renovate-operator dashboard CR is renamed to avoid the immutable `spec.instanceSelector` update on the existing no-match CR

## Validation
- `pre-commit run --files .github/scripts/helm_diff.sh .github/scripts/kustomize_build_check.sh apps/argocd/manifests/apps.yaml apps/argocd/manifests/values.yaml apps/monitoring/grafana/kustomization.yaml apps/monitoring/grafana/manifests/dashboards.yaml apps/monitoring/grafana/manifests/datasources.yaml apps/monitoring/grafana/manifests/grafana.yaml apps/monitoring/values.yaml apps/renovate/kustomization.yaml apps/renovate/manifests/values.yaml docs/grafana-operator-migration.md`
- `kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/monitoring`
- `kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/renovate`
- `kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/argocd`
- server-side dry-runs for rendered Grafana, GrafanaDatasource, and GrafanaDashboard CRs
- `docker buildx imagetools inspect docker.io/grafana/grafana:13.0.1` confirms linux/arm64 manifest
