### PR TITLE
feat: migrate prometheus to prompp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .claude.local.md
 .DS_Store
+.worktrees/
 # Helm charts extracted by kustomize build --enable-helm
 apps/**/charts/

--- a/apps/monitoring/values.yaml
+++ b/apps/monitoring/values.yaml
@@ -4,6 +4,43 @@ crds:
     enabled: false
 prometheus:
   prometheusSpec:
+    image:
+      registry: ghcr.io
+      repository: deckhouse/prompp
+      tag: "0.7.10"
+      sha: 405dbe39fe3ca1daf9a942a047418c153ace49ccbb91c5ad029552be27b96446
+      pullPolicy: IfNotPresent
+    version: v3.11.3
+    initContainers:
+      - name: prompptool-walvanilla
+        image: ghcr.io/deckhouse/prompp:0.7.10@sha256:405dbe39fe3ca1daf9a942a047418c153ace49ccbb91c5ad029552be27b96446
+        command:
+          - /bin/sh
+          - -ec
+          - |
+            started=/prometheus/.prompp-walvanilla-started
+            complete=/prometheus/.prompp-walvanilla-complete
+            if [ -f "$complete" ]; then
+              echo "Prom++ WAL conversion marker exists; skipping walvanilla"
+              exit 0
+            fi
+            if [ -f "$started" ]; then
+              echo "Prom++ WAL conversion started previously but did not complete; refusing automatic retry" >&2
+              exit 1
+            fi
+            touch "$started"
+            /bin/prompptool --working-dir=/prometheus walvanilla
+            touch "$complete"
+        volumeMounts:
+          - name: prometheus-kube-prometheus-stack-prometheus-db
+            mountPath: /prometheus
+            subPath: prometheus-db
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            memory: 512Mi
     serviceMonitorSelectorNilUsesHelmValues: false
     ruleSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
## Summary
- Switch kube-prometheus-stack Prometheus to the pinned GHCR Deckhouse Prom++ image.
- Keep Prometheus Operator compatibility at `spec.version: v3.11.3` while using Prom++ `0.7.10`.
- Add a guarded one-shot WAL conversion init container with started/complete markers to avoid unsafe automatic retries.
- Ignore local `.worktrees/` directories used for isolated implementation work.

## Test plan
- [x] `docker run --rm --platform linux/arm64 --entrypoint /bin/sh ghcr.io/deckhouse/prompp:0.7.10@sha256:405dbe39fe3ca1daf9a942a047418c153ace49ccbb91c5ad029552be27b96446 -ec 'test -x /bin/sh; /bin/prompp --version; /bin/prompptool --help >/dev/null; echo ok'`
- [x] `kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/monitoring/ | kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f -`
- [x] `pre-commit run --files .gitignore apps/monitoring/values.yaml`