### PR TITLE
fix: label dragonfly metrics for dashboard

### DIFF
--- a/components/dragonfly/podmonitor.yaml
+++ b/components/dragonfly/podmonitor.yaml
@@ -8,6 +8,8 @@ spec:
   selector:
     matchLabels:
       app: dragonfly
+  podTargetLabels:
+    - app
   podMetricsEndpoints:
     - port: admin
       path: /metrics


### PR DESCRIPTION
## Summary
- transfer the Dragonfly pod app label onto PodMonitor target metrics
- fixes the Dragonfly dashboard template variable query label_values(dragonfly_uptime_in_seconds,app)

## Validation
- pre-commit run --files components/dragonfly/podmonitor.yaml components/dragonfly/kustomization.yaml apps/renovate/kustomization.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/renovate/ | kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f -