### PR TITLE
fix: remove operator managed adguard dashboard

### DIFF
--- a/apps/monitoring/grafana/manifests/dashboards.yaml
+++ b/apps/monitoring/grafana/manifests/dashboards.yaml
@@ -63,26 +63,6 @@ spec:
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  name: adguard-dns-metrics-dashboard
-  namespace: monitoring
-spec:
-  uid: adguard-dns-metrics
-  folder: General
-  resyncPeriod: 10m
-  instanceSelector:
-    matchLabels:
-      dashboards: grafana
-  grafanaCom:
-    id: 21403
-    revision: 3
-  datasources:
-    - inputName: DS_PROMETHEUS
-      datasourceName: Prometheus
----
-# yaml-language-server: $schema=https://kube-schemas.shold.io/grafana.integreatly.org/grafanadashboard_v1beta1.json
-apiVersion: grafana.integreatly.org/v1beta1
-kind: GrafanaDashboard
-metadata:
   name: cert-manager-dashboard
   namespace: monitoring
 spec:


### PR DESCRIPTION
## Summary
- remove the AdGuard GrafanaDashboard from Grafana Operator management
- leave the dashboard to be managed manually from Grafana.com import ID 21403

## Validation
- pre-commit run --files apps/monitoring/grafana/manifests/dashboards.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaManifest apps/monitoring/grafana/