### PR TITLE
fix: scrape grafana metrics

### DIFF
--- a/apps/monitoring/grafana/kustomization.yaml
+++ b/apps/monitoring/grafana/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - manifests/externalsecret.yaml
   - manifests/grafana.yaml
   - manifests/httproute.yaml
+  - manifests/servicemonitor.yaml

--- a/apps/monitoring/grafana/manifests/servicemonitor.yaml
+++ b/apps/monitoring/grafana/manifests/servicemonitor.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: grafana-operator
+      dashboards: grafana
+  namespaceSelector:
+    matchNames:
+      - monitoring
+  endpoints:
+    - port: grafana
+      path: /metrics
+      interval: 30s
+      honorLabels: true


### PR DESCRIPTION
## Summary
- Add a ServiceMonitor for the operator-managed Grafana service
- Scrape `/metrics` on the `grafana` service port so kube-prometheus-stack Grafana dashboards have data

## Validation
- pre-commit run --files apps/monitoring/grafana/kustomization.yaml apps/monitoring/grafana/manifests/servicemonitor.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/monitoring/
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/monitoring/ | kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f -