### PR TITLE
feat: prompt for 1password signin during bootstrap

### DIFF
--- a/docs/just-bootstrap.md
+++ b/docs/just-bootstrap.md
@@ -55,8 +55,7 @@ Recreate kind and then run the bootstrap in one step:
 just bootstrap-kind-fresh
 ```
 
-If the local shell needs to read the 1Password seed secret first, seed kind and
-resume from the next phase:
+To seed kind separately before resuming the remaining phases:
 
 ```sh
 just bootstrap-kind-seed
@@ -181,14 +180,19 @@ Secret. This one apply path uses scoped server-side `--force-conflicts` because
 the 1Password item is authoritative for the bootstrap seed Secret and older
 clusters may have created it with client-side apply.
 
-If `op` works in the shell but not inside the bootstrap script, authenticate
-first:
+Before reading from 1Password, the seed phase runs `op whoami`. If the CLI is
+not signed in and the run is interactive, it runs `op signin`, evaluates the
+returned session export inside the bootstrap process without logging it, and
+then retries the read.
+
+If the automatic prompt is not appropriate, authenticate first:
 
 ```sh
 eval "$(op signin)"
 ```
 
-Then rerun bootstrap, or pipe the seed manifest directly:
+Then rerun bootstrap. You can also pipe the seed manifest directly to bypass
+all script-managed `op` calls:
 
 ```sh
 op read op://Kubernetes/op-credentials/op-credentials.yaml \

--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -59,14 +59,15 @@ written to disk or stored in the local run report. The seed Secret is normalized
 to `data`, applied server-side, and cleaned of any old
 `kubectl.kubernetes.io/last-applied-configuration` annotation. That seed apply
 uses scoped server-side `--force-conflicts` because the 1Password item is
-authoritative. Keep 1Password CLI desktop app integration enabled and the app
-unlocked for local interactive bootstrap runs, or authenticate `op` before
-invoking the script. Leave `--op-account` unset unless you need to
-disambiguate accounts; when you do set it, use the shorthand from
-`op account list`, such as `my`.
+authoritative. The seed phase checks `op whoami` and, when stdin is
+interactive, falls back to `op signin` without logging the returned session
+export. Keep 1Password CLI desktop app integration enabled and the app unlocked
+for local interactive bootstrap runs, or authenticate `op` before invoking the
+script. Leave `--op-account` unset unless you need to disambiguate accounts;
+when you do set it, use the shorthand from `op account list`, such as `my`.
 
-If `op` works in your interactive shell but not from inside the bootstrap
-script, let your shell run `op read` and pipe the manifest to the seed phase:
+If script-managed `op` auth is not appropriate, let your shell run `op read`
+and pipe the manifest to the seed phase:
 
 ```sh
 op read op://Kubernetes/op-credentials/op-credentials.yaml \

--- a/hack/bootstrap/phases/seed-secret.sh
+++ b/hack/bootstrap/phases/seed-secret.sh
@@ -10,11 +10,26 @@ if [[ -n "${BOOTSTRAP_OP_ACCOUNT:-}" ]]; then
   op_args+=(--account "$BOOTSTRAP_OP_ACCOUNT")
 fi
 
+op_signin_if_needed() {
+  bool "$SEED_SECRET_STDIN" && return
+  op whoami "${op_args[@]}" >/dev/null 2>&1 && return
+
+  [[ -t 0 ]] || die "1Password CLI is not signed in and stdin is not interactive; run 'eval \"\$(op signin)\"' first, or pipe the seed Secret with --seed-secret-stdin"
+
+  log "1Password CLI is not signed in; starting interactive op signin"
+  local signin
+  signin="$(op signin --force "${op_args[@]}")" || die "op signin failed"
+  # op signin writes shell exports to stdout. Evaluate them without logging.
+  eval "$signin"
+  op whoami "${op_args[@]}" >/dev/null 2>&1 || die "op signin completed but op whoami still failed"
+}
+
 op_read_seed_secret() {
   if bool "$SEED_SECRET_STDIN"; then
     cat
     return
   fi
+  op_signin_if_needed
   op read "${op_args[@]}" "$op_ref"
 }
 

--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ bootstrap-kind-dry-run:
   ./hack/bootstrap/bootstrap.sh --kube-context '{{kind_context}}' --from-phase bootstrap-crds --dry-run --yes
 
 bootstrap-kind-seed:
-  @op read op://Kubernetes/op-credentials/op-credentials.yaml | ./hack/bootstrap/bootstrap.sh --kube-context '{{kind_context}}' --only-phase seed-secret --seed-secret-stdin --yes
+  ./hack/bootstrap/bootstrap.sh --kube-context '{{kind_context}}' --only-phase seed-secret --yes
 
 bootstrap-kind-resume phase='bootstrap-crds':
   ./hack/bootstrap/bootstrap.sh --kube-context '{{kind_context}}' --from-phase '{{phase}}' --yes


### PR DESCRIPTION
## Summary

- make the seed-secret phase run `op whoami` before reading the 1Password seed Secret
- fall back to interactive `op signin --force` when needed, capturing and evaluating the session export without logging it
- update `just bootstrap-kind-seed` so it uses the script-managed auth path
- keep `--seed-secret-stdin` as the bypass for externally managed `op read` flows

## Validation

- just bootstrap-test
- just --dry-run bootstrap-kind-seed
- pre-commit run --files hack/bootstrap/phases/seed-secret.sh justfile docs/just-bootstrap.md hack/bootstrap/README.md
- fake seed-secret stdin server-side dry-run against default context
- review agent approval