### PR TITLE
fix(grafana): pin spegel dashboard source

### DIFF
--- a/apps/monitoring/grafana/manifests/dashboards.yaml
+++ b/apps/monitoring/grafana/manifests/dashboards.yaml
@@ -251,9 +251,7 @@ spec:
   instanceSelector:
     matchLabels:
       dashboards: grafana
-  grafanaCom:
-    id: 18089
-    revision: 1
+  url: https://raw.githubusercontent.com/spegel-org/spegel/ab5eadd1b0d201829f0783c0d16d1682314535bc/charts/spegel/monitoring/grafana-dashboard.json
   datasources:
     - inputName: DS_PROMETHEUS
       datasourceName: Prometheus


### PR DESCRIPTION
## Summary
- switch the Spegel GrafanaDashboard from Grafana.com dashboard 18089 revision 1 to the pinned upstream raw dashboard JSON
- keep the existing dashboard UID and DS_PROMETHEUS datasource mapping

## Validation
- fetched the pinned raw dashboard JSON and verified UID 1iY4QMJVk-psee plus DS_PROMETHEUS input
- yq assertion confirms the Spegel dashboard uses the requested raw URL and no longer has grafanaCom
- pre-commit run --files apps/monitoring/grafana/manifests/dashboards.yaml
- kustomize build --enable-helm apps/monitoring/grafana
- kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f /tmp/grafana-spegel-dashboard-render.yaml