### PR TITLE
chore: group just recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,19 +4,23 @@ helm_api_version := "grafana.integreatly.org/v1beta1/GrafanaDashboard"
 lima_app_env := "LIMA_AGENT_COUNT=3 LIMA_AGENT_CPUS=4 LIMA_AGENT_MEMORY_GIB=6 LIMA_DISK_GIB=120 LIMA_VALIDATE_APP_WAIT_SECONDS=3600"
 
 # Show available just tasks and their descriptions.
+[group('core')]
 default:
-    @just --list
+    @just --list --unsorted
 
 # Run full local validation, including pre-commit and bootstrap script tests.
+[group('core')]
 check:
     just pre-commit
     just bootstrap-test
 
 # Run every pre-commit hook against the repository.
+[group('core')]
 pre-commit:
     pre-commit run --all-files
 
 # Render one top-level app directory with the same Kustomize Helm settings used by CI.
+[group('apps')]
 app-build $app:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -36,6 +40,7 @@ app-build $app:
     kustomize build --enable-helm --helm-api-versions '{{ helm_api_version }}' "${dir}"
 
 # Server-side dry-run one top-level app with ArgoCD's field manager.
+[group('apps')]
 app-dry-run $app $context='default':
     #!/usr/bin/env bash
     set -euo pipefail
@@ -56,6 +61,7 @@ app-dry-run $app $context='default':
       | kubectl --context "${context}" apply --server-side --dry-run=server --field-manager=argocd-controller -f -
 
 # Diff one top-level app against a cluster using ArgoCD's field manager.
+[group('apps')]
 app-diff $app $context='default':
     #!/usr/bin/env bash
     set -euo pipefail
@@ -76,130 +82,162 @@ app-diff $app $context='default':
       | kubectl --context "${context}" diff --server-side --field-manager=argocd-controller -f -
 
 # Run the bootstrap flow against the current kube context with confirmation.
+[group('bootstrap')]
 bootstrap repo='.':
     ./hack/bootstrap/bootstrap.sh --repo '{{ repo }}'
 
 # Run the bootstrap flow against the current kube context without confirmation.
+[group('bootstrap')]
 bootstrap-yes repo='.':
     ./hack/bootstrap/bootstrap.sh --repo '{{ repo }}' --yes
 
 # Server-side dry-run the bootstrap flow against the current kube context.
+[group('bootstrap')]
 bootstrap-dry-run repo='.':
     ./hack/bootstrap/bootstrap.sh --repo '{{ repo }}' --dry-run
 
 # Run bootstrap against the configured kind cluster.
+[group('bootstrap-kind')]
 bootstrap-kind:
     ./hack/bootstrap/bootstrap.sh --kube-context '{{ kind_context }}' --yes
 
 # Recreate the configured kind cluster and run bootstrap from scratch.
+[group('bootstrap-kind')]
 bootstrap-kind-fresh: kind-reset
     ./hack/bootstrap/bootstrap.sh --kube-context '{{ kind_context }}' --yes
 
 # Server-side dry-run bootstrap against an already bootstrapped kind cluster.
+[group('bootstrap-kind')]
 bootstrap-kind-dry-run:
     ./hack/bootstrap/bootstrap.sh --kube-context '{{ kind_context }}' --from-phase bootstrap-crds --dry-run --yes
 
 # Seed only the 1Password External Secrets credential into kind.
+[group('bootstrap-kind')]
 bootstrap-kind-seed:
     ./hack/bootstrap/bootstrap.sh --kube-context '{{ kind_context }}' --only-phase seed-secret --yes
 
 # Resume kind bootstrap from a specific phase.
+[group('bootstrap-kind')]
 bootstrap-kind-resume phase='bootstrap-crds':
     ./hack/bootstrap/bootstrap.sh --kube-context '{{ kind_context }}' --from-phase '{{ phase }}' --yes
 
 # Audit a live cluster for bootstrap/takeover state without applying changes.
+[group('bootstrap-live')]
 bootstrap-live-audit context='default':
     ./hack/bootstrap/bootstrap.sh --kube-context '{{ context }}' --audit-only
 
 # Server-side dry-run the bootstrap flow against a live cluster.
+[group('bootstrap-live')]
 bootstrap-live-dry-run context='default':
     ./hack/bootstrap/bootstrap.sh --kube-context '{{ context }}' --from-phase bootstrap-crds --dry-run --yes
 
 # Server-side dry-run one bootstrap phase against a live cluster.
+[group('bootstrap-live')]
 bootstrap-live-phase phase context='default':
     ./hack/bootstrap/bootstrap.sh --kube-context '{{ context }}' --only-phase '{{ phase }}' --dry-run --yes
 
 # Render live k3s-ansible inventory and derived vars without changing nodes.
+[group('bootstrap-live')]
 bootstrap-live-ansible-plan:
     ./hack/bootstrap/ansible/render-inventory.sh --profile live --summary
 
 # Import the existing live K3s server token into 1Password.
+[group('bootstrap-live')]
 bootstrap-ansible-import-token:
     ./hack/bootstrap/ansible/import-token.sh
 
 # Run the live k3s-ansible convergence wrapper.
+[group('bootstrap-live')]
 bootstrap-live-ansible:
     ./hack/bootstrap/ansible/run.sh --profile live
 
 # Run the Kubernetes bootstrap phase against the live default context.
+[group('bootstrap-live')]
 bootstrap-live-kube context='default':
     ./hack/bootstrap/bootstrap.sh --kube-context '{{ context }}' --profile full --yes
 
 # Run live k3s-ansible convergence, then home-ops Kubernetes bootstrap.
