### PR TITLE
feat: add reusable dragonfly component

### DIFF
--- a/apps/renovate/kustomization.yaml
+++ b/apps/renovate/kustomization.yaml
@@ -7,10 +7,10 @@ resources:
   - manifests/externalsecret.yaml
   - manifests/renovatejob.yaml
   - manifests/httproute.yaml
-  - manifests/redis.yaml
   - manifests/netpol.yaml
 components:
   - ../../components/namespace
+  - ../../components/dragonfly
 helmCharts:
   - name: renovate-operator
     repo: oci://ghcr.io/mogenius/helm-charts

--- a/apps/renovate/manifests/netpol.yaml
+++ b/apps/renovate/manifests/netpol.yaml
@@ -36,11 +36,11 @@ spec:
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: renovate-redis
+  name: dragonfly
 spec:
   endpointSelector:
     matchLabels:
-      app: renovate-redis
+      app: dragonfly
   ingress:
     - fromEndpoints:
         - matchLabels:

--- a/apps/renovate/manifests/renovatejob.yaml
+++ b/apps/renovate/manifests/renovatejob.yaml
@@ -17,7 +17,7 @@ spec:
     - name: NODE_OPTIONS
       value: "--max-old-space-size=1536"
     - name: RENOVATE_REDIS_URL
-      value: "redis://renovate-redis.renovate.svc.cluster.local:6379"
+      value: "redis://dragonfly.renovate.svc.cluster.local:6379"
     - name: RENOVATE_REPOSITORY_CACHE
       value: enabled
     - name: RENOVATE_REPOSITORY_CACHE_TYPE

--- a/components/dragonfly/dragonfly.yaml
+++ b/components/dragonfly/dragonfly.yaml
@@ -2,18 +2,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: renovate-redis
+  name: dragonfly
   labels:
-    app: renovate-redis
+    app: dragonfly
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: renovate-redis
+      app: dragonfly
   template:
     metadata:
       labels:
-        app: renovate-redis
+        app: dragonfly
     spec:
       securityContext:
         runAsNonRoot: true
@@ -23,9 +23,11 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
-        - name: redis
-          image: redis:8.6.2-alpine@sha256:c5e375abb885e6b2021c0377879e4890bf76f9065b8922ffc113f2b226b9fc17
-          args: ["--maxmemory", "128mb", "--maxmemory-policy", "allkeys-lru"]
+        - name: dragonfly
+          image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.38.0@sha256:243bf004df5e137d9432c35367d7c86e6d2b5bcb6700be4b6397fcb9306b794b
+          args:
+            - --maxmemory=128mb
+            - --cache_mode=true
           ports:
             - containerPort: 6379
           securityContext:
@@ -50,10 +52,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: renovate-redis
+  name: dragonfly
 spec:
   selector:
-    app: renovate-redis
+    app: dragonfly
   ports:
     - port: 6379
       targetPort: 6379

--- a/components/dragonfly/kustomization.yaml
+++ b/components/dragonfly/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - dragonfly.yaml


### PR DESCRIPTION
## Summary
- Replace Renovate's app-local Redis deployment with a reusable Dragonfly Kustomize component.
- Rename the cache service to `dragonfly` and update `RENOVATE_REDIS_URL` accordingly.
- Update the Cilium policy to select the new Dragonfly app labels.

## Test plan
- `pre-commit run --files apps/renovate/kustomization.yaml apps/renovate/manifests/netpol.yaml apps/renovate/manifests/renovatejob.yaml components/dragonfly/kustomization.yaml components/dragonfly/dragonfly.yaml`
- `kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/renovate/`