### PR TITLE
fix(grafana): tune database pool limits

### DIFF
--- a/apps/monitoring/grafana/manifests/cnpg-cluster.yaml
+++ b/apps/monitoring/grafana/manifests/cnpg-cluster.yaml
@@ -73,8 +73,8 @@ spec:
   pgbouncer:
     poolMode: session
     parameters:
-      max_client_conn: "100"
-      default_pool_size: "5"
+      max_client_conn: "200"
+      default_pool_size: "20"
   template:
     metadata:
       labels:

--- a/apps/monitoring/grafana/manifests/grafana.yaml
+++ b/apps/monitoring/grafana/manifests/grafana.yaml
@@ -86,6 +86,10 @@ spec:
                   value: grafana
                 - name: GF_DATABASE_SSL_MODE
                   value: disable
+                - name: GF_DATABASE_MAX_OPEN_CONN
+                  value: "10"
+                - name: GF_DATABASE_MAX_IDLE_CONN
+                  value: "5"
                 - name: GF_DATABASE_USER
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
## Summary
- keep PgBouncer in session mode but raise Grafana pooler capacity from 5 to 20 server connections
- cap each Grafana replica DB pool at 10 open / 5 idle connections
- avoid transaction pooling because live validation produced prepared-statement protocol errors in Grafana 13

## Validation
- pre-commit run --files apps/monitoring/grafana/manifests/cnpg-cluster.yaml apps/monitoring/grafana/manifests/grafana.yaml
- kustomize build --enable-helm apps/monitoring/grafana
- kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f /tmp/grafana-pooler-session-tuned-render.yaml
- live applied the two manifests for validation
- PgBouncer SHOW CONFIG reports pool_mode=session, default_pool_size=20, max_client_conn=200
- PgBouncer SHOW POOLS reports cl_waiting=0 after validation traffic
- Grafana /api/health reports database ok via port-forward
- Prometheus datasource query returned HTTP 200; 12 concurrent query checks returned HTTP 200 in roughly 40-60 ms
- fresh Grafana and PgBouncer logs show no new prepared-statement errors or query_wait_timeout after reverting from the transaction-mode test