### PR TITLE
feat: add dragonfly operator app

### DIFF
--- a/.github/scripts/extract_image_info.py
+++ b/.github/scripts/extract_image_info.py
@@ -1,6 +1,5 @@
 import os
 import re
-import requests
 import sys
 import json
 
@@ -30,8 +29,19 @@ def is_valid_docker_image(image):
     """Validates whether an image reference conforms to Docker standard."""
     return bool(DOCKER_IMAGE_REGEX.fullmatch(image))
 
+def parse_docker_image(image):
+    """Returns image, tag, and digest parts for a valid Docker image reference."""
+    match = DOCKER_IMAGE_REGEX.fullmatch(image)
+    if not match:
+        return None
+
+    image_name, tag, digest = match.groups()
+    return image_name.strip(), (tag or "").strip(), (digest or "").strip()
+
 def extract_images_from_pr_diff():
     """Extracts container image updates from PR files with validation."""
+    import requests
+
     pr_number = os.environ['PR_NUMBER']
     repo = os.environ['GITHUB_REPOSITORY']
     token = os.environ['GITHUB_TOKEN']
@@ -77,10 +87,9 @@ def extract_images_from_pr_diff():
                     match = re.match(r'^\+\s*(?:image|[a-z_]+image|imageName):\s*"?([^\s"]+)"?', line, re.IGNORECASE)
                     if match:
                         image_tag = match.group(1).strip()
-                        if is_valid_docker_image(image_tag):
-                            image = image_tag.split('@')[0].split(':')[0].strip()
-                            tag = image_tag.split(':')[1].split('@')[0].strip() if ':' in image_tag else ""
-                            digest = image_tag.split('@')[1].strip() if '@' in image_tag else ""
+                        parsed_image = parse_docker_image(image_tag)
+                        if parsed_image:
+                            image, tag, digest = parsed_image
 
                             print(f"   ✅ Found Image: {image}, Tag: {tag}, Digest: {digest}")
                             images.append((image, tag, digest))
@@ -129,11 +138,14 @@ def extract_images_from_helm_diff():
 
                 image_tag = f"{repo_image}@{digest}" if digest else f"{repo_image}:{tag}"
 
-        if image_tag and is_valid_docker_image(image_tag):
+        if image_tag:
             # Extract components
-            image = image_tag.split('@')[0].split(':')[0].strip()
-            tag = image_tag.split(':')[1].split('@')[0].strip() if ':' in image_tag else ""
-            digest = image_tag.split('@')[1].strip() if '@' in image_tag else ""
+            parsed_image = parse_docker_image(image_tag)
+            if not parsed_image:
+                print(f"❌ Invalid Docker Image Reference: {image_tag}")
+                continue
+
+            image, tag, digest = parsed_image
 
             image_entry = (image, tag, digest)
             if image_entry not in unique_images:
@@ -141,8 +153,6 @@ def extract_images_from_helm_diff():
                 unique_images.add(image_entry)
             else:
                 print(f"ℹ️ Skipped Duplicate Image: {image}, Tag: {tag}, Digest: {digest}")
-        elif image_tag:
-            print(f"❌ Invalid Docker Image Reference: {image_tag}")
 
     print(f"📊 Extracted {len(unique_images)} unique images.")
     return list(unique_images)  # Convert set back to list before returning

--- a/.github/workflows/helm-diff.yml
+++ b/.github/workflows/helm-diff.yml
@@ -204,7 +204,8 @@ jobs:
             DIGEST_VAR="DIGEST_$i"
 
             declare -n IMG="$IMAGE_VAR" TAG="$TAG_VAR" DIG="$DIGEST_VAR"
-            IMAGE_FULL="${IMG:-}:${TAG:-}"
+            IMAGE_FULL="${IMG:-}"
+            [ -n "${TAG:-}" ] && IMAGE_FULL="${IMG}:${TAG}"
             [ -n "${DIG-}" ] && IMAGE_FULL="${IMG}@${DIG}"
 
             echo "Pulling image: $IMAGE_FULL"

--- a/.github/workflows/pull-image.yml
+++ b/.github/workflows/pull-image.yml
@@ -27,7 +27,8 @@ jobs:
           : > pull_results.txt
           PULL_FAILED=0
 
-          IMAGE_FULL="${IMAGE}:${TAG}"
+          IMAGE_FULL="${IMAGE}"
+          [ -n "${TAG:-}" ] && IMAGE_FULL="${IMAGE}:${TAG}"
           [ -n "${DIGEST:-}" ] && IMAGE_FULL="${IMAGE}@${DIGEST}"
 
           echo "Pulling image for linux/arm64: $IMAGE_FULL"

--- a/apps/argocd/manifests/apps.yaml
+++ b/apps/argocd/manifests/apps.yaml
@@ -157,7 +157,6 @@ spec:
     targetRevision: v1.5.0
     helm:
       releaseName: dragonfly-operator
-      skipTests: true
       valuesObject:
         crds:
           install: true

--- a/apps/argocd/manifests/apps.yaml
+++ b/apps/argocd/manifests/apps.yaml
@@ -145,6 +145,56 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  name: dragonfly-operator
+spec:
+  destination:
+    name: in-cluster
+    namespace: dragonfly-operator
+  project: k3s
+  source:
+    chart: dragonfly-operator
+    repoURL: ghcr.io/dragonflydb/dragonfly-operator/helm
+    targetRevision: v1.5.0
+    helm:
+      releaseName: dragonfly-operator
+      skipTests: true
+      valuesObject:
+        crds:
+          install: true
+          keep: true
+        manager:
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+        serviceMonitor:
+          enabled: true
+          rbacProxyMetricsReader:
+            create: true
+            serviceAccountName: kube-prometheus-stack-prometheus
+            serviceAccountNamespace: monitoring
+        grafanaDashboard:
+          enabled: true
+          folder: General
+          grafanaOperator:
+            enabled: true
+            allowCrossNamespaceImport: true
+            matchLabels:
+              dashboards: grafana
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+      - ApplyOutOfSyncOnly=true
+      - CreateNamespace=true
+      - ServerSideApply=true
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/argoproj.io/application_v1alpha1.json
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
   name: grafana-operator
 spec:
   destination:

--- a/apps/argocd/manifests/repos.yaml
+++ b/apps/argocd/manifests/repos.yaml
@@ -54,6 +54,20 @@ type: Opaque
 ---
 apiVersion: v1
 stringData:
+  name: dragonfly-operator
+  project: k3s
+  type: helm
+  url: ghcr.io/dragonflydb/dragonfly-operator/helm
+  enableOCI: "true"
+kind: Secret
+metadata:
+  labels:
+    argocd.argoproj.io/secret-type: repository
+  name: dragonfly-operator
+type: Opaque
+---
+apiVersion: v1
+stringData:
   name: stakater
   project: k3s
   type: helm


### PR DESCRIPTION
## Summary
- Add the Dragonfly Operator OCI Helm repository to Argo CD.
- Add a Dragonfly Operator Application pinned to chart `v1.5.0`.
- Enable CRD installation, ServiceMonitor, and Grafana Operator dashboard resources in the chart values.

## Rollout
- This PR installs the operator and CRD first so `crd-schema-publisher` can publish the Dragonfly schema before the follow-up Dragonfly CR migration.

## Test plan
- `pre-commit run --files apps/argocd/manifests/apps.yaml apps/argocd/manifests/repos.yaml`
- `kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/argocd/`
- `kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/argocd/ | kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f -`
