### PR TITLE
fix: grant dragonfly readiness status access

### DIFF
--- a/apps/argocd/kustomization.yaml
+++ b/apps/argocd/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - manifests/repos.yaml
   - manifests/httproute.yaml
   - manifests/cilium-preflight.yaml
+  - manifests/dragonfly-operator-rbac.yaml
   - manifests/namespace.yaml
   - manifests/netpol.yaml
   - manifests/externalsecret.yaml

--- a/apps/argocd/manifests/dragonfly-operator-rbac.yaml
+++ b/apps/argocd/manifests/dragonfly-operator-rbac.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dragonfly-operator-pods-status
+rules:
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dragonfly-operator-pods-status
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dragonfly-operator-pods-status
+subjects:
+  - kind: ServiceAccount
+    name: dragonfly-operator-controller-manager
+    namespace: dragonfly-operator

--- a/components/dragonfly/dragonfly.yaml
+++ b/components/dragonfly/dragonfly.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   replicas: 2
   image: docker.dragonflydb.io/dragonflydb/dragonfly:v1.38.1@sha256:baf70ba7ad182a992b988497cfa31a488978c8fab7712079784c2401f447e402
+  imagePullPolicy: IfNotPresent
   args:
     - --maxmemory=256mb
     - --cache_mode=true


### PR DESCRIPTION
## Summary
- add supplemental RBAC so dragonfly-operator can patch pods/status for replication readiness gates
- set Dragonfly imagePullPolicy to IfNotPresent, which also bumps the CR generation and causes the operator to reconcile generated resources again

## Validation
- pre-commit run --files apps/argocd/kustomization.yaml apps/argocd/manifests/dragonfly-operator-rbac.yaml components/dragonfly/dragonfly.yaml apps/renovate/kustomization.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/argocd/ | kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f -
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/renovate/ | kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f -