### PR TITLE
fix: rotate hubble certs with cilium certgen

### DIFF
--- a/apps/argocd/manifests/apps.yaml
+++ b/apps/argocd/manifests/apps.yaml
@@ -63,6 +63,13 @@ spec:
           enabled: true
         hubble:
           enabled: true
+          tls:
+            enabled: true
+            auto:
+              enabled: true
+              method: cronJob
+              certValidityDuration: 1095
+              schedule: "0 0 1 */4 *"
           relay:
             enabled: true
           ui:


### PR DESCRIPTION
## Summary
- switch Cilium Hubble TLS auto-generation from Helm-generated certs to the certgen CronJob method
- keep Hubble mTLS enabled and renew certs every four months with three-year validity
- allow ArgoCD sync to create the immediate certgen Job plus recurring CronJob

## Diagnosis
- hubble-relay is failing TLS verification because Hubble leaf certs expired on 2026-05-07
- existing Cilium CA remains valid until 2028-03-08
- current Helm method does not renew certs unless Helm is upgraded before expiry

## Validation
- pre-commit run --files apps/argocd/manifests/apps.yaml
- helm template cilium cilium/cilium --version 1.19.3 --namespace kube-system -f /tmp/home-ops-cilium-values.yaml