### PR TITLE
chore: add kind cleanup recipe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ just bootstrap-live-phase argocd default
 
 - Bootstrap is deliberately narrower than steady-state GitOps. Keep it limited to dependencies required before ArgoCD can take over: CRDs, cert-manager, External Secrets and 1Password Connect, Dragonfly Operator, ArgoCD dependencies, and ArgoCD itself.
 - Do not add normal workloads to `hack/bootstrap/` if ArgoCD can safely reconcile them after takeover.
-- `kind-kind` bootstrap validation intentionally omits real-cluster-only resources when `ciliumnetworkpolicies.cilium.io` is absent: the `k3s-apps` ApplicationSet, Cilium apps, Longhorn, and `crd-schema-publisher`.
+- Kind bootstrap validation uses the repo-specific `home-ops-bootstrap` cluster by default and intentionally omits real-cluster-only resources when `ciliumnetworkpolicies.cilium.io` is absent: the `k3s-apps` ApplicationSet, Cilium apps, Longhorn, and `crd-schema-publisher`.
 - `bootstrap-kind-dry-run` is a post-bootstrap validation pass. It is not a clean-cluster first-boot test because server-side dry-run does not persist CRDs for later CR validation.
 - Do not let local kind tests publish schemas or touch other external live services.
 - Secret manifests from 1Password must be streamed, normalized to Secret `data`, and applied server-side; do not write them to disk, logs, or client-side last-applied annotations. The seed Secret may use scoped `--force-conflicts` because the 1Password item is authoritative.

--- a/docs/just-bootstrap.md
+++ b/docs/just-bootstrap.md
@@ -30,6 +30,13 @@ just bootstrap-test
 
 ## Local Kind Test
 
+Kind recipes use the repo-specific cluster name `home-ops-bootstrap`, which
+creates the kube context `kind-home-ops-bootstrap`. Override it only when needed:
+
+```sh
+KIND_CLUSTER=my-test-cluster just kind-reset
+```
+
 Create a clean three-node kind cluster:
 
 ```sh
@@ -61,6 +68,12 @@ dry-run validation against the local API:
 
 ```sh
 just bootstrap-kind-dry-run
+```
+
+Delete the local kind cluster when validation is complete:
+
+```sh
+just kind-delete
 ```
 
 Do not use `bootstrap-kind-dry-run` as the first command after `kind-reset`.

--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -32,7 +32,7 @@ exist.
 Run against an explicit context:
 
 ```sh
-./hack/bootstrap/bootstrap.sh --kube-context kind-kind --yes
+./hack/bootstrap/bootstrap.sh --kube-context kind-home-ops-bootstrap --yes
 ```
 
 For local bootstrap testing, recreate kind as one control-plane plus two worker
@@ -50,7 +50,7 @@ If more than one 1Password account is configured and the default account is
 wrong, pin the account explicitly:
 
 ```sh
-./hack/bootstrap/bootstrap.sh --kube-context kind-kind --op-account my --yes
+./hack/bootstrap/bootstrap.sh --kube-context kind-home-ops-bootstrap --op-account my --yes
 ```
 
 The script writes local run logs under `.out/`. Secret manifests read from
@@ -70,5 +70,5 @@ script, let your shell run `op read` and pipe the manifest to the seed phase:
 
 ```sh
 op read op://Kubernetes/op-credentials/op-credentials.yaml \
-  | ./hack/bootstrap/bootstrap.sh --kube-context kind-kind --only-phase seed-secret --seed-secret-stdin --yes
+  | ./hack/bootstrap/bootstrap.sh --kube-context kind-home-ops-bootstrap --only-phase seed-secret --seed-secret-stdin --yes
 ```

--- a/justfile
+++ b/justfile
@@ -1,3 +1,6 @@
+kind_cluster := env_var_or_default("KIND_CLUSTER", "home-ops-bootstrap")
+kind_context := "kind-" + kind_cluster
+
 bootstrap repo='.':
   ./hack/bootstrap/bootstrap.sh --repo '{{repo}}'
 
@@ -8,19 +11,19 @@ bootstrap-dry-run repo='.':
   ./hack/bootstrap/bootstrap.sh --repo '{{repo}}' --dry-run
 
 bootstrap-kind:
-  ./hack/bootstrap/bootstrap.sh --kube-context kind-kind --yes
+  ./hack/bootstrap/bootstrap.sh --kube-context '{{kind_context}}' --yes
 
 bootstrap-kind-fresh: kind-reset
-  ./hack/bootstrap/bootstrap.sh --kube-context kind-kind --yes
+  ./hack/bootstrap/bootstrap.sh --kube-context '{{kind_context}}' --yes
 
 bootstrap-kind-dry-run:
-  ./hack/bootstrap/bootstrap.sh --kube-context kind-kind --from-phase bootstrap-crds --dry-run --yes
+  ./hack/bootstrap/bootstrap.sh --kube-context '{{kind_context}}' --from-phase bootstrap-crds --dry-run --yes
 
 bootstrap-kind-seed:
-  @op read op://Kubernetes/op-credentials/op-credentials.yaml | ./hack/bootstrap/bootstrap.sh --kube-context kind-kind --only-phase seed-secret --seed-secret-stdin --yes
+  @op read op://Kubernetes/op-credentials/op-credentials.yaml | ./hack/bootstrap/bootstrap.sh --kube-context '{{kind_context}}' --only-phase seed-secret --seed-secret-stdin --yes
 
 bootstrap-kind-resume phase='bootstrap-crds':
-  ./hack/bootstrap/bootstrap.sh --kube-context kind-kind --from-phase '{{phase}}' --yes
+  ./hack/bootstrap/bootstrap.sh --kube-context '{{kind_context}}' --from-phase '{{phase}}' --yes
 
 bootstrap-live-audit context='default':
   ./hack/bootstrap/bootstrap.sh --kube-context '{{context}}' --audit-only
@@ -32,8 +35,11 @@ bootstrap-live-phase phase context='default':
   ./hack/bootstrap/bootstrap.sh --kube-context '{{context}}' --only-phase '{{phase}}' --dry-run --yes
 
 kind-reset:
-  kind delete cluster --name kind
-  kind create cluster --name kind --config hack/bootstrap/kind-three-node.yaml
+  kind delete cluster --name '{{kind_cluster}}'
+  kind create cluster --name '{{kind_cluster}}' --config hack/bootstrap/kind-three-node.yaml
+
+kind-delete:
+  kind delete cluster --name '{{kind_cluster}}'
 
 bootstrap-audit:
   ./hack/bootstrap/bootstrap.sh --audit-only


### PR DESCRIPTION
## Summary

- add `just kind-delete` for explicit local kind cleanup
- use repo-specific kind cluster name `home-ops-bootstrap` by default to avoid deleting another default `kind` cluster
- allow `KIND_CLUSTER=...` overrides and document the derived context

## Validation

- just --list
- just --evaluate kind_cluster
- just --evaluate kind_context
- KIND_CLUSTER=scratch just --evaluate kind_context
- just --dry-run kind-delete
- KIND_CLUSTER=scratch just --dry-run bootstrap-kind
- pre-commit run --files AGENTS.md docs/just-bootstrap.md hack/bootstrap/README.md justfile