### PR TITLE
feat: add control-plane etcd status helper

### DIFF
--- a/docs/just-bootstrap.md
+++ b/docs/just-bootstrap.md
@@ -347,6 +347,7 @@ into explicit operator steps:
 
 ```sh
 just node-live-status k3s-worker-0
+just node-live-control-plane-status k3s-master-0
 just node-live-drain k3s-worker-0
 just node-live-longhorn-evict k3s-worker-0
 just node-live-delete k3s-worker-0
@@ -359,6 +360,7 @@ The Lima equivalents use the `node-lima-*` group:
 
 ```sh
 just node-lima-status home-ops-k3s-test-agent-1
+just node-lima-control-plane-status home-ops-k3s-test-server-1
 just node-lima-drain home-ops-k3s-test-agent-1
 just node-lima-longhorn-evict home-ops-k3s-test-agent-1
 just node-lima-delete home-ops-k3s-test-agent-1
@@ -369,6 +371,10 @@ just node-lima-uncordon home-ops-k3s-test-agent-1
 
 Mutating commands support worker nodes only. Control-plane lifecycle remains
 blocked until the embedded-etcd member removal and rejoin procedure is proven.
+The control-plane status command is read-only and exists to validate that future
+procedure: it reports inventory/Ready quorum math and probes the selected server
+for K3s service state, datastore files, etcd listeners, and `etcdctl`
+availability.
 
 For normal node maintenance or reboots, run drain and then uncordon. Drain only
 requires ordinary workloads to move and Longhorn volumes to detach from the

--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -269,6 +269,7 @@ delete, join, and uncordon steps:
 
 ```sh
 just node-live-status k3s-worker-0
+just node-live-control-plane-status k3s-master-0
 just node-live-drain k3s-worker-0
 just node-live-longhorn-evict k3s-worker-0
 just node-live-delete k3s-worker-0
@@ -276,10 +277,15 @@ just node-live-refresh-ssh-host-key k3s-worker-0
 just node-live-join k3s-worker-0
 just node-live-uncordon k3s-worker-0
 just node-lima-status home-ops-k3s-test-agent-1
+just node-lima-control-plane-status home-ops-k3s-test-server-1
 ```
 
-Control-plane lifecycle is intentionally refused until the embedded-etcd member
-procedure is proven. Worker delete stops and disables `k3s-node` before deleting
+Control-plane lifecycle mutations are intentionally refused until the
+embedded-etcd member procedure is proven. The control-plane status helper is
+read-only: it checks the inventory control-plane set, Ready control-plane nodes,
+quorum math, K3s service state, local datastore indicators, etcd listeners, and
+whether `etcdctl` is available for member inspection. Worker delete stops and
+disables `k3s-node` before deleting
 the Kubernetes Node and node-password Secret. If Longhorn is installed, delete
 also requires Longhorn scheduling to be disabled for the target node, no attached
 volumes on the target node, and no active or unsafe target-node replica state.

