### PR TITLE
docs: record prompp migration final state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,28 @@ branch is merged to `master` and ArgoCD syncs it.
 - `local-path` is intentionally used for small replicated CNPG clusters where important app state is GitOps-managed, such as Grafana
 - For PVC backups, use `components/volsync` and `components/volsync/b2`; patch ReplicationSource, ReplicationDestination, ExternalSecret, and PVC together
 
+## Monitoring
+
+- Prometheus is deployed by kube-prometheus-stack in `apps/monitoring`; image
+  changes belong in `apps/monitoring/values.yaml` under
+  `prometheus.prometheusSpec`, not in generated StatefulSet patches
+- For Prometheus image migrations, keep `prometheus.prometheusSpec.version`
+  explicit when the image tag is not an upstream Prometheus version, because the
+  Prometheus Operator uses it for feature compatibility and command generation
+- Before any Prometheus WAL-format migration, create and verify a Longhorn
+  `VolumeSnapshot` of
+  `prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-0`
+- Validate the exact digest-pinned candidate image on the actual ARM64
+  Prometheus node before rollout; local Docker ARM64 checks can miss Raspberry
+  Pi 5 16 KiB page-size issues
+- If a one-shot WAL conversion init container is required, mount the PVC root at
+  `/prometheus-volume`, keep marker files outside `/prometheus-volume/prometheus-db`,
+  make retries fail closed after an incomplete start marker, and remove the init
+  container in a follow-up PR immediately after the first healthy rollout
+- Prom++ writes a different WAL format than upstream Prometheus. Do not simply
+  revert back to `quay.io/prometheus/prometheus` after Prom++ starts; use the
+  documented reverse conversion or restore the pre-migration snapshot
+
 ## Grafana
 
 Grafana is managed by Grafana Operator in `apps/monitoring/grafana`; the

--- a/docs/superpowers/plans/2026-05-02-prompp-ghcr-migration.md
+++ b/docs/superpowers/plans/2026-05-02-prompp-ghcr-migration.md
@@ -597,7 +597,7 @@ Expected: all hooks pass.
 
 Execution note, 2026-05-02: final render showed the pinned Prom++ image, `version: v3.11.3`, and `initContainers: null`; the ArgoCD-style server-side dry-run completed; `pre-commit run --files apps/monitoring/values.yaml docs/superpowers/plans/2026-05-02-prompp-ghcr-migration.md` passed.
 
-- [ ] **Step 5: Commit the cleanup change**
+- [x] **Step 5: Commit the cleanup change**
 
 Run:
 
@@ -606,9 +606,11 @@ git add apps/monitoring/values.yaml
 git commit -m "chore: remove prompp wal migration init container"
 ```
 
-Expected: a commit containing only `apps/monitoring/values.yaml`.
+Expected: a commit containing `apps/monitoring/values.yaml` and this migration plan.
 
-- [ ] **Step 6: Merge the cleanup PR and validate final state**
+Execution note, 2026-05-02: committed as `a29b5c82 chore: remove prompp wal migration init container`; merged through PR #2796 as `2c8eae5e`.
+
+- [x] **Step 6: Merge the cleanup PR and validate final state**
 
 After CI passes and ArgoCD syncs, run:
 
@@ -625,6 +627,8 @@ v3.11.3
 ```
 
 The third line should be empty.
+
+Execution note, 2026-05-02: ArgoCD synced cleanup revision `2c8eae5e479f1f5eaba35530f14ce22e9716fb2c` and returned `Synced Healthy Succeeded`; the live Prometheus CR has the pinned Prom++ image, `version: v3.11.3`, no `spec.initContainers`, Available `True`, and generation `16` observed as `16`; the pod is Ready with `init-config-reloader=0`, `config-reloader=true:0`, and `prometheus=true:0`; final API checks returned `Prometheus Server is Ready.`, buildinfo version `0.7.10-jemalloc-aarch64-fix`, and query `up` returned `success results=103`.
 
 ---
 


### PR DESCRIPTION
## Summary
- mark the Prom++ migration plan cleanup steps complete with final live validation evidence
- add AGENTS.md monitoring guidance for future Prometheus/Prom++ image and WAL migrations

## Verification
- pre-commit run --files AGENTS.md docs/superpowers/plans/2026-05-02-prompp-ghcr-migration.md

## Live state recorded
- ArgoCD monitoring synced 2c8eae5e479f1f5eaba35530f14ce22e9716fb2c and returned Synced Healthy
- Prometheus CR has the pinned Prom++ image, version v3.11.3, and no initContainers
- Prometheus readiness, buildinfo, and query=up succeeded