### PR TITLE
feat: install matching etcdctl for control planes

### DIFF
--- a/docs/just-bootstrap.md
+++ b/docs/just-bootstrap.md
@@ -374,7 +374,10 @@ blocked until the embedded-etcd member removal and rejoin procedure is proven.
 The control-plane status command is read-only and exists to validate that future
 procedure: it reports inventory/Ready quorum math and probes the selected server
 for K3s service state, datastore files, etcd listeners, and `etcdctl`
-availability.
+availability. The home-ops Ansible backend derives the upstream `etcdctl`
+version from the K3s release's embedded Etcd version, verifies the release
+archive checksum, and installs `etcdctl` on control-plane nodes so
+embedded-etcd member inspection is available after node convergence.
 
 For normal node maintenance or reboots, run drain and then uncordon. Drain only
 requires ordinary workloads to move and Longhorn volumes to detach from the

--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -284,8 +284,11 @@ Control-plane lifecycle mutations are intentionally refused until the
 embedded-etcd member procedure is proven. The control-plane status helper is
 read-only: it checks the inventory control-plane set, Ready control-plane nodes,
 quorum math, K3s service state, local datastore indicators, etcd listeners, and
-whether `etcdctl` is available for member inspection. Worker delete stops and
-disables `k3s-node` before deleting
+whether `etcdctl` is available for member inspection. The home-ops Ansible
+backend derives the upstream `etcdctl` version from the K3s release's embedded
+Etcd version, verifies the release archive checksum, and installs `etcdctl` on
+control-plane nodes so this probe can list members once embedded etcd is
+present. Worker delete stops and disables `k3s-node` before deleting
 the Kubernetes Node and node-password Secret. If Longhorn is installed, delete
 also requires Longhorn scheduling to be disabled for the target node, no attached
 volumes on the target node, and no active or unsafe target-node replica state.

--- a/hack/bootstrap/ansible/home-ops/site.yml
+++ b/hack/bootstrap/ansible/home-ops/site.yml
@@ -19,6 +19,16 @@
     - name: Write K3s token file
       ansible.builtin.import_tasks: tasks/token.yml
 
+- name: Install home-ops control-plane tools
+  hosts: master
+  gather_facts: true
+  become: true
+  tasks:
+    - name: Install etcdctl
+      ansible.builtin.import_tasks: tasks/etcdctl.yml
+      tags:
+        - etcdctl
+
 - name: Install first home-ops control-plane node
   hosts: master[0]
   gather_facts: true

