### PR TITLE
fix: sync powerdns db policy before cnpg

### DIFF
--- a/apps/powerdns/manifests/netpol.yaml
+++ b/apps/powerdns/manifests/netpol.yaml
@@ -110,6 +110,8 @@ kind: CiliumNetworkPolicy
 metadata:
   name: powerdns-db
   namespace: powerdns
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
 spec:
   endpointSelector:
     matchLabels:


### PR DESCRIPTION
## Summary
- apply the PowerDNS CNPG database CiliumNetworkPolicy before the CNPG cluster health gate
- keep the join-job ingress allowance available during replica rebuilds and operator upgrades

## Validation
- pre-commit run --files apps/powerdns/manifests/netpol.yaml
- kustomize build --enable-helm apps/powerdns/
- kustomize build --enable-helm apps/powerdns/ | kubectl --context default apply --server-side --dry-run=server --field-manager=argocd-controller -f -