### PR TITLE
fix: allow dragonfly operator admin traffic

### DIFF
--- a/apps/renovate/manifests/netpol.yaml
+++ b/apps/renovate/manifests/netpol.yaml
@@ -49,3 +49,14 @@ spec:
         - ports:
             - port: "6379"
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: dragonfly-operator
+            control-plane: controller-manager
+        - matchLabels:
+            io.kubernetes.pod.namespace: renovate
+            app: dragonfly
+      toPorts:
+        - ports:
+            - port: "9999"
+              protocol: TCP


### PR DESCRIPTION
## Summary
- allow the Dragonfly operator to reach Dragonfly pods on admin port 9999
- allow Dragonfly peer pods to reach admin port 9999 as in the operator's generated NetworkPolicy

## Validation
- pre-commit run --files apps/renovate/manifests/netpol.yaml components/dragonfly/dragonfly.yaml apps/renovate/kustomization.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/renovate/ | kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f -