--- a/hack/bootstrap/nodes/control-plane-status.sh
+++ b/hack/bootstrap/nodes/control-plane-status.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: hack/bootstrap/nodes/control-plane-status.sh [options] NODE
+
+Options:
+  --profile NAME   Node lifecycle profile: live or lima. Defaults to live.
+  --context NAME   Kubernetes context. Defaults to the profile context.
+  -h, --help       Show help.
+EOF
+}
+
+join_csv() {
+  if (($# == 0)); then
+    printf 'none\n'
+    return
+  fi
+  local IFS=,
+  printf '%s\n' "$*"
+}
+
+indent_block() {
+  while IFS= read -r line; do
+    printf '  %s\n' "$line"
+  done
+}
+
+filter_ansible_probe_output() {
+  local host="$1"
+  awk -v host="$host" '
+    $0 == host " | CHANGED | rc=0 >>" {next}
+    $0 == host " | SUCCESS | rc=0 >>" {next}
+    {print}
+  '
+}
+
+profile=live
+context=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      profile="$2"
+      shift 2
+      ;;
+    --context)
+      context="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      node_die "unknown argument: $1"
+      ;;
+    *)
+      if [[ -n "${node_name:-}" ]]; then
+        node_die "only one node may be provided"
+      fi
+      node_name="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "${node_name:-}" ]] || node_die "NODE is required"
+node_validate_profile "$profile"
+context="${context:-$(node_context_for_profile "$profile")}"
+
+node_require_tool "$NODE_KUBECTL_BIN"
+node_require_tool "$NODE_YQ_BIN"
+node_require_tool "$NODE_JQ_BIN"
+node_require_tool ansible
+
+IFS=$'\t' read -r inventory_node_name inventory_role < <(node_resolve_inventory_node "$profile" "$node_name")
+node_assert_inventory_control_plane "$inventory_node_name" "$inventory_role"
+kubernetes_node_name="$(node_expected_kubernetes_node_name "$profile" "$inventory_node_name" "$node_name")"
+inventory_file="$(node_ansible_inventory_file "$profile")"
+
+node_assert_api_reachable "$context"
+node_json="$(node_node_json_if_present "$context" "$kubernetes_node_name")"
+[[ -n "$node_json" ]] || node_die "Kubernetes node is absent: ${kubernetes_node_name}"
+node_assert_kubernetes_control_plane "$node_json" "$kubernetes_node_name"
+
+mapfile -t inventory_masters < <(node_inventory_group_names "$profile" master)
+mapfile -t ready_control_planes < <(node_ready_control_planes "$context")
+inventory_master_count="${#inventory_masters[@]}"
+ready_control_plane_count="${#ready_control_planes[@]}"
+quorum_size="$(node_etcd_quorum_size "$inventory_master_count")"
+
+printf 'profile: %s\n' "$profile"
+printf 'context: %s\n' "$context"
+printf 'inventory: %s\n' "$inventory_file"
+printf 'inventory_node: %s\n' "$inventory_node_name"
+printf 'kubernetes_node: %s\n' "$kubernetes_node_name"
+printf 'inventory_control_planes: %s\n' "$(join_csv "${inventory_masters[@]}")"
+printf 'inventory_control_plane_count: %s\n' "$inventory_master_count"
+printf 'ready_control_planes: %s\n' "$(join_csv "${ready_control_planes[@]}")"
+printf 'ready_control_plane_count: %s\n' "$ready_control_plane_count"
+printf 'etcd_quorum_size_from_inventory: %s\n' "$quorum_size"
+if ((inventory_master_count >= 3 && ready_control_plane_count > quorum_size)); then
+  printf 'single_control_plane_outage_budget: available\n'
+else
+  printf 'single_control_plane_outage_budget: unavailable\n'
+fi
+
+read -r -d '' remote_probe <<'EOF' || true
+set -eu
+
+printf 'hostname=%s\n' "$(hostname)"
+if command -v k3s >/dev/null 2>&1; then
+  k3s --version | sed -n '1s/^/k3s_version=/p'
+else
+  printf 'k3s_version=missing\n'
+fi
+
+if command -v systemctl >/dev/null 2>&1; then
+  printf 'k3s_service_active=%s\n' "$(systemctl is-active k3s 2>/dev/null || true)"
+  printf 'k3s_service_enabled=%s\n' "$(systemctl is-enabled k3s 2>/dev/null || true)"
+else
+  printf 'k3s_service_active=unknown_no_systemctl\n'
+  printf 'k3s_service_enabled=unknown_no_systemctl\n'
+fi
+
+etcd_tls_dir=/var/lib/rancher/k3s/server/tls/etcd
+etcd_data_dir=/var/lib/rancher/k3s/server/db/etcd
+sqlite_db=/var/lib/rancher/k3s/server/db/state.db
+
+if [ -d "$etcd_tls_dir" ]; then
+  printf 'etcd_tls_dir=present\n'
+else
+  printf 'etcd_tls_dir=absent\n'
+fi
+
+if [ -d "$etcd_data_dir/member" ]; then
+  printf 'embedded_etcd_data=present\n'
+elif [ -d "$etcd_data_dir" ]; then
+  printf 'embedded_etcd_data=partial\n'
+else
+  printf 'embedded_etcd_data=absent\n'
+fi
+
+if [ -f "$sqlite_db" ]; then
+  printf 'sqlite_state_db=present\n'
+else
+  printf 'sqlite_state_db=absent\n'
+fi
+
+if command -v ss >/dev/null 2>&1; then
+  etcd_listeners="$(ss -ltn 2>/dev/null | awk 'NR > 1 {print $4}' | grep -E '(:|\])23(79|80)$' | paste -sd ',' - || true)"
+  printf 'etcd_listeners=%s\n' "${etcd_listeners:-none}"
+else
+  printf 'etcd_listeners=unknown_no_ss\n'
+fi
+
+etcdctl_path="$(command -v etcdctl 2>/dev/null || true)"
+if [ -n "$etcdctl_path" ]; then
+  printf 'etcdctl=%s\n' "$etcdctl_path"
+else
+  printf 'etcdctl=absent\n'
+fi
+
+if [ -n "$etcdctl_path" ] &&
+  [ -f "$etcd_tls_dir/server-ca.crt" ] &&
+  [ -f "$etcd_tls_dir/client.crt" ] &&
+  [ -f "$etcd_tls_dir/client.key" ]; then
+  printf 'etcd_member_list_begin\n'
+  ETCDCTL_API=3 "$etcdctl_path" \
+    --endpoints=https://127.0.0.1:2379 \
+    --dial-timeout=3s \
+    --command-timeout=5s \
+    --cacert="$etcd_tls_dir/server-ca.crt" \
+    --cert="$etcd_tls_dir/client.crt" \
+    --key="$etcd_tls_dir/client.key" \
+    member list -w table || printf 'etcd_member_list_error=%s\n' "$?"
+  printf 'etcd_member_list_end\n'
+else
+  printf 'etcd_member_list=skipped_missing_etcdctl_or_certs\n'
+fi
+EOF
+
+printf '\nremote_probe:\n'
+if remote_output="$(
+  ANSIBLE_HOST_KEY_CHECKING=False \
+  ANSIBLE_PYTHON_INTERPRETER=auto_silent \
+    ansible -i "$inventory_file" "$inventory_node_name" \
+      --become \
+      -m ansible.builtin.shell \
+      -a "$remote_probe" 2>&1
+)"; then
+  filter_ansible_probe_output "$inventory_node_name" <<<"$remote_output" | indent_block
+else
+  indent_block <<<"$remote_output"
+  node_die "control-plane remote probe failed for ${inventory_node_name}"
+fi