+[group('bootstrap-live')]
 bootstrap-live-full:
     ./hack/bootstrap/ansible/run.sh --profile live --kube-bootstrap
 
 # Delete and recreate the configured three-node kind cluster.
+[group('bootstrap-kind')]
 kind-reset:
     kind delete cluster --name '{{ kind_cluster }}'
     kind create cluster --name '{{ kind_cluster }}' --config hack/bootstrap/kind-three-node.yaml
 
 # Delete the configured kind cluster.
+[group('bootstrap-kind')]
 kind-delete:
     kind delete cluster --name '{{ kind_cluster }}'
 
 # Create the configured Lima VMs for a foundation bootstrap test.
+[group('bootstrap-lima')]
 bootstrap-lima-create:
     ./hack/bootstrap/lima/create.sh
 
 # Create larger Lima VMs for the app bootstrap profile.
+[group('bootstrap-lima-apps')]
 bootstrap-lima-create-apps:
     {{ lima_app_env }} ./hack/bootstrap/lima/create.sh
 
 # Run k3s-ansible against the configured Lima VMs.
+[group('bootstrap-lima')]
 bootstrap-lima-ansible:
     ./hack/bootstrap/lima/run-ansible.sh
 
 # Run k3s-ansible against the larger Lima app-profile VM shape.
+[group('bootstrap-lima-apps')]
 bootstrap-lima-ansible-apps:
     {{ lima_app_env }} ./hack/bootstrap/lima/run-ansible.sh
 
 # Import/update the Lima K3s context in the local kubeconfig and keep its API tunnel running.
+[group('bootstrap-lima')]
 bootstrap-lima-kubecontext:
     ./hack/bootstrap/lima/kubecontext.sh
 
 # Run home-ops foundation bootstrap against the Lima K3s cluster.
+[group('bootstrap-lima')]
 bootstrap-lima-bootstrap:
     ./hack/bootstrap/lima/bootstrap-home-ops.sh
 
 # Run home-ops app bootstrap profile against the Lima K3s cluster.
+[group('bootstrap-lima-apps')]
 bootstrap-lima-bootstrap-apps:
     LIMA_BOOTSTRAP_PROFILE=lima-apps ./hack/bootstrap/lima/bootstrap-home-ops.sh
 
 # Run Lima app bootstrap with the seed Secret manifest provided on stdin.
+[group('bootstrap-lima-apps')]
 bootstrap-lima-bootstrap-apps-stdin:
     LIMA_BOOTSTRAP_PROFILE=lima-apps ./hack/bootstrap/lima/bootstrap-home-ops.sh --seed-secret-stdin
 
 # Run Lima foundation bootstrap with the seed Secret manifest provided on stdin.
+[group('bootstrap-lima')]
 bootstrap-lima-bootstrap-stdin:
     ./hack/bootstrap/lima/bootstrap-home-ops.sh --seed-secret-stdin
 
 # Validate Cilium BGP APIs and backup-safety invariants in the Lima cluster.
+[group('bootstrap-lima')]
 bootstrap-lima-validate:
     ./hack/bootstrap/lima/validate.sh
 
 # Validate app-profile safety invariants in the Lima cluster.
+[group('bootstrap-lima-apps')]
 bootstrap-lima-validate-apps:
     LIMA_VALIDATE_PROFILE=lima-apps ./hack/bootstrap/lima/validate.sh
 
 # Delete the configured Lima VMs.
+[group('bootstrap-lima')]
 bootstrap-lima-delete:
     ./hack/bootstrap/lima/delete.sh
 
 # Recreate Lima VMs, run k3s-ansible, bootstrap home-ops, and validate foundation state.
+[group('bootstrap-lima')]
 bootstrap-lima-fresh: bootstrap-lima-delete bootstrap-lima-create bootstrap-lima-ansible bootstrap-lima-bootstrap bootstrap-lima-validate
 
 # Recreate larger Lima VMs, run k3s-ansible, bootstrap app profile, and validate app safety.
+[group('bootstrap-lima-apps')]
 bootstrap-lima-fresh-apps:
     {{ lima_app_env }} ./hack/bootstrap/lima/delete.sh
     {{ lima_app_env }} ./hack/bootstrap/lima/create.sh
@@ -208,10 +246,12 @@ bootstrap-lima-fresh-apps:
     LIMA_VALIDATE_PROFILE=lima-apps ./hack/bootstrap/lima/validate.sh
 
 # Audit the current kube context for bootstrap/takeover state.
+[group('bootstrap')]
 bootstrap-audit:
     ./hack/bootstrap/bootstrap.sh --audit-only
 
 # Run shellcheck and offline bootstrap parsing/rendering tests.
+[group('bootstrap')]
 bootstrap-test:
     shellcheck hack/bootstrap/bootstrap.sh hack/bootstrap/lib/*.sh hack/bootstrap/phases/*.sh hack/bootstrap/tests/*.sh hack/bootstrap/lima/*.sh hack/bootstrap/ansible/*.sh
     hack/bootstrap/tests/offline-parse.sh


### PR DESCRIPTION
## Summary
- add just recipe groups for core, apps, bootstrap, kind, live, Lima foundation, and Lima app-profile commands
- make the default just listing use source order so the grouped list is stable and easier to scan

## Validation
- just
- just --groups --unsorted
- just --fmt --check
- just --dry-run check
- just --dry-run bootstrap-test
- pre-commit run --files justfile