### PR TITLE
fix: manage hubble certs with cert-manager

### DIFF
--- a/apps/argocd/manifests/apps.yaml
+++ b/apps/argocd/manifests/apps.yaml
@@ -67,9 +67,12 @@ spec:
             enabled: true
             auto:
               enabled: true
-              method: cronJob
+              method: certmanager
               certValidityDuration: 1095
-              schedule: "0 0 1 */4 *"
+              certManagerIssuerRef:
+                group: cert-manager.io
+                kind: Issuer
+                name: cilium-hubble-ca
           relay:
             enabled: true
           ui:

--- a/apps/kube-system/cilium/kustomization.yaml
+++ b/apps/kube-system/cilium/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - manifests/CiliumBGPClusterConfig.yaml
+  - manifests/hubble/certificates.yaml
   - manifests/hubble/externalsecret.yaml
   - manifests/hubble/httproute.yaml
   - manifests/hubble/netpol.yaml

--- a/apps/kube-system/cilium/manifests/hubble/certificates.yaml
+++ b/apps/kube-system/cilium/manifests/hubble/certificates.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/cert-manager.io/issuer_v1.json
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cilium-hubble-selfsigned
+  namespace: kube-system
+spec:
+  selfSigned: {}
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cilium-hubble-ca
+  namespace: kube-system
+spec:
+  isCA: true
+  commonName: Cilium Hubble CA
+  secretName: cilium-hubble-ca
+  duration: 43800h
+  renewBefore: 720h
+  privateKey:
+    rotationPolicy: Always
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: cilium-hubble-selfsigned
+---
+# yaml-language-server: $schema=https://kube-schemas.shold.io/cert-manager.io/issuer_v1.json
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cilium-hubble-ca
+  namespace: kube-system
+spec:
+  ca:
+    secretName: cilium-hubble-ca


### PR DESCRIPTION
## Summary
- move Hubble TLS auto-generation from Cilium certgen CronJob to cert-manager
- add a kube-system Hubble CA Certificate plus self-signed and CA Issuers
- point the Cilium chart's Hubble leaf Certificates at Issuer/cilium-hubble-ca

## Why
The merged certgen fix rotates Hubble leaf certs, but it reuses cilium-ca and does not make the CA lifecycle automatic. This change puts both the CA and leaf certificates under cert-manager renewal.

## Validation
- pre-commit run --files apps/argocd/manifests/apps.yaml apps/kube-system/cilium/kustomization.yaml apps/kube-system/cilium/manifests/hubble/certificates.yaml
- helm template cilium cilium/cilium --version 1.19.3 --namespace kube-system -f /tmp/home-ops-cilium-values.yaml
- kustomize build apps/kube-system/cilium