### PR TITLE
fix: disable kube-proxy after cilium bootstrap

### DIFF
--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -192,6 +192,15 @@ network settings. Keep that checkout close to upstream and let this wrapper
 render the homelab-specific K3s, Cilium, BGP, kube-vip, API endpoint, and
 control-plane taint values.
 
+Initial K3s server args intentionally leave kube-proxy enabled so the
+`k3s-ansible` bootstrap can complete before Cilium owns Service routing. After
+`site.yml` installs and waits for Cilium, the wrapper runs a home-ops
+post-Cilium playbook. When the derived Cilium config has
+`kube_proxy_replacement: true`, that playbook writes
+`/etc/rancher/k3s/config.yaml.d/90-home-ops-kube-proxy.yaml` with
+`disable-kube-proxy: true`, then restarts K3s servers one at a time and waits
+for each node plus Cilium to become ready.
+
 The live K3s token is stored at `op://Kubernetes/k3s-bootstrap/k3s_token`.
 Normal runs load it from 1Password. If a fresh cluster has no remote token and
 the 1Password item is missing, the wrapper generates and stores a token. If an

--- a/hack/bootstrap/ansible/lib.sh
+++ b/hack/bootstrap/ansible/lib.sh
@@ -501,3 +501,11 @@ ansible_run_site() {
     ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i "$inventory_file" site.yml
   )
 }
+
+ansible_disable_kube_proxy_after_cilium() {
+  local inventory_file="$1"
+  ansible_log "converging post-Cilium K3s kube-proxy state"
+  ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
+    -i "$inventory_file" \
+    "${ANSIBLE_BOOTSTRAP_DIR}/playbooks/disable-kube-proxy.yml"
+}

--- a/hack/bootstrap/ansible/playbooks/disable-kube-proxy.yml
+++ b/hack/bootstrap/ansible/playbooks/disable-kube-proxy.yml
@@ -1,0 +1,83 @@
+---
+- name: Disable K3s kube-proxy after Cilium takeover
+  hosts: master
+  become: true
+  gather_facts: true
+  serial: 1
+  vars:
+    kube_proxy_config_dir: /etc/rancher/k3s/config.yaml.d
+    kube_proxy_config_file: "{{ kube_proxy_config_dir }}/90-home-ops-kube-proxy.yaml"
+    kube_proxy_config_content: |
+      disable-kube-proxy: true
+    bootstrap_first_master: "{{ groups[group_name_master | default('master')][0] }}"
+    bootstrap_node_name: "{{ ansible_facts.hostname | default(inventory_hostname) }}"
+
+  pre_tasks:
+    - name: Skip when Cilium kube-proxy replacement is disabled
+      ansible.builtin.meta: end_play
+      when: not (kube_proxy_replacement | default(false) | bool)
+
+    - name: Wait for Cilium DaemonSet before disabling K3s kube-proxy
+      ansible.builtin.command: >-
+        {{ k3s_kubectl_binary | default('k3s kubectl') }}
+        -n kube-system rollout status daemonset/cilium --timeout=5m
+      delegate_to: "{{ bootstrap_first_master }}"
+      run_once: true
+      changed_when: false
+
+    - name: Wait for Cilium operator before disabling K3s kube-proxy
+      ansible.builtin.command: >-
+        {{ k3s_kubectl_binary | default('k3s kubectl') }}
+        -n kube-system rollout status deployment/cilium-operator --timeout=5m
+      delegate_to: "{{ bootstrap_first_master }}"
+      run_once: true
+      changed_when: false
+
+  tasks:
+    - name: Create K3s config drop-in directory
+      ansible.builtin.file:
+        path: "{{ kube_proxy_config_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Write K3s kube-proxy disable drop-in
+      ansible.builtin.copy:
+        dest: "{{ kube_proxy_config_file }}"
+        content: "{{ kube_proxy_config_content }}"
+        owner: root
+        group: root
+        mode: "0644"
+      register: kube_proxy_config
+
+    - name: Restart K3s server to apply kube-proxy disable drop-in
+      ansible.builtin.systemd:
+        name: k3s
+        daemon_reload: true
+        state: restarted
+      when: kube_proxy_config.changed
+
+    - name: Wait for local K3s API port after restart
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: 6443
+        delay: 3
+        timeout: 180
+      when: kube_proxy_config.changed
+
+    - name: Wait for restarted server node to be Ready
+      ansible.builtin.command: >-
+        {{ k3s_kubectl_binary | default('k3s kubectl') }}
+        wait node/{{ bootstrap_node_name }} --for=condition=Ready --timeout=5m
+      delegate_to: "{{ bootstrap_first_master }}"
+      changed_when: false
+      when: kube_proxy_config.changed
+
+    - name: Wait for Cilium DaemonSet after server restart
+      ansible.builtin.command: >-
+        {{ k3s_kubectl_binary | default('k3s kubectl') }}
+        -n kube-system rollout status daemonset/cilium --timeout=5m
+      delegate_to: "{{ bootstrap_first_master }}"
+      changed_when: false
+      when: kube_proxy_config.changed

