### PR TITLE
fix: remove unused cilium ca ignores

### DIFF
--- a/apps/argocd/manifests/apps.yaml
+++ b/apps/argocd/manifests/apps.yaml
@@ -14,14 +14,6 @@ spec:
     - jsonPointers:
         - /data
       kind: Secret
-      name: cilium-ca
-    - jsonPointers:
-        - /data
-      kind: Secret
-      name: hubble-ca-cert
-    - jsonPointers:
-        - /data
-      kind: Secret
       name: hubble-relay-client-certs
     - jsonPointers:
         - /data


### PR DESCRIPTION
## Summary
- remove stale Cilium ignoreDifferences entries for cilium-ca and hubble-ca-cert
- keep the live cert-manager-managed Hubble certificate Secret ignore rules

## Validation
- rg cilium-ca/hubble-ca-cert across apps returned no desired references
- Cilium Helm render has no cilium-ca/hubble-ca-cert/certgen output
- pre-commit run --files apps/argocd/manifests/apps.yaml