### PR TITLE
fix: rollback prompp on pi page size

### DIFF
--- a/apps/monitoring/values.yaml
+++ b/apps/monitoring/values.yaml
@@ -4,58 +4,6 @@ crds:
     enabled: false
 prometheus:
   prometheusSpec:
-    image:
-      registry: ghcr.io
-      repository: deckhouse/prompp
-      tag: "0.7.10"
-      sha: 405dbe39fe3ca1daf9a942a047418c153ace49ccbb91c5ad029552be27b96446
-      pullPolicy: IfNotPresent
-    version: v3.11.3
-    initContainers:
-      - name: prompptool-marker-cleanup
-        image: busybox:1.37.0@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
-        command:
-          - /bin/sh
-          - -ec
-          - |
-            rm -f /prometheus-volume/prometheus-db/.prompp-walvanilla-started /prometheus-volume/prometheus-db/.prompp-walvanilla-complete
-        volumeMounts:
-          - name: prometheus-kube-prometheus-stack-prometheus-db
-            mountPath: /prometheus-volume
-        resources:
-          requests:
-            cpu: 10m
-            memory: 16Mi
-          limits:
-            memory: 32Mi
-      - name: prompptool-walvanilla
-        image: ghcr.io/deckhouse/prompp:0.7.10@sha256:405dbe39fe3ca1daf9a942a047418c153ace49ccbb91c5ad029552be27b96446
-        command:
-          - /bin/sh
-          - -ec
-          - |
-            started=/prometheus-volume/.prompp-walvanilla-started
-            complete=/prometheus-volume/.prompp-walvanilla-complete
-            if [ -f "$complete" ]; then
-              echo "Prom++ WAL conversion marker exists; skipping walvanilla"
-              exit 0
-            fi
-            if [ -f "$started" ]; then
-              echo "Prom++ WAL conversion started previously but did not complete; refusing automatic retry" >&2
-              exit 1
-            fi
-            : > "$started"
-            /bin/prompptool --working-dir=/prometheus-volume/prometheus-db walvanilla
-            : > "$complete"
-        volumeMounts:
-          - name: prometheus-kube-prometheus-stack-prometheus-db
-            mountPath: /prometheus-volume
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-          limits:
-            memory: 512Mi
     serviceMonitorSelectorNilUsesHelmValues: false
     ruleSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
## Summary
- roll monitoring back to the kube-prometheus-stack default Prometheus image
- remove the Prom++ image override and WAL migration init containers

## Root cause
- ghcr.io/deckhouse/prompp:0.7.10 fails on the Raspberry Pi 5 cluster before reaching WAL conversion with the jemalloc unsupported system page size error
- this matches upstream deckhouse/prompp#87 and the linked deckhouse/prompp#238 page-size discussion
- cluster smoke tests also failed for GHCR 0.7.10-arm64, Docker Hub 0.7.10, and GHCR 0.7.5

## Live cleanup performed
- removed failed migration markers and the generated prompptool core dump from the Prometheus PVC
- removed temporary smoke/debug pods

## Validation
- pre-commit run --files apps/monitoring/values.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/monitoring/ -o /tmp/monitoring-rollback-render.yaml
- kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f /tmp/monitoring-rollback-render.yaml
- Kubernetes smoke tests confirmed Prom++ images exit 139 with the jemalloc page-size error