### PR TITLE
fix: keep op signin output out of seed pipeline

### DIFF
--- a/docs/just-bootstrap.md
+++ b/docs/just-bootstrap.md
@@ -180,10 +180,10 @@ Secret. This one apply path uses scoped server-side `--force-conflicts` because
 the 1Password item is authoritative for the bootstrap seed Secret and older
 clusters may have created it with client-side apply.
 
-Before reading from 1Password, the seed phase runs `op whoami`. If the CLI is
-not signed in and the run is interactive, it runs `op signin`, evaluates the
-returned session export inside the bootstrap process without logging it, and
-then retries the read.
+The seed phase first tries `op read`. If that fails and the run is interactive,
+it runs `op signin`, evaluates the returned session export inside the bootstrap
+process without logging it, and then retries the read. Only the Secret manifest
+is written to stdout for the YAML pipeline.
 
 If the automatic prompt is not appropriate, authenticate first:
 

--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -59,12 +59,13 @@ written to disk or stored in the local run report. The seed Secret is normalized
 to `data`, applied server-side, and cleaned of any old
 `kubectl.kubernetes.io/last-applied-configuration` annotation. That seed apply
 uses scoped server-side `--force-conflicts` because the 1Password item is
-authoritative. The seed phase checks `op whoami` and, when stdin is
-interactive, falls back to `op signin` without logging the returned session
-export. Keep 1Password CLI desktop app integration enabled and the app unlocked
-for local interactive bootstrap runs, or authenticate `op` before invoking the
-script. Leave `--op-account` unset unless you need to disambiguate accounts;
-when you do set it, use the shorthand from `op account list`, such as `my`.
+authoritative. The seed phase tries `op read` and, when that fails with
+interactive stdin, falls back to `op signin` without logging the returned
+session export. Keep 1Password CLI desktop app integration enabled and the app
+unlocked for local interactive bootstrap runs, or authenticate `op` before
+invoking the script. Leave `--op-account` unset unless you need to
+disambiguate accounts; when you do set it, use the shorthand from
+`op account list`, such as `my`.
 
 If script-managed `op` auth is not appropriate, let your shell run `op read`
 and pipe the manifest to the seed phase:

--- a/hack/bootstrap/phases/seed-secret.sh
+++ b/hack/bootstrap/phases/seed-secret.sh
@@ -12,16 +12,14 @@ fi
 
 op_signin_if_needed() {
   bool "$SEED_SECRET_STDIN" && return
-  op whoami "${op_args[@]}" >/dev/null 2>&1 && return
 
   [[ -t 0 ]] || die "1Password CLI is not signed in and stdin is not interactive; run 'eval \"\$(op signin)\"' first, or pipe the seed Secret with --seed-secret-stdin"
 
-  log "1Password CLI is not signed in; starting interactive op signin"
+  log "1Password CLI is not signed in; starting interactive op signin" >&2
   local signin
   signin="$(op signin --force "${op_args[@]}")" || die "op signin failed"
   # op signin writes shell exports to stdout. Evaluate them without logging.
   eval "$signin"
-  op whoami "${op_args[@]}" >/dev/null 2>&1 || die "op signin completed but op whoami still failed"
 }
 
 op_read_seed_secret() {
@@ -29,8 +27,15 @@ op_read_seed_secret() {
     cat
     return
   fi
+  local seed_secret
+  if seed_secret="$(op read "${op_args[@]}" "$op_ref" 2>/dev/null)"; then
+    printf '%s\n' "$seed_secret"
+    return
+  fi
+
   op_signin_if_needed
-  op read "${op_args[@]}" "$op_ref"
+  seed_secret="$(op read "${op_args[@]}" "$op_ref")" || die "op read failed after op signin"
+  printf '%s\n' "$seed_secret"
 }
 
 normalize_seed_secret() {


### PR DESCRIPTION
## Summary
- retry seed Secret reads after interactive `op signin` without writing signin/log output into the YAML pipeline
- keep the session export captured/evaluated inside the bootstrap process and out of logs
- update bootstrap docs to describe the new read/signin/read flow

## Review
- Review agent approval obtained: Approved

## Tests
- `just bootstrap-test`
- `pre-commit run --files hack/bootstrap/phases/seed-secret.sh docs/just-bootstrap.md hack/bootstrap/README.md`
- fake `op` harness for failed read -> signin -> successful read