--- a/hack/bootstrap/nodes/lib.sh
+++ b/hack/bootstrap/nodes/lib.sh
@@ -193,6 +193,40 @@ node_inventory_value() {
     "$inventory"
 }
 
+node_inventory_group_names() {
+  local profile="$1"
+  local group="$2"
+  local inventory
+  inventory="$(node_inventory_file "$profile")"
+  [[ -f "$inventory" ]] || return 0
+  "$NODE_YQ_BIN" -r \
+    ".all.children.k3s_cluster.children.${group}.hosts // {} | keys | .[]" \
+    "$inventory"
+}
+
+node_inventory_group_count() {
+  local profile="$1"
+  local group="$2"
+  local inventory
+  inventory="$(node_inventory_file "$profile")"
+  [[ -f "$inventory" ]] || {
+    printf '0\n'
+    return 0
+  }
+  "$NODE_YQ_BIN" -r \
+    ".all.children.k3s_cluster.children.${group}.hosts // {} | length" \
+    "$inventory"
+}
+
+node_etcd_quorum_size() {
+  local member_count="$1"
+  ((member_count > 0)) || {
+    printf '0\n'
+    return 0
+  }
+  printf '%s\n' $((member_count / 2 + 1))
+}
+
 node_group_var() {
   local profile="$1"
   local key="$2"
@@ -336,6 +370,28 @@ node_assert_inventory_worker() {
   esac
 }
 
+node_assert_inventory_control_plane() {
+  local inventory_node="$1"
+  local inventory_role="$2"
+
+  case "$inventory_role" in
+    master)
+      ;;
+    node)
+      node_die "node is a worker in the selected inventory: ${inventory_node}"
+      ;;
+    absent)
+      node_die "node is not present in the selected inventory: ${inventory_node}"
+      ;;
+    conflict)
+      node_die "node appears in both master and node inventory groups: ${inventory_node}"
+      ;;
+    *)
+      node_die "unexpected inventory role for ${inventory_node}: ${inventory_role}"
+      ;;
+  esac
+}
+
 node_assert_kubernetes_worker() {
   local node_json="$1"
   local node="$2"
@@ -344,6 +400,16 @@ node_assert_kubernetes_worker() {
   k8s_role="$(node_k8s_role_from_node_json <<<"$node_json")"
   [[ "$k8s_role" == node ]] ||
     node_die "control-plane lifecycle is not implemented yet: ${node}"
+}
+
+node_assert_kubernetes_control_plane() {
+  local node_json="$1"
+  local node="$2"
+  local k8s_role
+
+  k8s_role="$(node_k8s_role_from_node_json <<<"$node_json")"
+  [[ "$k8s_role" == control-plane ]] ||
+    node_die "node is not a Kubernetes control-plane node: ${node}"
 }
 
 node_assert_ready() {

--- a/hack/bootstrap/tests/offline-nodes.sh
+++ b/hack/bootstrap/tests/offline-nodes.sh
@@ -79,6 +79,17 @@ resolved_worker="$(
 )"
 test "$resolved_worker" = "$(printf 'k3s-worker-0\tnode')"
 
+master_count="$(
+  NODE_LIVE_INVENTORY_DIR="$inventory" \
+    bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_inventory_group_count live master"
+)"
+test "$master_count" = "1"
+
+quorum_size="$(
+  bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_etcd_quorum_size 3"
+)"
+test "$quorum_size" = "2"
+
 expected_lima_node="$(
   bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_expected_kubernetes_node_name lima home-ops-k3s-test-agent-1 home-ops-k3s-test-agent-1"
 )"
