### PR TITLE
fix: move prompp migration markers off tsdb

### DIFF
--- a/apps/monitoring/values.yaml
+++ b/apps/monitoring/values.yaml
@@ -12,14 +12,30 @@ prometheus:
       pullPolicy: IfNotPresent
     version: v3.11.3
     initContainers:
+      - name: prompptool-marker-cleanup
+        image: busybox:1.37.0@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
+        command:
+          - /bin/sh
+          - -ec
+          - |
+            rm -f /prometheus-volume/prometheus-db/.prompp-walvanilla-started /prometheus-volume/prometheus-db/.prompp-walvanilla-complete
+        volumeMounts:
+          - name: prometheus-kube-prometheus-stack-prometheus-db
+            mountPath: /prometheus-volume
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            memory: 32Mi
       - name: prompptool-walvanilla
         image: ghcr.io/deckhouse/prompp:0.7.10@sha256:405dbe39fe3ca1daf9a942a047418c153ace49ccbb91c5ad029552be27b96446
         command:
           - /bin/sh
           - -ec
           - |
-            started=/prometheus/.prompp-walvanilla-started
-            complete=/prometheus/.prompp-walvanilla-complete
+            started=/prometheus-volume/.prompp-walvanilla-started
+            complete=/prometheus-volume/.prompp-walvanilla-complete
             if [ -f "$complete" ]; then
               echo "Prom++ WAL conversion marker exists; skipping walvanilla"
               exit 0
@@ -29,12 +45,11 @@ prometheus:
               exit 1
             fi
             : > "$started"
-            /bin/prompptool --working-dir=/prometheus walvanilla
+            /bin/prompptool --working-dir=/prometheus-volume/prometheus-db walvanilla
             : > "$complete"
         volumeMounts:
           - name: prometheus-kube-prometheus-stack-prometheus-db
-            mountPath: /prometheus
-            subPath: prometheus-db
+            mountPath: /prometheus-volume
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Summary
- add a cleanup init container to remove the bad Prom++ migration marker from the Prometheus TSDB directory
- mount the Prometheus PVC root for the migration init container and keep guard markers outside the TSDB path
- run walvanilla against the prometheus-db subdirectory

## Validation
- pre-commit run --files apps/monitoring/values.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/monitoring/ -o /tmp/monitoring-render.yaml
- kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f /tmp/monitoring-render.yaml
- docker manifest inspect busybox:1.37.0@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e