### PR TITLE
fix: drop legacy etcdctl api env

### DIFF
--- a/hack/bootstrap/nodes/control-plane-status.sh
+++ b/hack/bootstrap/nodes/control-plane-status.sh
@@ -179,7 +179,7 @@ if [ -n "$etcdctl_path" ] &&
   [ -f "$etcd_tls_dir/client.crt" ] &&
   [ -f "$etcd_tls_dir/client.key" ]; then
   printf 'etcd_member_list_begin\n'
-  ETCDCTL_API=3 "$etcdctl_path" \
+  "$etcdctl_path" \
     --endpoints=https://127.0.0.1:2379 \
     --dial-timeout=3s \
     --command-timeout=5s \


### PR DESCRIPTION
## Summary
- remove the legacy ETCDCTL_API=3 environment prefix from the read-only control-plane status probe
- avoids the v3.6 etcdctl warning while preserving successful member listing

## Validation
- shellcheck hack/bootstrap/nodes/control-plane-status.sh
- hack/bootstrap/tests/offline-nodes.sh
- pre-commit run --files hack/bootstrap/nodes/control-plane-status.sh
- just node-live-control-plane-status k3s-master-0