### PR TITLE
fix: enable server-side diff for crd schema publisher

### DIFF
--- a/apps/argocd/manifests/apps.yaml
+++ b/apps/argocd/manifests/apps.yaml
@@ -102,6 +102,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: crd-schema-publisher
+  annotations:
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
 spec:
   destination:
     name: in-cluster


### PR DESCRIPTION
## Summary

- add `argocd.argoproj.io/compare-options: ServerSideDiff=true` to the explicit crd-schema-publisher Application
- matches the compare behavior already used by ApplicationSet-generated apps
- avoids ExternalSecret defaulted fields leaving the app OutOfSync while healthy

## Validation

- pre-commit run --files apps/argocd/manifests/apps.yaml
- kustomize build --enable-helm apps/argocd
- kubectl --context default -n argocd apply --server-side --dry-run=server --field-manager=argocd-controller -f apps/argocd/manifests/apps.yaml