--- a/hack/bootstrap/ansible/home-ops/tasks/etcdctl.yml
+++ b/hack/bootstrap/ansible/home-ops/tasks/etcdctl.yml
@@ -1,0 +1,135 @@
+---
+- name: Ensure temporary bootstrap directory exists
+  ansible.builtin.file:
+    path: /tmp/home-ops-bootstrap
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Set etcdctl defaults
+  ansible.builtin.set_fact:
+    home_ops_etcdctl_binary_path_effective: "{{ home_ops_etcdctl_binary_path | default('/usr/local/bin/etcdctl') }}"
+    home_ops_etcdctl_version_override_effective: "{{ home_ops_etcdctl_version_override | default('') }}"
+
+- name: Fetch K3s release metadata
+  ansible.builtin.uri:
+    url: "https://api.github.com/repos/k3s-io/k3s/releases/tags/{{ k3s_version | urlencode }}"
+    return_content: true
+  register: home_ops_k3s_release_metadata
+  until: home_ops_k3s_release_metadata is succeeded
+  retries: 5
+  delay: 10
+
+- name: Set embedded Etcd version fact
+  ansible.builtin.set_fact:
+    home_ops_embedded_etcd_version: >-
+      {{-
+        home_ops_k3s_release_metadata.json.body
+        | regex_findall('\| Etcd \| \[v([0-9]+\.[0-9]+\.[0-9]+)(?:-k3s[0-9]+)?\]')
+        | first
+        | default('')
+      -}}
+
+- name: Fail if embedded Etcd version cannot be derived
+  ansible.builtin.fail:
+    msg: "Could not derive embedded Etcd version from K3s release metadata for {{ k3s_version }}"
+  when: home_ops_embedded_etcd_version | length == 0
+
+- name: Set effective etcdctl version
+  ansible.builtin.set_fact:
+    home_ops_etcdctl_version_effective: >-
+      {{-
+        home_ops_etcdctl_version_override_effective
+        if (home_ops_etcdctl_version_override_effective | length > 0)
+        else 'v' ~ home_ops_embedded_etcd_version
+      -}}
+
+- name: Set etcdctl release facts
+  ansible.builtin.set_fact:
+    home_ops_etcdctl_arch: "{{ 'arm64' if ansible_facts['architecture'] in ['aarch64', 'arm64'] else 'amd64' }}"
+    home_ops_etcdctl_version_number: "{{ home_ops_etcdctl_version_effective | regex_replace('^v', '') }}"
+
+- name: Set etcdctl archive fact
+  ansible.builtin.set_fact:
+    home_ops_etcdctl_archive: "etcd-{{ home_ops_etcdctl_version_effective }}-linux-{{ home_ops_etcdctl_arch }}.tar.gz"
+    home_ops_etcdctl_extract_dir: "/tmp/home-ops-bootstrap/etcd-{{ home_ops_etcdctl_version_effective }}-linux-{{ home_ops_etcdctl_arch }}"
+
+- name: Check installed etcdctl version
+  ansible.builtin.command: "{{ home_ops_etcdctl_binary_path_effective }} version"
+  register: home_ops_etcdctl_version_check
+  failed_when: false
+  changed_when: false
+
+- name: Set installed etcdctl version fact
+  ansible.builtin.set_fact:
+    home_ops_installed_etcdctl_version: >-
+      {{-
+        home_ops_etcdctl_version_check.stdout_lines
+        | default([])
+        | join(' ')
+        | regex_findall('etcdctl version: ([0-9]+\.[0-9]+\.[0-9]+)')
+        | first
+        | default('')
+      -}}
+
+- name: Install or update etcdctl
+  when: home_ops_installed_etcdctl_version != home_ops_etcdctl_version_number
+  block:
+    - name: Download etcd release archive and checksums
+      ansible.builtin.get_url:
+        url: "https://github.com/etcd-io/etcd/releases/download/{{ home_ops_etcdctl_version_effective }}/{{ item }}"
+        dest: "/tmp/home-ops-bootstrap/{{ item }}"
+        owner: root
+        group: root
+        mode: "0644"
+      loop:
+        - "{{ home_ops_etcdctl_archive }}"
+        - SHA256SUMS
+      register: home_ops_etcdctl_archive_download
+      until: home_ops_etcdctl_archive_download is succeeded
+      retries: 5
+      delay: 10
+
+    - name: Verify etcd release archive
+      ansible.builtin.shell: |
+        set -euo pipefail
+        cd /tmp/home-ops-bootstrap
+        archive={{ home_ops_etcdctl_archive | quote }}
+        checksum_line="$(awk -v archive="$archive" '$2 == archive {print}' SHA256SUMS)"
+        test -n "$checksum_line"
+        printf '%s\n' "$checksum_line" | sha256sum --check
+      args:
+        executable: /bin/bash
+      changed_when: false
+
+    - name: Ensure etcd release extract directory exists
+      ansible.builtin.file:
+        path: "{{ home_ops_etcdctl_extract_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Extract etcdctl from release archive
+      ansible.builtin.unarchive:
+        src: "/tmp/home-ops-bootstrap/{{ home_ops_etcdctl_archive }}"
+        dest: "{{ home_ops_etcdctl_extract_dir }}"
+        remote_src: true
+        extra_opts:
+          - --strip-components=1
+
+    - name: Install etcdctl binary
+      ansible.builtin.copy:
+        src: "{{ home_ops_etcdctl_extract_dir }}/etcdctl"
+        dest: "{{ home_ops_etcdctl_binary_path_effective }}"
+        remote_src: true
+        owner: root
+        group: root
+        mode: "0755"
+
+- name: Verify installed etcdctl version
+  ansible.builtin.command: "{{ home_ops_etcdctl_binary_path_effective }} version"
+  register: home_ops_etcdctl_verify
+  changed_when: false
+  failed_when: "'etcdctl version: ' ~ home_ops_etcdctl_version_number not in home_ops_etcdctl_verify.stdout"

--- a/hack/bootstrap/ansible/home-ops/vars/defaults.yml
+++ b/hack/bootstrap/ansible/home-ops/vars/defaults.yml
@@ -35,6 +35,10 @@ home_ops_k3s_token_file: /etc/rancher/k3s/home-ops-token
 home_ops_remote_kubeconfig: /tmp/home-ops-kubeconfig
 home_ops_cilium_values_file: /tmp/home-ops-cilium-values.yaml
 home_ops_cilium_checksum_file: /var/lib/rancher/k3s/server/home-ops-cilium-bootstrap.sha256
+# Empty means derive the upstream etcdctl base version from the K3s release's
+# embedded Etcd version, such as K3s Etcd v3.6.7-k3s1 -> etcdctl v3.6.7.
+home_ops_etcdctl_version_override: ""
+home_ops_etcdctl_binary_path: /usr/local/bin/etcdctl
 
 kube_vip_enabled: true
 kube_vip_arp: true

--- a/hack/bootstrap/nodes/control-plane-status.sh
+++ b/hack/bootstrap/nodes/control-plane-status.sh
@@ -152,9 +152,13 @@ else
   printf 'sqlite_state_db=absent\n'
 fi
 
