### PR TITLE
fix: refine Longhorn node maintenance flow

### DIFF
--- a/docs/just-bootstrap.md
+++ b/docs/just-bootstrap.md
@@ -347,6 +347,7 @@ into explicit operator steps:
 ```sh
 just node-live-status k3s-worker-0
 just node-live-drain k3s-worker-0
+just node-live-longhorn-evict k3s-worker-0
 just node-live-delete k3s-worker-0
 just node-live-refresh-ssh-host-key k3s-worker-0
 just node-live-join k3s-worker-0
@@ -358,6 +359,7 @@ The Lima equivalents use the `node-lima-*` group:
 ```sh
 just node-lima-status home-ops-k3s-test-agent-1
 just node-lima-drain home-ops-k3s-test-agent-1
+just node-lima-longhorn-evict home-ops-k3s-test-agent-1
 just node-lima-delete home-ops-k3s-test-agent-1
 just node-lima-refresh-ssh-host-key home-ops-k3s-test-agent-1
 just node-lima-join home-ops-k3s-test-agent-1
@@ -367,27 +369,26 @@ just node-lima-uncordon home-ops-k3s-test-agent-1
 Mutating commands support worker nodes only. Control-plane lifecycle remains
 blocked until the embedded-etcd member removal and rejoin procedure is proven.
 
+For normal node maintenance or reboots, run drain and then uncordon. Drain only
+requires ordinary workloads to move and Longhorn volumes to detach from the
+target node. It does not require every Longhorn volume to stay healthy, because
+three-replica volumes on exactly three storage nodes will be temporarily
+degraded while one node is drained.
+
 The delete step is deliberately conservative. It stops and disables `k3s-node`
 through Ansible before deleting the Kubernetes `Node` and the K3s node-password
-Secret, so the old node cannot immediately re-register. When Longhorn is
-installed, delete also requires Longhorn scheduling to be disabled for the
-target node and all target-node replicas/attached volumes to be gone. Evacuate
-Longhorn replicas first, then rerun delete. Disabling scheduling can be done in
-the Longhorn UI or with:
-
-```sh
-kubectl -n longhorn-system patch nodes.longhorn.io/k3s-worker-0 --type=merge -p '{"spec":{"allowScheduling":false}}'
-```
-
-After the rebuilt worker has joined, re-enable Longhorn scheduling before
-running uncordon.
+Secret, so the old node cannot immediately re-register. For node replacement,
+run `node-*-longhorn-evict` after drain and before delete. The eviction helper
+disables Longhorn scheduling for the target, requests replica eviction, and
+fails before mutating anything if the remaining eligible storage nodes cannot
+hold the maximum configured replica count.
 
 Join uses the generated home-ops Ansible worker playbook and starts the agent
 with `node.home-ops.sh/joining=true:NoSchedule`. After the node object appears,
 the helper cordons it while Cilium settles. The uncordon helper removes the
 taint from the rendered agent service, restarts the agent if needed, removes
-the live taint, waits for Cilium and Longhorn safety checks, and only then
-uncordons the node.
+the live taint, waits for Cilium, verifies Longhorn is ready to schedule on the
+node, uncordons, and then verifies Longhorn marks the node schedulable.
 
 Review the active context:
 

--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -263,12 +263,13 @@ endpoint before making changes.
 ## Node Lifecycle
 
 `hack/bootstrap/nodes/` contains existing-cluster node lifecycle helpers. The