@@ -220,7 +231,89 @@ grep -q 'default/workload phase=Running owner=ReplicaSet' <<<"$status_output"
 grep -q 'cilium-one phase=Running ready=1/1' <<<"$status_output"
 grep -q 'installed: false' <<<"$status_output"
 
+fake_control_plane_kubectl="${tmp}/kubectl-control-plane"
+cat > "$fake_control_plane_kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--context" ]]; then
+  shift 2
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "--raw=/readyz" ]]; then
+  printf 'ok\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "node/k3s-master-0" ]]; then
+  cat <<'JSON'
+{
+  "metadata": {
+    "name": "k3s-master-0",
+    "labels": {"node-role.kubernetes.io/control-plane": "true"}
+  },
+  "status": {
+    "conditions": [
+      {"type": "Ready", "status": "True"}
+    ]
+  }
+}
+JSON
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "nodes" ]]; then
+  cat <<'JSON'
+{
+  "items": [
+    {
+      "metadata": {
+        "name": "k3s-master-0",
+        "labels": {"node-role.kubernetes.io/control-plane": "true"}
+      },
+      "status": {"conditions": [{"type": "Ready", "status": "True"}]}
+    },
+    {
+      "metadata": {"name": "k3s-worker-0", "labels": {}},
+      "status": {"conditions": [{"type": "Ready", "status": "True"}]}
+    }
+  ]
+}
+JSON
+  exit 0
+fi
+
+printf 'unexpected fake control-plane kubectl args: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$fake_control_plane_kubectl"
+
+fake_ansible="${tmp}/ansible"
+cat > "$fake_ansible" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'k3s-master-0 | CHANGED | rc=0 >>\n'
+printf 'k3s_service_active=active\n'
+printf 'embedded_etcd_data=present\n'
+printf 'etcdctl=absent\n'
+EOF
+chmod +x "$fake_ansible"
+
+control_plane_output="$(
+  PATH="${tmp}:${PATH}" \
+  NODE_LIVE_INVENTORY_DIR="$inventory" \
+  NODE_KUBECTL_BIN="$fake_control_plane_kubectl" \
+    "${ROOT}/hack/bootstrap/nodes/control-plane-status.sh" --profile live --context test k3s-master-0
+)"
+
+grep -q '^inventory_control_planes: k3s-master-0$' <<<"$control_plane_output"
+grep -q '^inventory_control_plane_count: 1$' <<<"$control_plane_output"
+grep -q '^ready_control_plane_count: 1$' <<<"$control_plane_output"
+grep -q '^etcd_quorum_size_from_inventory: 1$' <<<"$control_plane_output"
+grep -q 'embedded_etcd_data=present' <<<"$control_plane_output"
+
 "${ROOT}/hack/bootstrap/nodes/drain.sh" --help >/dev/null
