### PR TITLE
feat(grafana): migrate remaining dashboards

### DIFF
--- a/apps/monitoring/grafana/manifests/dashboards.yaml
+++ b/apps/monitoring/grafana/manifests/dashboards.yaml
@@ -52,3 +52,246 @@ spec:
   configMapRef:
     name: cilium-operator-dashboard
     key: cilium-operator-dashboard.json
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: adguard-dns-metrics-dashboard
+  namespace: monitoring
+spec:
+  uid: adguard-dns-metrics
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  grafanaCom:
+    id: 21403
+    revision: 2
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Prometheus
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cert-manager-dashboard
+  namespace: monitoring
+spec:
+  uid: cert-manager
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  grafanaCom:
+    id: 20340
+    revision: 1
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Prometheus
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: cloudnative-pg-dashboard
+  namespace: monitoring
+spec:
+  uid: cloudnative-pg
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  grafanaCom:
+    id: 20417
+    revision: 4
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Prometheus
+    - inputName: DS_EXPRESSION
+      datasourceName: __expr__
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: external-dns-dashboard
+  namespace: monitoring
+spec:
+  uid: eea5u_I7z
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  grafanaCom:
+    id: 23969
+    revision: 1
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: etcd-cluster-overview-dashboard
+  namespace: monitoring
+spec:
+  uid: etcd_cluster
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  grafanaCom:
+    id: 21473
+    revision: 3
+  datasources:
+    - inputName: datasource
+      datasourceName: Prometheus
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: velero-dashboard
+  namespace: monitoring
+spec:
+  uid: EbXSjT24k
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  grafanaCom:
+    id: 16829
+    revision: 5
+  datasources:
+    - inputName: datasource
+      datasourceName: Prometheus
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: longhorn-dashboard
+  namespace: monitoring
+spec:
+  uid: ozk-lh-mon
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  grafanaCom:
+    id: 16888
+    revision: 9
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Prometheus
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: volsync-dashboard
+  namespace: monitoring
+spec:
+  uid: cdp5agkgn4yrkc
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  grafanaCom:
+    id: 21356
+    revision: 3
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Prometheus
+    - inputName: VAR_REPLICATIONDESTNAME
+      datasourceName: .*-dst|.*-bootstrap
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: spegel-dashboard
+  namespace: monitoring
+spec:
+  uid: 1iY4QMJVk-psee
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  grafanaCom:
+    id: 18089
+    revision: 1
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Prometheus
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: hivemq-platform-dashboard
+  namespace: monitoring
+spec:
+  uid: d4471aa7-d362-4715-a583-c0cd0ae6a11d
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  url: https://raw.githubusercontent.com/hivemq/helm-charts/hivemq-platform-operator-0.2.23/charts/hivemq-platform/files/grafana-dashboard.json
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: envoy-overview-dashboard
+  namespace: monitoring
+spec:
+  uid: envoy-overview-skj2
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  grafanaCom:
+    id: 24459
+    revision: 3
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: envoy-clusters-dashboard
+  namespace: monitoring
+spec:
+  uid: 8WkEOMnANKE6PW5hhpVv
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  url: https://raw.githubusercontent.com/envoyproxy/gateway/v1.7.2/charts/gateway-addons-helm/dashboards/envoy-clusters.json
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: envoy-global-dashboard
+  namespace: monitoring
+spec:
+  uid: heHhNSFf6Na8vIZWRs8H
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  url: https://raw.githubusercontent.com/envoyproxy/gateway/v1.7.2/charts/gateway-addons-helm/dashboards/envoy-proxy-global.json
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: envoy-gateway-global-dashboard
+  namespace: monitoring
+spec:
+  uid: bdn8lriao7myoa
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  url: https://raw.githubusercontent.com/envoyproxy/gateway/v1.7.2/charts/gateway-addons-helm/dashboards/envoy-gateway-global.json
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: envoy-resources-monitor-dashboard
+  namespace: monitoring
+spec:
+  uid: f7aeb41676b7865cf31ae49691325f91
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  url: https://raw.githubusercontent.com/envoyproxy/gateway/v1.7.2/charts/gateway-addons-helm/dashboards/resources-monitor.gen.json


### PR DESCRIPTION
## Summary
- add first-class GrafanaDashboard CRs for the remaining UI-managed dashboards
- pin Grafana.com dashboard revisions and preserve existing dashboard UIDs
- use upstream raw dashboard JSON for HiveMQ and Envoy Gateway chart-owned dashboards

## Validation
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/monitoring
- pre-commit run --files apps/monitoring/grafana/manifests/dashboards.yaml
- kubectl apply --dry-run=server -f apps/monitoring/grafana/manifests/dashboards.yaml