-worker path is split into explicit status, drain, delete, join, and uncordon
-steps:
+worker path is split into explicit status, drain, optional Longhorn eviction,
+delete, join, and uncordon steps:
 
 ```sh
 just node-live-status k3s-worker-0
 just node-live-drain k3s-worker-0
+just node-live-longhorn-evict k3s-worker-0
 just node-live-delete k3s-worker-0
 just node-live-refresh-ssh-host-key k3s-worker-0
 just node-live-join k3s-worker-0
@@ -280,12 +281,20 @@ Control-plane lifecycle is intentionally refused until the embedded-etcd member
 procedure is proven. Worker delete stops and disables `k3s-node` before deleting
 the Kubernetes Node and node-password Secret. If Longhorn is installed, delete
 also requires Longhorn scheduling to be disabled for the target node and all
-target-node replicas/attached volumes to be gone.
+target-node replicas and attached volumes to be gone.
+
+For normal maintenance or reboot work, use `drain` and `uncordon` only. The
+drain helper allows the expected temporary Longhorn degraded state after
+workloads leave the node, which matters when three-replica volumes are spread
+across exactly three storage nodes. The `longhorn-evict` helper is only for
+node replacement; it fails before mutating Longhorn if the remaining storage
+nodes cannot hold the maximum configured replica count.
 
 Worker join starts the agent with
 `node.home-ops.sh/joining=true:NoSchedule`, then cordons the node. The uncordon
 helper removes that taint from the rendered agent service and live Node, waits
-for Cilium and Longhorn checks, and uncordons last.
+for Cilium, verifies Longhorn is ready to schedule on the node, uncordons, and
+then verifies Longhorn marks the node schedulable.
 
 If more than one 1Password account is configured and the default account is
 wrong, pin the account explicitly:

--- a/hack/bootstrap/nodes/lib.sh
+++ b/hack/bootstrap/nodes/lib.sh
@@ -586,9 +586,13 @@ node_longhorn_node_report() {
 
   # shellcheck disable=SC2016
   "$NODE_JQ_BIN" -r '
+    def allow_scheduling:
+      if ((.spec // {}) | has("allowScheduling")) then .spec.allowScheduling else true end;
+    def eviction_requested:
+      if ((.spec // {}) | has("evictionRequested")) then .spec.evictionRequested else false end;
     def condition_status($type):
       ([.status.conditions[]? | select(.type == $type) | .status] | first) // "unknown";
-    "allowScheduling=\((.spec.allowScheduling // true) | tostring) ready=\(condition_status("Ready")) schedulable=\(condition_status("Schedulable"))"
+    "allowScheduling=\(allow_scheduling | tostring) evictionRequested=\(eviction_requested | tostring) ready=\(condition_status("Ready")) schedulable=\(condition_status("Schedulable"))"
   ' <<<"$longhorn_node_json"
 }
 
@@ -776,6 +780,52 @@ node_longhorn_replicas_on_node() {
   ' <<<"$replicas_json"
 }
 
+node_longhorn_max_replica_count() {
+  local context="$1"
+  local volumes_json
+
+  volumes_json="$(node_get_json "$context" -n longhorn-system volumes.longhorn.io 2>/dev/null || true)"
+  [[ -n "$volumes_json" ]] || {
+    printf 'Longhorn volumes not readable\n'
+    return 0
+  }
+
+  "$NODE_JQ_BIN" -r '
+    [
+      .items[]
+      | (.spec.numberOfReplicas // 0)
+      | tonumber
+    ] | max // 0
+  ' <<<"$volumes_json"
+}
+
+node_longhorn_eligible_storage_node_count_excluding() {
+  local context="$1"
+  local node="$2"
+  local nodes_json
+
+  nodes_json="$(node_get_json "$context" -n longhorn-system nodes.longhorn.io 2>/dev/null || true)"
+  [[ -n "$nodes_json" ]] || {
+    printf 'Longhorn nodes not readable\n'
+    return 0
+  }
+
+  # shellcheck disable=SC2016
+  "$NODE_JQ_BIN" -r --arg node "$node" '
+    def allow_scheduling:
+      if ((.spec // {}) | has("allowScheduling")) then .spec.allowScheduling else true end;
+    def condition_status($type):
+      ([.status.conditions[]? | select(.type == $type) | .status] | first) // "unknown";
+    [
+      .items[]
+      | select(.metadata.name != $node)
+      | select(allow_scheduling == true)
+      | select(condition_status("Ready") == "True")
+      | select(condition_status("Schedulable") == "True")
+    ] | length
+  ' <<<"$nodes_json"
+}
+
 node_longhorn_scheduling_problem() {
   local context="$1"
   local node="$2"
@@ -788,7 +838,9 @@ node_longhorn_scheduling_problem() {
   }
 
   "$NODE_JQ_BIN" -r '
-    select((.spec.allowScheduling // true) != false)
+    def allow_scheduling:
+      if ((.spec // {}) | has("allowScheduling")) then .spec.allowScheduling else true end;
+    select(allow_scheduling != false)
     | "Longhorn scheduling is still enabled"
   ' <<<"$longhorn_node_json"
 }
@@ -815,6 +867,33 @@ node_longhorn_managers_report() {
         }
       | "\($kind)/\(.name) state=\(.state)"
     ] | if length == 0 then "no \($kind) resources on node" else .[] end
+  ' <<<"$json"
+}
+
+node_longhorn_managers_on_node() {
+  local context="$1"
+  local node="$2"
+  local kind="$3"
+  local resource="$4"
+  local json
+
+  json="$(node_get_json "$context" -n longhorn-system "$resource" 2>/dev/null || true)"
+  [[ -n "$json" ]] || {
+    printf '%s not readable\n' "$kind"
+    return 0
+  }
+
+  # shellcheck disable=SC2016
+  "$NODE_JQ_BIN" -r --arg node "$node" --arg kind "$kind" '
+    [
+      .items[]
+      | select((.spec.nodeID // .status.ownerID // .status.currentNodeID // "") == $node)
+      | {
+          name: .metadata.name,
+          state: (.status.currentState // .status.state // "unknown")
+        }
+      | "\($kind)/\(.name) state=\(.state)"
+    ] | .[]
   ' <<<"$json"
 }
 
@@ -872,6 +951,28 @@ node_assert_longhorn_safe() {
   fi
 }
 
+node_assert_longhorn_maintenance_safe() {
+  local context="$1"
+  local node="$2"
+  local problems state
+
+  state="$(node_assert_longhorn_discovery "$context")"
+  if [[ "$state" == absent ]]; then
+    return
+  fi
+
+  problems="$(
+    {
+      node_longhorn_attached_volumes_on_node "$context" "$node"
+    } | sed '/^$/d'
+  )"
+
+  if [[ -n "$problems" ]]; then
+    printf '%s\n' "$problems" >&2
+    node_die "Longhorn volumes are still attached to ${node}; wait for workloads to move before maintenance"
+  fi
+}
+
 node_assert_longhorn_empty_for_delete() {
   local context="$1"
   local node="$2"
@@ -892,8 +993,86 @@ node_assert_longhorn_empty_for_delete() {
 
   if [[ -n "$problems" ]]; then
     printf '%s\n' "$problems" >&2
-    node_die "Longhorn still has target-node state; disable scheduling and evict replicas before deleting ${node}"
+    node_die "Longhorn still has target-node state; run the explicit Longhorn eviction helper before deleting ${node}"
   fi
+}
+
+node_assert_longhorn_eviction_feasible() {
+  local context="$1"
+  local node="$2"
+  local state max_replicas eligible_nodes problems
+
+  state="$(node_assert_longhorn_discovery "$context")"
+  [[ "$state" == installed ]] || node_die "Longhorn is not installed in ${context}"
+
+  max_replicas="$(node_longhorn_max_replica_count "$context")"
+  [[ "$max_replicas" =~ ^[0-9]+$ ]] || node_die "$max_replicas"
+  eligible_nodes="$(node_longhorn_eligible_storage_node_count_excluding "$context" "$node")"
+  [[ "$eligible_nodes" =~ ^[0-9]+$ ]] || node_die "$eligible_nodes"
+
+  problems="$(
+    {
+      if ((max_replicas > eligible_nodes)); then
+        printf 'Longhorn eviction is not feasible: max volume replicas=%s, eligible storage nodes after removing target=%s\n' \
+          "$max_replicas" "$eligible_nodes"
+        printf 'Add another storage node or temporarily lower replica counts before replacing %s; use drain/uncordon for reboot maintenance.\n' \
+          "$node"
+      fi
+      node_longhorn_attached_volumes_on_node "$context" "$node"
+    } | sed '/^$/d'
+  )"
+
+  if [[ -n "$problems" ]]; then
+    printf '%s\n' "$problems" >&2
+    node_die "Longhorn cannot safely evict ${node}"
+  fi
+}
+
+node_request_longhorn_eviction() {
+  local context="$1"
+  local node="$2"
+
+  node_kubectl "$context" -n longhorn-system patch "nodes.longhorn.io/${node}" \
+    --type=merge \
+    -p '{"spec":{"allowScheduling":false,"evictionRequested":true}}'
+}
+
+node_restore_longhorn_scheduling() {
+  local context="$1"
+  local node="$2"
+  local state
+
+  state="$(node_assert_longhorn_discovery "$context")"
+  if [[ "$state" == absent ]]; then
+    return
+  fi
+
+  node_wait_for_longhorn_node_resource "$context" "$node"
+  node_kubectl "$context" -n longhorn-system patch "nodes.longhorn.io/${node}" \
+    --type=merge \
+    -p '{"spec":{"allowScheduling":true,"evictionRequested":false}}'
+}
+
+node_wait_for_longhorn_node_resource() {
+  local context="$1"
+  local node="$2"
+  local timeout="${3:-300}"
+  local deadline=$((SECONDS + timeout))
+  local state longhorn_node_json
+
+  state="$(node_assert_longhorn_discovery "$context")"
+  if [[ "$state" == absent ]]; then
+    return
+  fi
+
+  while true; do
+    longhorn_node_json="$(node_get_json "$context" -n longhorn-system "nodes.longhorn.io/${node}" 2>/dev/null || true)"
+    if [[ -n "$longhorn_node_json" ]]; then
+      return 0
+    fi
+    ((SECONDS < deadline)) || node_die "timed out waiting for Longhorn node resource: ${node}"
+    sleep 5
+  done
 }
 
 node_longhorn_uncordon_problems() {
@@ -909,11 +1088,18 @@ node_longhorn_uncordon_problems() {
 
   # shellcheck disable=SC2016
   "$NODE_JQ_BIN" -r '
+    def allow_scheduling:
+      if ((.spec // {}) | has("allowScheduling")) then .spec.allowScheduling else true end;
+    def eviction_requested:
+      if ((.spec // {}) | has("evictionRequested")) then .spec.evictionRequested else false end;
     def condition_status($type):
       ([.status.conditions[]? | select(.type == $type) | .status] | first) // "unknown";
     [
-      if ((.spec.allowScheduling // true) != true) then
+      if allow_scheduling != true then
         "Longhorn scheduling is not enabled"
+      else empty end,
+      if eviction_requested != false then
+        "Longhorn eviction is still requested"
       else empty end,
       if condition_status("Ready") != "True" then
         "Longhorn node Ready condition is \(condition_status("Ready"))"
@@ -923,6 +1109,56 @@ node_longhorn_uncordon_problems() {
       else empty end
     ] | .[]
   ' <<<"$longhorn_node_json"
+}
+
+node_longhorn_ready_for_kubernetes_uncordon_problems() {
+  local context="$1"
+  local node="$2"
+  local longhorn_node_json
+
+  longhorn_node_json="$(node_get_json "$context" -n longhorn-system "nodes.longhorn.io/${node}" 2>/dev/null || true)"
+  [[ -n "$longhorn_node_json" ]] || {
+    printf 'Longhorn node resource not readable: %s\n' "$node"
+    return 0
+  }
+
+  # shellcheck disable=SC2016
+  "$NODE_JQ_BIN" -r '
+    def allow_scheduling:
+      if ((.spec // {}) | has("allowScheduling")) then .spec.allowScheduling else true end;
+    def eviction_requested:
+      if ((.spec // {}) | has("evictionRequested")) then .spec.evictionRequested else false end;
+    def condition_status($type):
+      ([.status.conditions[]? | select(.type == $type) | .status] | first) // "unknown";
+    [
+      if allow_scheduling != true then
+        "Longhorn scheduling is not enabled"
+      else empty end,
+      if eviction_requested != false then
+        "Longhorn eviction is still requested"
+      else empty end,
+      if condition_status("Ready") != "True" then
+        "Longhorn node Ready condition is \(condition_status("Ready"))"
+      else empty end
+    ] | .[]
+  ' <<<"$longhorn_node_json"
+}
+
+node_assert_longhorn_ready_for_kubernetes_uncordon() {
+  local context="$1"
+  local node="$2"
+  local problems state
+
+  state="$(node_assert_longhorn_discovery "$context")"
+  if [[ "$state" == absent ]]; then
+    return
+  fi
+
+  problems="$(node_longhorn_ready_for_kubernetes_uncordon_problems "$context" "$node")"
+  if [[ -n "$problems" ]]; then
+    printf '%s\n' "$problems" >&2
+    node_die "Longhorn node is not ready for Kubernetes uncordon: ${node}"
+  fi
 }
 
 node_assert_longhorn_ready_for_uncordon() {
@@ -1068,6 +1304,51 @@ node_wait_for_longhorn_safe() {
       return 0
     fi
     ((SECONDS < deadline)) || node_assert_longhorn_safe "$context" "$node"
+    sleep 5
+  done
+}
+
+node_wait_for_longhorn_maintenance_safe() {
+  local context="$1"
+  local node="$2"
+  local timeout="${3:-300}"
+  local deadline=$((SECONDS + timeout))
+
+  while true; do
+    if (node_assert_longhorn_maintenance_safe "$context" "$node") >/dev/null 2>&1; then
+      return 0
+    fi
+    ((SECONDS < deadline)) || node_assert_longhorn_maintenance_safe "$context" "$node"
+    sleep 5
+  done
+}
+
+node_wait_for_longhorn_empty_for_delete() {
+  local context="$1"
+  local node="$2"
+  local timeout="${3:-1800}"
+  local deadline=$((SECONDS + timeout))
+
+  while true; do
+    if (node_assert_longhorn_empty_for_delete "$context" "$node") >/dev/null 2>&1; then
+      return 0
+    fi
+    ((SECONDS < deadline)) || node_assert_longhorn_empty_for_delete "$context" "$node"
+    sleep 10
+  done
+}
+
+node_wait_for_longhorn_ready_for_kubernetes_uncordon() {
+  local context="$1"
+  local node="$2"
+  local timeout="${3:-300}"
+  local deadline=$((SECONDS + timeout))
+
+  while true; do
+    if (node_assert_longhorn_ready_for_kubernetes_uncordon "$context" "$node") >/dev/null 2>&1; then
+      return 0
+    fi
+    ((SECONDS < deadline)) || node_assert_longhorn_ready_for_kubernetes_uncordon "$context" "$node"
     sleep 5
   done
 }

--- a/hack/bootstrap/nodes/longhorn-evict.sh
+++ b/hack/bootstrap/nodes/longhorn-evict.sh
@@ -6,7 +6,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {
   cat <<'EOF'
-Usage: hack/bootstrap/nodes/drain.sh [options] NODE
+Usage: hack/bootstrap/nodes/longhorn-evict.sh [options] NODE
 
 Options:
   --profile NAME   Node lifecycle profile: live or lima. Defaults to live.
@@ -67,19 +67,12 @@ node_assert_api_reachable "$context"
 node_json="$(node_node_json_if_present "$context" "$kubernetes_node_name")"
 [[ -n "$node_json" ]] || node_die "Kubernetes node is absent: ${kubernetes_node_name}"
 node_assert_kubernetes_worker "$node_json" "$kubernetes_node_name"
-
-node_confirm "$yes" "drain ${kubernetes_node_name} from ${context}"
-node_log "draining ${kubernetes_node_name}"
-node_kubectl "$context" drain "$kubernetes_node_name" \
-  --ignore-daemonsets \
-  --delete-emptydir-data \
-  --grace-period=120 \
-  --timeout=15m
-
-node_json="$(node_node_json_if_present "$context" "$kubernetes_node_name")"
-[[ -n "$node_json" ]] || node_die "Kubernetes node disappeared during drain: ${kubernetes_node_name}"
-node_assert_kubernetes_worker "$node_json" "$kubernetes_node_name"
 node_assert_cordoned "$node_json" "$kubernetes_node_name"
 node_assert_no_ordinary_pods "$context" "$kubernetes_node_name"
-node_wait_for_longhorn_maintenance_safe "$context" "$kubernetes_node_name"
-node_log "drain complete: ${kubernetes_node_name}"
+node_assert_longhorn_eviction_feasible "$context" "$kubernetes_node_name"
+
+node_confirm "$yes" "evict Longhorn replicas from ${kubernetes_node_name} in ${context}"
+node_log "requesting Longhorn replica eviction from ${kubernetes_node_name}"
+node_request_longhorn_eviction "$context" "$kubernetes_node_name"
+node_wait_for_longhorn_empty_for_delete "$context" "$kubernetes_node_name"
+node_log "Longhorn eviction complete: ${kubernetes_node_name}"

--- a/hack/bootstrap/nodes/uncordon.sh
+++ b/hack/bootstrap/nodes/uncordon.sh
@@ -99,8 +99,9 @@ fi
 
 node_wait_for_ready "$context" "$kubernetes_node_name"
 node_wait_for_cilium_ready "$context" "$kubernetes_node_name"
-node_wait_for_longhorn_safe "$context" "$kubernetes_node_name"
-node_wait_for_longhorn_ready_for_uncordon "$context" "$kubernetes_node_name"
+node_log "restoring Longhorn scheduling for ${kubernetes_node_name} if Longhorn is installed"
+node_restore_longhorn_scheduling "$context" "$kubernetes_node_name"
+node_wait_for_longhorn_ready_for_kubernetes_uncordon "$context" "$kubernetes_node_name"
 
 node_json="$(node_node_json_if_present "$context" "$kubernetes_node_name")"
 [[ -n "$node_json" ]] || node_die "Kubernetes node disappeared before uncordon: ${kubernetes_node_name}"
@@ -110,4 +111,5 @@ node_assert_no_joining_taint "$node_json" "$kubernetes_node_name"
 
 node_log "uncordoning ${kubernetes_node_name}"
 node_kubectl "$context" uncordon "$kubernetes_node_name"
+node_wait_for_longhorn_ready_for_uncordon "$context" "$kubernetes_node_name"
 node_log "uncordon complete: ${kubernetes_node_name}"

--- a/hack/bootstrap/tests/offline-nodes.sh
+++ b/hack/bootstrap/tests/offline-nodes.sh
@@ -222,8 +222,106 @@ grep -q 'installed: false' <<<"$status_output"
 
 "${ROOT}/hack/bootstrap/nodes/drain.sh" --help >/dev/null
 "${ROOT}/hack/bootstrap/nodes/delete.sh" --help >/dev/null
+"${ROOT}/hack/bootstrap/nodes/longhorn-evict.sh" --help >/dev/null
 "${ROOT}/hack/bootstrap/nodes/join.sh" --help >/dev/null
 "${ROOT}/hack/bootstrap/nodes/uncordon.sh" --help >/dev/null
 "${ROOT}/hack/bootstrap/nodes/refresh-ssh-host-key.sh" --help >/dev/null
+
+fake_longhorn_kubectl="${tmp}/kubectl-longhorn"
+cat > "$fake_longhorn_kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--context" ]]; then
+  shift 2
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "crd" && "${3:-}" == "volumes.longhorn.io" ]]; then
+  printf '{"metadata":{"name":"volumes.longhorn.io"}}\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "-n" && "${3:-}" == "longhorn-system" && "${4:-}" == "volumes.longhorn.io" ]]; then
+  cat <<'JSON'
+{
+  "items": [
+    {"metadata": {"name": "vol-a"}, "spec": {"numberOfReplicas": 3}, "status": {"state": "detached", "robustness": "healthy", "currentNodeID": ""}}
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "-n" && "${3:-}" == "longhorn-system" && "${4:-}" == "nodes.longhorn.io/k3s-worker-0" ]]; then
+  cat <<'JSON'
+{
+  "metadata": {"name": "k3s-worker-0"},
+  "spec": {"allowScheduling": false, "evictionRequested": true},
+  "status": {"conditions": [{"type": "Ready", "status": "True"}, {"type": "Schedulable", "status": "False"}]}
+}
+JSON
+  exit 0
+fi
+
+if [[ "${1:-}" == "-n" && "${2:-}" == "longhorn-system" && "${3:-}" == "patch" && "${4:-}" == "nodes.longhorn.io/k3s-worker-0" ]]; then
+  printf 'node.longhorn.io/k3s-worker-0 patched\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "-n" && "${3:-}" == "longhorn-system" && "${4:-}" == "nodes.longhorn.io" ]]; then
+  cat <<'JSON'
+{
+  "items": [
+    {
+      "metadata": {"name": "k3s-worker-0"},
+      "spec": {"allowScheduling": true},
+      "status": {"conditions": [{"type": "Ready", "status": "True"}, {"type": "Schedulable", "status": "True"}]}
+    },
+    {
+      "metadata": {"name": "k3s-worker-1"},
+      "spec": {"allowScheduling": true},
+      "status": {"conditions": [{"type": "Ready", "status": "True"}, {"type": "Schedulable", "status": "True"}]}
+    },
+    {
+      "metadata": {"name": "k3s-worker-2"},
+      "spec": {"allowScheduling": true},
+      "status": {"conditions": [{"type": "Ready", "status": "True"}, {"type": "Schedulable", "status": "True"}]}
+    }
+  ]
+}
+JSON
+  exit 0
+fi
+
+printf 'unexpected fake Longhorn kubectl args: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$fake_longhorn_kubectl"
+
+if NODE_KUBECTL_BIN="$fake_longhorn_kubectl" \
+  bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_assert_longhorn_eviction_feasible test k3s-worker-0" \
+  2>"${tmp}/longhorn-evict.err"; then
+  echo "expected Longhorn eviction feasibility to fail for 3 replicas on 2 remaining nodes" >&2
+  exit 1
+fi
+grep -q 'max volume replicas=3, eligible storage nodes after removing target=2' "${tmp}/longhorn-evict.err"
+
+longhorn_node_report="$(
+  NODE_KUBECTL_BIN="$fake_longhorn_kubectl" \
+    bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_longhorn_node_report test k3s-worker-0"
+)"
+grep -q 'allowScheduling=false evictionRequested=true' <<<"$longhorn_node_report"
+
+longhorn_scheduling_problem="$(
+  NODE_KUBECTL_BIN="$fake_longhorn_kubectl" \
+    bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_longhorn_scheduling_problem test k3s-worker-0"
+)"
+test -z "$longhorn_scheduling_problem"
+
+restore_scheduling_output="$(
+  NODE_KUBECTL_BIN="$fake_longhorn_kubectl" \
+    bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_restore_longhorn_scheduling test k3s-worker-0"
+)"
+grep -q 'node.longhorn.io/k3s-worker-0 patched' <<<"$restore_scheduling_output"
 
 echo "offline node lifecycle test passed"

--- a/justfile
+++ b/justfile
@@ -187,6 +187,11 @@ node-live-drain node:
 node-live-delete node:
     ./hack/bootstrap/nodes/delete.sh --profile live --context default '{{ node }}'
 
+# Evict Longhorn replicas from a drained live worker before replacement.
+[group('node-live')]
+node-live-longhorn-evict node:
+    ./hack/bootstrap/nodes/longhorn-evict.sh --profile live --context default '{{ node }}'
+
 # Refresh a rebuilt live worker's SSH host key in known_hosts.
 [group('node-live')]
 node-live-refresh-ssh-host-key node:
@@ -197,7 +202,7 @@ node-live-refresh-ssh-host-key node:
 node-live-join node:
     ./hack/bootstrap/nodes/join.sh --profile live --context default '{{ node }}'
 
-# Remove the temporary live worker taint, validate system health, and uncordon.
+# Remove the temporary live worker taint and restore scheduling.
 [group('node-live')]
 node-live-uncordon node:
     ./hack/bootstrap/nodes/uncordon.sh --profile live --context default '{{ node }}'
@@ -292,6 +297,11 @@ node-lima-drain node:
 node-lima-delete node:
     ./hack/bootstrap/nodes/delete.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
 
+# Evict Longhorn replicas from a drained Lima worker before replacement.
+[group('node-lima')]
+node-lima-longhorn-evict node:
+    ./hack/bootstrap/nodes/longhorn-evict.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
+
 # Refresh a rebuilt Lima worker's SSH host key in known_hosts.
 [group('node-lima')]
 node-lima-refresh-ssh-host-key node:
@@ -302,7 +312,7 @@ node-lima-refresh-ssh-host-key node:
 node-lima-join node:
     ./hack/bootstrap/nodes/join.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
 
-# Remove the temporary Lima worker taint, validate system health, and uncordon.
+# Remove the temporary Lima worker taint and restore scheduling.
 [group('node-lima')]
 node-lima-uncordon node:
     ./hack/bootstrap/nodes/uncordon.sh --profile lima --context '{{ lima_context }}' '{{ node }}'


### PR DESCRIPTION
## Summary
- split Longhorn maintenance drain checks from replacement eviction checks
- add explicit node-*-longhorn-evict helpers with replica/topology feasibility checks
- restore Longhorn scheduling and clear stale eviction flags during uncordon
- document the 3-storage-node/3-replica maintenance behavior

## Validation
- just bootstrap-test
- pre-commit run --files hack/bootstrap/nodes/lib.sh hack/bootstrap/nodes/drain.sh hack/bootstrap/nodes/uncordon.sh hack/bootstrap/nodes/longhorn-evict.sh hack/bootstrap/tests/offline-nodes.sh justfile hack/bootstrap/README.md docs/just-bootstrap.md
- just node-lima-longhorn-evict home-ops-k3s-test-agent-3 (failed safely: 3 replicas, 2 remaining eligible storage nodes)
- just node-lima-drain home-ops-k3s-test-agent-3
- just node-lima-uncordon home-ops-k3s-test-agent-3

Review agent: APPROVED