+"${ROOT}/hack/bootstrap/nodes/control-plane-status.sh" --help >/dev/null
 "${ROOT}/hack/bootstrap/nodes/delete.sh" --help >/dev/null
 "${ROOT}/hack/bootstrap/nodes/longhorn-evict.sh" --help >/dev/null
 "${ROOT}/hack/bootstrap/nodes/join.sh" --help >/dev/null

--- a/justfile
+++ b/justfile
@@ -177,6 +177,11 @@ bootstrap-live-full:
 node-live-status node:
     ./hack/bootstrap/nodes/status.sh --profile live --context default '{{ node }}'
 
+# Show read-only control-plane quorum and embedded-etcd status for a live cluster node.
+[group('node-live')]
+node-live-control-plane-status node:
+    ./hack/bootstrap/nodes/control-plane-status.sh --profile live --context default '{{ node }}'
+
 # Drain a live worker node before deletion or maintenance.
 [group('node-live')]
 node-live-drain node:
@@ -286,6 +291,11 @@ bootstrap-lima-fresh: bootstrap-lima-delete bootstrap-lima-create bootstrap-lima
 [group('node-lima')]
 node-lima-status node:
     ./hack/bootstrap/nodes/status.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
+
+# Show read-only control-plane quorum and embedded-etcd status for a Lima cluster node.
+[group('node-lima')]
+node-lima-control-plane-status node:
+    ./hack/bootstrap/nodes/control-plane-status.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
 
 # Drain a Lima worker node before deletion or maintenance.
 [group('node-lima')]


### PR DESCRIPTION
## Summary
- add a read-only control-plane status helper for quorum, K3s service, datastore, listener, and etcdctl visibility
- expose live and Lima just recipes for control-plane status
- document the read-only control-plane discovery step while keeping mutating lifecycle worker-only

## Validation
- just bootstrap-test
- pre-commit run --files docs/just-bootstrap.md hack/bootstrap/README.md hack/bootstrap/nodes/lib.sh hack/bootstrap/nodes/control-plane-status.sh hack/bootstrap/tests/offline-nodes.sh justfile
- just node-lima-control-plane-status home-ops-k3s-test-server-1
- just node-live-control-plane-status k3s-master-0
- just node-live-control-plane-status k3s-master-1
- just node-live-control-plane-status k3s-master-2

Review-agent approved with no findings.