### PR TITLE
fix: pin cnpg dashboard with barman metrics

### DIFF
--- a/apps/monitoring/grafana/manifests/dashboards.yaml
+++ b/apps/monitoring/grafana/manifests/dashboards.yaml
@@ -112,9 +112,7 @@ spec:
   instanceSelector:
     matchLabels:
       dashboards: grafana
-  grafanaCom:
-    id: 20417
-    revision: 4
+  url: https://raw.githubusercontent.com/cloudnative-pg/grafana-dashboards/19f534b2b3d2d34e871d656351599eb8b170ad86/charts/cluster/grafana-dashboard.json
   datasources:
     - inputName: DS_PROMETHEUS
       datasourceName: Prometheus


### PR DESCRIPTION
## Summary

- Switch CloudNativePG dashboard from Grafana.com revision 4 to a pinned raw upstream dashboard JSON.
- Pin to cloudnative-pg/grafana-dashboards@19f534b2b3d2d34e871d656351599eb8b170ad86, which contains the fix for plugin-barman-cloud backup metric names.
- Preserve compatibility with the legacy cnpg_collector metrics.

## Validation

- `rg` check for the pinned raw dashboard URL.
- `kustomize build --enable-helm apps/monitoring/grafana`.
- `pre-commit run --files apps/monitoring/grafana/manifests/dashboards.yaml`.
- Server-side dry-run with rendered Grafana manifests and `kubectl apply --server-side --dry-run=server --field-manager=argocd-controller`.
- Applied `dashboards.yaml` live; `cloudnative-pg-dashboard` reached `observedGeneration: 4` with `DashboardSynchronized=True`.
- Grafana API showed imported dashboard expressions include `barman_cloud_cloudnative_pg_io_*` metrics.

## Notes

The Grafana.com dashboard is still revision 4 and does not include the upstream fix. This can move back to `grafanaCom` once CloudNativePG publishes a new Grafana.com revision.