### PR TITLE
feat: add raspios system upgrade plan

### DIFF
--- a/apps/system-upgrade/kustomization.yaml
+++ b/apps/system-upgrade/kustomization.yaml
@@ -9,3 +9,10 @@ resources:
   - https://raw.githubusercontent.com/rancher/system-upgrade-controller/refs/tags/v0.19.2/pkg/crds/yaml/generated/upgrade.cattle.io_plans.yaml
   - manifests/controller.yaml
   - manifests/plan.yaml
+  - manifests/os-plan.yaml
+secretGenerator:
+  - name: raspios-upgrade-script
+    files:
+      - upgrade.sh=manifests/raspios-upgrade.sh
+generatorOptions:
+  disableNameSuffixHash: true

--- a/apps/system-upgrade/manifests/os-plan.yaml
+++ b/apps/system-upgrade/manifests/os-plan.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/upgrade.cattle.io/plan_v1.json
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: raspios-bookworm
+  namespace: system-upgrade
+  labels:
+    os-upgrade: raspios-bookworm
+spec:
+  concurrency: 1
+  exclusive: true
+  jobActiveDeadlineSecs: 7200
+  postCompleteDelay: "5m"
+  version: bookworm-2026-05-09
+  nodeSelector:
+    matchExpressions:
+      - key: plan.upgrade.cattle.io/raspios-bookworm
+        operator: Exists
+      - key: plan.upgrade.cattle.io/raspios-bookworm
+        operator: NotIn
+        values:
+          - "disabled"
+          - "false"
+  serviceAccountName: system-upgrade
+  secrets:
+    - name: raspios-upgrade-script
+      path: /host/run/system-upgrade/secrets/raspios-bookworm
+      ignoreUpdates: true
+  tolerations:
+    - key: CriticalAddonsOnly
+      operator: Exists
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/etcd
+      operator: Exists
+      effect: NoExecute
+    - key: node-role.kubernetes.io/etcd
+      operator: Exists
+      effect: NoSchedule
+  drain:
+    force: true
+    skipWaitForDeleteTimeout: 180
+  upgrade:
+    image: debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
+    command: ["chroot", "/host"]
+    args: ["sh", "/run/system-upgrade/secrets/raspios-bookworm/upgrade.sh"]

--- a/apps/system-upgrade/manifests/plan.yaml
+++ b/apps/system-upgrade/manifests/plan.yaml
@@ -9,6 +9,7 @@ metadata:
     k3s-upgrade: server
 spec:
   concurrency: 1 # Batch size (roughly maps to maximum number of unschedulable nodes)
+  exclusive: true
   postCompleteDelay: "1m30s"
   version: v1.35.4+k3s1
   nodeSelector:
@@ -34,6 +35,7 @@ metadata:
     k3s-upgrade: agent
 spec:
   concurrency: 1 # Batch size (roughly maps to maximum number of unschedulable nodes)
+  exclusive: true
   postCompleteDelay: "1m30s"
   version: v1.35.4+k3s1
   nodeSelector:

--- a/apps/system-upgrade/manifests/raspios-upgrade.sh
+++ b/apps/system-upgrade/manifests/raspios-upgrade.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -eu
+
+marker_dir="/var/lib/rancher/system-upgrade/reboot"
+marker="${marker_dir}/raspios-bookworm"
+boot_id="$(cat /proc/sys/kernel/random/boot_id)"
+
+mkdir -p "${marker_dir}"
+
+if [ -f "${marker}" ]; then
+  previous_boot_id="$(cat "${marker}")"
+  if [ "${previous_boot_id}" != "${boot_id}" ]; then
+    rm -f "${marker}"
+    echo "Raspberry Pi OS update completed after reboot"
+    exit 0
+  fi
+
+  echo "Reboot marker exists for current boot; requesting reboot again"
+  systemctl reboot
+  while true; do
+    sleep 3600
+  done
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=a
+
+apt-get update
+apt-get -y \
+  -o Dpkg::Options::=--force-confdef \
+  -o Dpkg::Options::=--force-confold \
+  full-upgrade
+apt-get -y autoremove --purge
+apt-get clean
+
+printf '%s\n' "${boot_id}" > "${marker}"
+sync
+
+systemctl reboot
+while true; do
+  sleep 3600
+done


### PR DESCRIPTION
## Summary
- add an opt-in Raspberry Pi OS Bookworm system-upgrade-controller Plan for apt full-upgrade and reboot automation
- add a checked-in upgrade shell script generated into a stable Secret for SUC mounting
- mark existing K3s upgrade Plans as exclusive so OS and K3s upgrades cannot overlap

## Validation
- pre-commit run --files apps/system-upgrade/manifests/plan.yaml apps/system-upgrade/manifests/raspios-upgrade.sh apps/system-upgrade/manifests/os-plan.yaml apps/system-upgrade/kustomization.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/system-upgrade/
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/system-upgrade/ | kubectl apply --server-side --dry-run=server --field-manager=argocd-controller -f -

## Rollout note
No nodes currently have plan.upgrade.cattle.io/raspios-bookworm, so this will not start OS updates on merge. After sync, adding that label to a node will start the first OS update run for that node because the Plan version is bookworm-2026-05-09.