### PR TITLE
feat: add argocd component ha

### DIFF
--- a/apps/argocd/manifests/values.yaml
+++ b/apps/argocd/manifests/values.yaml
@@ -11,6 +11,17 @@ externalRedis:
   port: 6379
   existingSecret: argocd-dragonfly-auth
 server:
+  replicas: 2
+  env:
+    - name: ARGOCD_API_SERVER_REPLICAS
+      value: "2"
+  pdb:
+    enabled: true
+    maxUnavailable: 1
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
   certificate:
     enabled: false
   certificateSecret:
@@ -33,10 +44,29 @@ controller:
     serviceMonitor:
       enabled: true
 repoServer:
+  replicas: 2
+  pdb:
+    enabled: true
+    maxUnavailable: 1
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
   metrics:
     enabled: true
     serviceMonitor:
       enabled: true
+applicationSet:
+  replicas: 2
+  extraArgs:
+    - --enable-leader-election=true
+  pdb:
+    enabled: true
+    maxUnavailable: 1
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: DoNotSchedule
 configs:
   cm:
     kustomize.buildOptions: --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard


### PR DESCRIPTION
## Summary
- scale Argo CD server, repo-server, and ApplicationSet controller to 2 replicas
- add PDBs and hostname topology spread constraints for those components
- enable ApplicationSet leader election for the second controller replica

## Practical benefit
- Dragonfly cache HA keeps Redis-compatible cache availability during a single pod/node loss
- repo-server HA keeps manifest generation available during node reboots and reduces reconciliation stalls
- server HA keeps UI/API/webhook availability during a single pod/node loss
- ApplicationSet HA keeps app generation from apps/* available while one controller pod is down

## Validation
- pre-commit run --files apps/argocd/manifests/values.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/argocd/
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/argocd/ | kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f -