### PR TITLE
fix: scan kustomize components with renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,7 @@
   kubernetes: {
     managerFilePatterns: [
       '/apps/.*\\.ya?ml$/',
+      '/components/.*\\.ya?ml$/',
     ],
   },
   argocd: {


### PR DESCRIPTION
## Summary
- Add `components/**/*.yaml` to Renovate's Kubernetes manager file patterns.
- Ensures images in reusable Kustomize components, including Dragonfly, are covered by Renovate updates.

## Test plan
- Original commit hook passed `Validate Renovate Config`.
