### PR TITLE
feat(grafana): cut over to operator instance

### DIFF
--- a/apps/monitoring/grafana/kustomization.yaml
+++ b/apps/monitoring/grafana/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - manifests/dashboards.yaml
   - manifests/datasources.yaml
+  - manifests/externalsecret.yaml
   - manifests/grafana.yaml
   - manifests/httproute.yaml
 components:
@@ -19,7 +20,7 @@ patches:
         value: grafana
       - op: replace
         path: /spec/sourcePVC
-        value: storage-kube-prometheus-stack-grafana-0
+        value: grafana-pvc
       - op: replace
         path: /spec/restic/repository
         value: grafana-volsync-b2

--- a/apps/monitoring/grafana/manifests/externalsecret.yaml
+++ b/apps/monitoring/grafana/manifests/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-admin-secret
+  namespace: monitoring
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: grafana-admin-secret
+    template:
+      engineVersion: v2
+      data:
+        GF_SECURITY_ADMIN_USER: "{{ .username }}"
+        GF_SECURITY_ADMIN_PASSWORD: "{{ .password }}"
+      type: Opaque
+  dataFrom:
+    - extract:
+        key: grafana

--- a/apps/monitoring/grafana/manifests/grafana.yaml
+++ b/apps/monitoring/grafana/manifests/grafana.yaml
@@ -32,6 +32,7 @@ spec:
       domain: grafana.mgmt.sholdee.net
       enable_gzip: "true"
       root_url: https://grafana.mgmt.sholdee.net
+  disableDefaultAdminSecret: true
   deployment:
     metadata:
       annotations:
@@ -59,6 +60,17 @@ spec:
               type: RuntimeDefault
           containers:
             - name: grafana
+              env:
+                - name: GF_SECURITY_ADMIN_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin-secret
+                      key: GF_SECURITY_ADMIN_USER
+                - name: GF_SECURITY_ADMIN_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin-secret
+                      key: GF_SECURITY_ADMIN_PASSWORD
               resources:
                 requests:
                   cpu: 50m

--- a/apps/monitoring/grafana/manifests/httproute.yaml
+++ b/apps/monitoring/grafana/manifests/httproute.yaml
@@ -13,6 +13,6 @@ spec:
     - grafana.mgmt.sholdee.net
   rules:
     - backendRefs:
-        - name: kube-prometheus-stack-grafana
+        - name: grafana-service
           namespace: monitoring
-          port: 80
+          port: 3000

--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -17,14 +17,3 @@ helmCharts:
     releaseName: kube-prometheus-stack
     namespace: monitoring
     valuesFile: values.yaml
-patches:
-  - target:
-      kind: StatefulSet
-      name: kube-prometheus-stack-grafana
-    patch: |-
-      - op: add
-        path: /spec/volumeClaimTemplates/0/spec/dataSourceRef
-        value:
-          apiGroup: volsync.backube
-          kind: ReplicationDestination
-          name: grafana-bootstrap

--- a/apps/monitoring/values.yaml
+++ b/apps/monitoring/values.yaml
@@ -46,24 +46,12 @@ alertmanager:
             requests:
               storage: 10Gi
 grafana:
+  enabled: false
+  forceDeployDashboards: true
   operator:
     dashboardsConfigMapRefEnabled: true
     matchLabels:
       dashboards: grafana
-  persistence:
-    enabled: true
-    type: sts
-    storageClassName: longhorn
-    accessModes: ["ReadWriteOnce"]
-    size: 20Gi
-  affinity:
-    nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 1
-          preference:
-            matchExpressions:
-              - key: node-role.kubernetes.io/control-plane
-                operator: DoesNotExist
 kubelet:
   enabled: true
   serviceMonitor:


### PR DESCRIPTION
## Summary
- route the Grafana HTTPRoute to the operator-managed `grafana-service:3000`
- disable the kube-prometheus-stack Grafana instance while preserving generated dashboard CRs
- add a 1Password-backed `grafana-admin-secret` ExternalSecret and wire it into the Grafana CR
- move Grafana VolSync backup source to the operator-managed `grafana-pvc`

## Validation
- `kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/monitoring`
- `pre-commit run --files apps/monitoring/values.yaml apps/monitoring/kustomization.yaml apps/monitoring/grafana/kustomization.yaml apps/monitoring/grafana/manifests/grafana.yaml apps/monitoring/grafana/manifests/httproute.yaml apps/monitoring/grafana/manifests/externalsecret.yaml`
- `kubectl apply --dry-run=server -f /tmp/home-ops-monitoring-cutover-render.yaml`
- compared rendered `GrafanaDashboard` count against `origin/master`: 43 before, 43 after
