### PR TITLE
fix: avoid touch in prompp init marker

### DIFF
--- a/apps/monitoring/values.yaml
+++ b/apps/monitoring/values.yaml
@@ -28,9 +28,9 @@ prometheus:
               echo "Prom++ WAL conversion started previously but did not complete; refusing automatic retry" >&2
               exit 1
             fi
-            touch "$started"
+            : > "$started"
             /bin/prompptool --working-dir=/prometheus walvanilla
-            touch "$complete"
+            : > "$complete"
         volumeMounts:
           - name: prometheus-kube-prometheus-stack-prometheus-db
             mountPath: /prometheus


### PR DESCRIPTION
## Summary
- Replace `touch` with POSIX shell redirection in the Prom++ WAL conversion marker script.
- Fixes the live `prompptool-walvanilla` init failure because the Prom++ image does not include `touch`.
- Leaves the started/complete marker safety behavior intact.

## Test plan
- [x] `kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/monitoring/ | yq 'select(.apiVersion == "monitoring.coreos.com/v1" and .kind == "Prometheus") | .spec.initContainers[] | select(.name == "prompptool-walvanilla") | .command'`
- [x] `pre-commit run --files apps/monitoring/values.yaml`