--- a/hack/bootstrap/ansible/run.sh
+++ b/hack/bootstrap/ansible/run.sh
@@ -136,6 +136,7 @@ ansible_install_collections
 
 if ! ansible_bool "$skip_site"; then
   ansible_run_site "$inventory_file"
+  ansible_disable_kube_proxy_after_cilium "$inventory_file"
 fi
 
 if ! ansible_bool "$skip_import"; then

--- a/hack/bootstrap/tests/offline-ansible.sh
+++ b/hack/bootstrap/tests/offline-ansible.sh
@@ -47,10 +47,19 @@ test "$(yq -r '.ansible_user' "$vars")" = "ethan"
 test "$(yq -r '.ansible_ssh_private_key_file' "$vars")" = "$expected_key"
 test "$(yq -r '.k3s_version' "$vars")" = "v1.35.4+k3s1"
 test "$(yq -r '.cilium_tag' "$vars")" = "$cilium_tag"
+test "$(yq -r '.kube_proxy_replacement' "$vars")" = "true"
 test "$(yq -r '.apiserver_endpoint' "$vars")" = "192.168.99.77"
 test "$(yq -r '.k3s_token' "$vars")" = "{{ lookup('ansible.builtin.env', 'K3S_TOKEN') }}"
 if grep -q 'sample-token' "$vars"; then
   echo "generated vars contain sample token" >&2
+  exit 1
+fi
+if yq -r '.extra_server_args' "$vars" | grep -q -- '--disable-kube-proxy'; then
+  echo "initial server args disable kube-proxy before Cilium is ready" >&2
+  exit 1
+fi
+if ! grep -q 'ansible_disable_kube_proxy_after_cilium' "${ROOT}/hack/bootstrap/ansible/run.sh"; then
+  echo "run.sh does not call the post-Cilium kube-proxy convergence playbook" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- add a home-ops post-Cilium Ansible playbook that writes a K3s config drop-in for disable-kube-proxy
- run that playbook after k3s-ansible site.yml, so initial bootstrap keeps kube-proxy until Cilium is ready
- restart K3s servers serially and wait for node/Cilium readiness when the drop-in changes
- document the ordering and add offline bootstrap assertions

## Validation
- just bootstrap-test
- pre-commit run --files hack/bootstrap/ansible/playbooks/disable-kube-proxy.yml hack/bootstrap/ansible/lib.sh hack/bootstrap/ansible/run.sh hack/bootstrap/tests/offline-ansible.sh hack/bootstrap/README.md
- just bootstrap-live-ansible-plan
- ansible-playbook --syntax-check -i hack/bootstrap/.out/ansible-live/inventory/live/hosts.yml hack/bootstrap/ansible/playbooks/disable-kube-proxy.yml
- just bootstrap-lima-fresh / resume: k3s-ansible completed, Cilium became ready, post-Cilium kube-proxy playbook wrote the drop-in, restarted K3s, passed node/Cilium readiness, and foundation bootstrap completed after seed-secret was supplied via stdin