### PR TITLE
fix(argocd): disable server-side diff for parent app

### DIFF
--- a/apps/argocd/manifests/app-set.yaml
+++ b/apps/argocd/manifests/app-set.yaml
@@ -37,6 +37,11 @@ spec:
           - RespectIgnoreDifferences=true
           - ServerSideApply=true
   templatePatch: |
+    {{- if eq .path.basename "argocd" }}
+    metadata:
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=false
+    {{- end }}
     {{- if eq .path.basename "monitoring" }}
     spec:
       ignoreDifferences:


### PR DESCRIPTION
## Summary
- disable server-side diff only for the generated parent argocd Application
- keep server-side diff enabled for the rest of the ApplicationSet-generated apps
- avoid ArgoCD server-side dry-run validation of child Application status during app-of-apps comparison

## Validation
- pre-commit run --files apps/argocd/manifests/app-set.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/argocd
- reproduced live error on parent argocd Application with ServerSideDiff=true
- temporary live ApplicationSet override changed generated argocd Application to ServerSideDiff=false and cleared ComparisonError before master reverted it