### PR TITLE
ci: add bootstrap validation

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -1,7 +1,7 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-action.json
 name: Setup CLI Tools
-description: Install kubeconform, actionlint, kustomize, and Helm for CI workflows
+description: Install shared CLI tools for CI workflows
 
 inputs:
   kubeconform-version:
@@ -20,6 +20,10 @@ inputs:
     description: Helm version
     # renovate: datasource=github-releases depName=helm/helm
     default: '3.20.2'
+  just-version:
+    description: just version
+    # renovate: datasource=github-releases depName=casey/just
+    default: '1.51.0'
 
 runs:
   using: composite
@@ -29,7 +33,7 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: /usr/local/bin/setup-tools
-        key: setup-tools-${{ inputs.kubeconform-version }}-${{ inputs.actionlint-version }}-${{ inputs.kustomize-version }}
+        key: setup-tools-${{ inputs.kubeconform-version }}-${{ inputs.actionlint-version }}-${{ inputs.kustomize-version }}-${{ inputs.just-version }}
 
     - name: Install kubeconform
       if: steps.cli-cache.outputs.cache-hit != 'true'
@@ -64,6 +68,17 @@ runs:
         tar -xzf kustomize.tar.gz
         mv kustomize /usr/local/bin/setup-tools/kustomize
         rm kustomize.tar.gz
+
+    - name: Install just
+      if: steps.cli-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        VERSION="${{ inputs.just-version }}"
+        curl -sSLo just.tar.gz \
+          "https://github.com/casey/just/releases/download/${VERSION}/just-${VERSION}-x86_64-unknown-linux-musl.tar.gz"
+        tar -xzf just.tar.gz just
+        mv just /usr/local/bin/setup-tools/just
+        rm just.tar.gz
 
     - name: Add tools to PATH
       shell: bash

--- a/.github/workflows/bootstrap-test.yml
+++ b/.github/workflows/bootstrap-test.yml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Bootstrap Test
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install CLI tools
+        uses: ./.github/actions/setup-tools
+
+      - name: Check justfile formatting
+        run: just --fmt --check
+
+      - name: List just tasks
+        run: just --list
+
+      - name: Check aggregate task wiring
+        run: just --dry-run check
+
+      - name: Show runner yq
+        run: yq --version
+
+      - name: Smoke render app helper
+        run: just --quiet app-build adguard >/tmp/adguard.yaml
+
+      - name: Verify app helper rejects path arguments
+        run: |
+          if just --quiet app-build ..; then
+            echo "app-build accepted a path-like app argument" >&2
+            exit 1
+          fi
+
+      - name: Check bootstrap test wiring
+        run: just --dry-run bootstrap-test
+
+      - name: Run bootstrap offline parse test
+        run: hack/bootstrap/tests/offline-parse.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,9 @@ jobs:
   pre-commit:
     uses: ./.github/workflows/pre-commit.yml
 
+  bootstrap-test:
+    uses: ./.github/workflows/bootstrap-test.yml
+
   helm-diff:
     needs: detect
     if: needs.detect.outputs.authorized == 'true' && needs.detect.outputs.helm == 'true'
@@ -84,18 +87,19 @@ jobs:
   gate:
     runs-on: ubuntu-latest
     if: always()
-    needs: [detect, pre-commit, helm-diff, docker-verify]
+    needs: [detect, pre-commit, bootstrap-test, helm-diff, docker-verify]
     steps:
       - name: Evaluate results
         run: |
           DETECT="${{ needs.detect.result }}"
           PRECOMMIT="${{ needs.pre-commit.result }}"
+          BOOTSTRAP="${{ needs.bootstrap-test.result }}"
           HELM="${{ needs.helm-diff.result }}"
           DOCKER="${{ needs.docker-verify.result }}"
 
-          echo "detect=$DETECT pre-commit=$PRECOMMIT helm-diff=$HELM docker-verify=$DOCKER"
+          echo "detect=$DETECT pre-commit=$PRECOMMIT bootstrap-test=$BOOTSTRAP helm-diff=$HELM docker-verify=$DOCKER"
 
-          if [[ "$DETECT" == "failure" || "$PRECOMMIT" == "failure" || "$HELM" == "failure" || "$DOCKER" == "failure" ]]; then
+          if [[ "$DETECT" == "failure" || "$PRECOMMIT" == "failure" || "$BOOTSTRAP" == "failure" || "$HELM" == "failure" || "$DOCKER" == "failure" ]]; then
             echo "CI failed"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- add a reusable Bootstrap Test workflow for justfile and bootstrap offline validation
- wire bootstrap validation into the existing CI gate
- install pinned Renovate-managed just through the shared setup-tools action

## Notes
- ShellCheck remains covered by pre-commit rather than duplicated in bootstrap CI
- yq uses the Ubuntu hosted runner image; the workflow prints yq --version for diagnosis
- no kind, op, live Kubernetes, server-side apply, or secrets are used in PR CI

## Validation
- just --fmt --check
- just --dry-run bootstrap-test
- hack/bootstrap/tests/offline-parse.sh
- just bootstrap-test
- actionlint .github/workflows/bootstrap-test.yml .github/workflows/ci.yaml
- pre-commit run --files .github/actions/setup-tools/action.yml .github/workflows/bootstrap-test.yml .github/workflows/ci.yaml
- git diff --check
- verified the just 1.51.0 linux musl release archive resolves and contains a root-level just binary

Review agent approved.