### PR TITLE
fix: lower dragonfly memory request

### DIFF
--- a/components/dragonfly/dragonfly.yaml
+++ b/components/dragonfly/dragonfly.yaml
@@ -38,7 +38,7 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 256Mi
+              memory: 64Mi
             limits:
               cpu: 500m
               memory: 256Mi


### PR DESCRIPTION
## Summary
- Lower Dragonfly's memory request from `256Mi` to `64Mi`.
- Keep `--maxmemory=256mb` and the memory limit at `256Mi` for the cache ceiling.

## Test plan
- Commit hook: `check yaml`, `yamllint`, and `kubeconform` passed for `components/dragonfly/dragonfly.yaml`.
