### PR TITLE
fix: raise dragonfly cpu limit

### DIFF
--- a/components/dragonfly/dragonfly.yaml
+++ b/components/dragonfly/dragonfly.yaml
@@ -40,7 +40,7 @@ spec:
               cpu: 50m
               memory: 256Mi
             limits:
-              cpu: 100m
+              cpu: 500m
               memory: 256Mi
           volumeMounts:
             - name: data


### PR DESCRIPTION
## Summary
- Raise Dragonfly's CPU limit from `100m` to `500m`.
- Keeps the request at `50m` while allowing burst capacity for short proactor work.

## Test plan
- Commit hook: `check yaml`, `yamllint`, and `kubeconform` passed for `components/dragonfly/dragonfly.yaml`.