+etcd_listeners=unknown_no_ss
 if command -v ss >/dev/null 2>&1; then
   etcd_listeners="$(ss -ltn 2>/dev/null | awk 'NR > 1 {print $4}' | grep -E '(:|\])23(79|80)$' | paste -sd ',' - || true)"
   printf 'etcd_listeners=%s\n' "${etcd_listeners:-none}"
+  if [ -z "$etcd_listeners" ]; then
+    etcd_listeners=none
+  fi
 else
   printf 'etcd_listeners=unknown_no_ss\n'
 fi
@@ -162,11 +166,15 @@ fi
 etcdctl_path="$(command -v etcdctl 2>/dev/null || true)"
 if [ -n "$etcdctl_path" ]; then
   printf 'etcdctl=%s\n' "$etcdctl_path"
+  etcdctl_version="$("$etcdctl_path" version 2>/dev/null | sed -n '1p' || true)"
+  printf 'etcdctl_version=%s\n' "${etcdctl_version:-unknown}"
 else
   printf 'etcdctl=absent\n'
 fi
 
 if [ -n "$etcdctl_path" ] &&
+  [ "$etcd_listeners" != "none" ] &&
+  [ "$etcd_listeners" != "unknown_no_ss" ] &&
   [ -f "$etcd_tls_dir/server-ca.crt" ] &&
   [ -f "$etcd_tls_dir/client.crt" ] &&
   [ -f "$etcd_tls_dir/client.key" ]; then
@@ -181,7 +189,7 @@ if [ -n "$etcdctl_path" ] &&
     member list -w table || printf 'etcd_member_list_error=%s\n' "$?"
   printf 'etcd_member_list_end\n'
 else
-  printf 'etcd_member_list=skipped_missing_etcdctl_or_certs\n'
+  printf 'etcd_member_list=skipped_missing_etcdctl_listener_or_certs\n'
 fi
 EOF
 

--- a/hack/bootstrap/tests/offline-ansible.sh
+++ b/hack/bootstrap/tests/offline-ansible.sh
@@ -65,6 +65,9 @@ if ! grep -q 'ansible_disable_kube_proxy_after_cilium' "${ROOT}/hack/bootstrap/a
   echo "run.sh does not call the post-Cilium kube-proxy convergence playbook" >&2
   exit 1
 fi
+grep -q 'api.github.com/repos/k3s-io/k3s/releases/tags' "${ROOT}/hack/bootstrap/ansible/home-ops/tasks/etcdctl.yml"
+grep -q 'home_ops_embedded_etcd_version' "${ROOT}/hack/bootstrap/ansible/home-ops/tasks/etcdctl.yml"
+grep -q 'home_ops_etcdctl_version_effective' "${ROOT}/hack/bootstrap/ansible/home-ops/tasks/etcdctl.yml"
 
 home_ops_out="${tmp}/home-ops-out"
 BOOTSTRAP_ANSIBLE_OUT_DIR="$home_ops_out" \
@@ -76,6 +79,7 @@ test "$(yq -r '.k3s_version' "$home_ops_vars")" = "v1.35.4+k3s1"
 test "$(yq -r '.cilium_tag' "$home_ops_vars")" = "$cilium_tag"
 test "$(yq -r '.cluster_cidr' "$home_ops_vars")" = "10.52.0.0/16"
 test "$(yq -r '.k3s_token' "$home_ops_vars")" = "{{ lookup('ansible.builtin.env', 'K3S_TOKEN') }}"
+test "$(yq -r '.home_ops_etcdctl_version_override' "$home_ops_vars")" = ""
 if grep -q 'sample-token' "$home_ops_vars"; then
   echo "home-ops backend vars contain sample token" >&2
   exit 1


### PR DESCRIPTION
## Summary
- derive the upstream etcdctl client version from the K3s release embedded Etcd version
- install checksum-verified etcdctl on home-ops control-plane nodes through the Ansible backend
- make control-plane status print etcdctl version and skip member listing unless the client, listener, and certs are all present

## Validation
- just bootstrap-test
- pre-commit run --files docs/just-bootstrap.md hack/bootstrap/README.md hack/bootstrap/ansible/home-ops/site.yml hack/bootstrap/ansible/home-ops/tasks/etcdctl.yml hack/bootstrap/ansible/home-ops/vars/defaults.yml hack/bootstrap/nodes/control-plane-status.sh hack/bootstrap/tests/offline-ansible.sh
- ansible-playbook -i hack/bootstrap/.out/lima-home-ops-k3s-test/inventory/hosts.yml hack/bootstrap/ansible/home-ops/site.yml --tags etcdctl --limit home-ops-k3s-test-server-1
- repeated the same ansible-playbook command and confirmed changed=0
- just node-lima-control-plane-status home-ops-k3s-test-server-1

Notes:
- K3s v1.35.4+k3s1 reports embedded Etcd v3.6.7-k3s1, so the installed upstream client was etcdctl v3.6.7.
- This does not update K3s or embedded etcd, and does not add any mutating control-plane lifecycle path.