### PR TITLE
fix: scrape dragonfly pod metrics

### DIFF
--- a/apps/renovate/manifests/netpol.yaml
+++ b/apps/renovate/manifests/netpol.yaml
@@ -60,3 +60,15 @@ spec:
         - ports:
             - port: "9999"
               protocol: TCP
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: monitoring
+            app.kubernetes.io/name: prometheus
+      toPorts:
+        - ports:
+            - port: "9999"
+              protocol: TCP
+          rules:
+            http:
+              - method: GET
+                path: ^/metrics$

--- a/components/dragonfly/kustomization.yaml
+++ b/components/dragonfly/kustomization.yaml
@@ -4,3 +4,4 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
   - dragonfly.yaml
+  - podmonitor.yaml

--- a/components/dragonfly/podmonitor.yaml
+++ b/components/dragonfly/podmonitor.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: dragonfly
+spec:
+  selector:
+    matchLabels:
+      app: dragonfly
+  podMetricsEndpoints:
+    - port: admin
+      path: /metrics


### PR DESCRIPTION
## Summary
- add a reusable Dragonfly PodMonitor that scrapes the admin metrics endpoint on pod port admin
- allow Prometheus to GET /metrics on Dragonfly admin port 9999 through the Renovate Cilium policy

## Root cause
The Dragonfly dashboard was imported, but its panels query dragonfly_* instance metrics. Prometheus was only scraping the dragonfly-operator controller ServiceMonitor, so it had no dragonfly_* series.

## Validation
- pre-commit run --files components/dragonfly/kustomization.yaml components/dragonfly/podmonitor.yaml apps/renovate/manifests/netpol.yaml apps/renovate/kustomization.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/renovate/ | kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f -