### PR TITLE
feat: add control-plane delete preflight

### DIFF
--- a/docs/just-bootstrap.md
+++ b/docs/just-bootstrap.md
@@ -348,6 +348,7 @@ into explicit operator steps:
 ```sh
 just node-live-status k3s-worker-0
 just node-live-control-plane-status k3s-master-0
+just node-live-control-plane-delete-preflight k3s-master-0
 just node-live-drain k3s-worker-0
 just node-live-longhorn-evict k3s-worker-0
 just node-live-delete k3s-worker-0
@@ -361,6 +362,7 @@ The Lima equivalents use the `node-lima-*` group:
 ```sh
 just node-lima-status home-ops-k3s-test-agent-1
 just node-lima-control-plane-status home-ops-k3s-test-server-1
+just node-lima-control-plane-delete-preflight home-ops-k3s-test-server-1
 just node-lima-drain home-ops-k3s-test-agent-1
 just node-lima-longhorn-evict home-ops-k3s-test-agent-1
 just node-lima-delete home-ops-k3s-test-agent-1
@@ -378,6 +380,11 @@ availability. The home-ops Ansible backend derives the upstream `etcdctl`
 version from the K3s release's embedded Etcd version, verifies the release
 archive checksum, and installs `etcdctl` on control-plane nodes so
 embedded-etcd member inspection is available after node convergence.
+The control-plane delete preflight is also read-only. It queries etcd from an
+alternate Ready control-plane, maps the target node to exactly one etcd member,
+checks quorum math, and prints the future `etcdctl member remove` command
+without running it. Single-server Lima clusters cannot pass that HA preflight
+because there is no alternate etcd member to query.
 
 For normal node maintenance or reboots, run drain and then uncordon. Drain only
 requires ordinary workloads to move and Longhorn volumes to detach from the

--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -270,6 +270,7 @@ delete, join, and uncordon steps:
 ```sh
 just node-live-status k3s-worker-0
 just node-live-control-plane-status k3s-master-0
+just node-live-control-plane-delete-preflight k3s-master-0
 just node-live-drain k3s-worker-0
 just node-live-longhorn-evict k3s-worker-0
 just node-live-delete k3s-worker-0
@@ -278,6 +279,7 @@ just node-live-join k3s-worker-0
 just node-live-uncordon k3s-worker-0
 just node-lima-status home-ops-k3s-test-agent-1
 just node-lima-control-plane-status home-ops-k3s-test-server-1
+just node-lima-control-plane-delete-preflight home-ops-k3s-test-server-1
 ```
 
 Control-plane lifecycle mutations are intentionally refused until the
@@ -288,7 +290,12 @@ whether `etcdctl` is available for member inspection. The home-ops Ansible
 backend derives the upstream `etcdctl` version from the K3s release's embedded
 Etcd version, verifies the release archive checksum, and installs `etcdctl` on
 control-plane nodes so this probe can list members once embedded etcd is
-present. Worker delete stops and disables `k3s-node` before deleting
+present. The control-plane delete preflight is also read-only: it must query
+etcd from an alternate Ready control-plane, match the target Kubernetes node to
+exactly one etcd member, check quorum math, and print the future
+`etcdctl member remove` command without running it. Single-server Lima clusters
+cannot pass that HA preflight because there is no alternate etcd member to
+query. Worker delete stops and disables `k3s-node` before deleting
 the Kubernetes Node and node-password Secret. If Longhorn is installed, delete
 also requires Longhorn scheduling to be disabled for the target node, no attached
 volumes on the target node, and no active or unsafe target-node replica state.

--- a/hack/bootstrap/nodes/control-plane-delete-preflight.sh
+++ b/hack/bootstrap/nodes/control-plane-delete-preflight.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: hack/bootstrap/nodes/control-plane-delete-preflight.sh [options] NODE
+
+Options:
+  --profile NAME   Node lifecycle profile: live or lima. Defaults to live.
+  --context NAME   Kubernetes context. Defaults to the profile context.
+  -h, --help       Show help.
+EOF
+}
+
+join_csv() {
+  if (($# == 0)); then
+    printf 'none\n'
+    return
+  fi
+  local IFS=,
+  printf '%s\n' "$*"
+}
+
+contains_line() {
+  local needle="$1"
+  shift
+  local value
+  for value in "$@"; do
+    [[ "$value" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s\n' "$value"
+}
+
+indent_block() {
+  while IFS= read -r line; do
+    printf '  %s\n' "$line"
+  done
+}
+
+filter_ansible_probe_output() {
+  local host="$1"
+  awk -v host="$host" '
+    $0 == host " | CHANGED | rc=0 >>" {next}
+    $0 == host " | SUCCESS | rc=0 >>" {next}
+    /^\[WARNING\]: / {next}
+    {print}
+  '
+}
+
+extract_block() {
+  local begin="$1"
+  local end="$2"
+  awk -v begin="$begin" -v end="$end" '
+    $0 == begin {inside = 1; next}
+    $0 == end {inside = 0}
+    inside {print}
+  '
+}
+
+profile=live
+context=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      profile="$2"
+      shift 2
+      ;;
+    --context)
+      context="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      node_die "unknown argument: $1"
+      ;;
+    *)
+      if [[ -n "${node_name:-}" ]]; then
+        node_die "only one node may be provided"
+      fi
+      node_name="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "${node_name:-}" ]] || node_die "NODE is required"
+node_validate_profile "$profile"
+context="${context:-$(node_context_for_profile "$profile")}"
+
+node_require_tool "$NODE_KUBECTL_BIN"
+node_require_tool "$NODE_YQ_BIN"
+node_require_tool "$NODE_JQ_BIN"
+node_require_tool ansible
+
+IFS=$'\t' read -r inventory_node_name inventory_role < <(node_resolve_inventory_node "$profile" "$node_name")
+node_assert_inventory_control_plane "$inventory_node_name" "$inventory_role"
+kubernetes_node_name="$(node_expected_kubernetes_node_name "$profile" "$inventory_node_name" "$node_name")"
+inventory_file="$(node_ansible_inventory_file "$profile")"
+target_ansible_host="$(node_inventory_value "$profile" "$inventory_node_name" ansible_host 2>/dev/null || true)"
+
+node_assert_api_reachable "$context"
+node_json="$(node_node_json_if_present "$context" "$kubernetes_node_name")"
+[[ -n "$node_json" ]] || node_die "Kubernetes node is absent: ${kubernetes_node_name}"
+node_assert_kubernetes_control_plane "$node_json" "$kubernetes_node_name"
+
+mapfile -t inventory_masters < <(node_inventory_group_names "$profile" master)
+mapfile -t ready_control_planes < <(node_ready_control_planes "$context")
+inventory_master_count="${#inventory_masters[@]}"
+ready_control_plane_count="${#ready_control_planes[@]}"
+target_ready=false
+if contains_line "$kubernetes_node_name" "${ready_control_planes[@]}"; then
+  target_ready=true
+fi
+
+probe_inventory_node=""
+for inventory_master in "${inventory_masters[@]}"; do
+  probe_kubernetes_node="$(node_expected_kubernetes_node_name "$profile" "$inventory_master" "$inventory_master")"
+  if [[ "$probe_kubernetes_node" != "$kubernetes_node_name" ]] &&
+    contains_line "$probe_kubernetes_node" "${ready_control_planes[@]}"; then
+    probe_inventory_node="$inventory_master"
+    break
+  fi
+done
+[[ -n "$probe_inventory_node" ]] ||
+  node_die "no alternate Ready control-plane node is available to query etcd"
+
+read -r -d '' remote_probe <<'EOF' || true
+set -eu
+
+etcd_tls_dir=/var/lib/rancher/k3s/server/tls/etcd
+etcdctl_path="$(command -v etcdctl 2>/dev/null || true)"
+if [ -z "$etcdctl_path" ]; then
+  printf 'preflight_error=etcdctl_absent\n'
+  exit 2
+fi
+
+for cert_file in server-ca.crt client.crt client.key; do
+  if [ ! -f "$etcd_tls_dir/$cert_file" ]; then
+    printf 'preflight_error=missing_etcd_cert:%s\n' "$cert_file"
+    exit 2
+  fi
+done
+
+printf 'hostname=%s\n' "$(hostname)"
+printf 'etcdctl=%s\n' "$etcdctl_path"
+etcdctl_version="$("$etcdctl_path" version 2>/dev/null | sed -n '1p' || true)"
+printf 'etcdctl_version=%s\n' "${etcdctl_version:-unknown}"
+printf 'etcd_member_simple_begin\n'
+"$etcdctl_path" \
+  --endpoints=https://127.0.0.1:2379 \
+  --dial-timeout=3s \
+  --command-timeout=5s \
+  --cacert="$etcd_tls_dir/server-ca.crt" \
+  --cert="$etcd_tls_dir/client.crt" \
+  --key="$etcd_tls_dir/client.key" \
+  member list
+printf 'etcd_member_simple_end\n'
+printf 'etcd_endpoint_health_begin\n'
+"$etcdctl_path" \
+  --endpoints=https://127.0.0.1:2379 \
+  --dial-timeout=3s \
+  --command-timeout=5s \
+  --cacert="$etcd_tls_dir/server-ca.crt" \
+  --cert="$etcd_tls_dir/client.crt" \
+  --key="$etcd_tls_dir/client.key" \
+  endpoint health
+printf 'etcd_endpoint_health_end\n'
+EOF
+
+if remote_output="$(
+  ANSIBLE_HOST_KEY_CHECKING=False \
+  ANSIBLE_PYTHON_INTERPRETER=auto_silent \
+    ansible -i "$inventory_file" "$probe_inventory_node" \
+      --become \
+      -m ansible.builtin.shell \
+      -a "$remote_probe" 2>&1
+)"; then
+  filtered_remote_output="$(filter_ansible_probe_output "$probe_inventory_node" <<<"$remote_output")"
+else
+  filtered_remote_output="$(filter_ansible_probe_output "$probe_inventory_node" <<<"$remote_output")"
+  printf 'remote_probe:\n'
+  indent_block <<<"$filtered_remote_output"
+  node_die "control-plane delete preflight probe failed from ${probe_inventory_node}"
+fi
+
+if grep -q '^preflight_error=' <<<"$filtered_remote_output"; then
+  printf 'remote_probe:\n'
+  indent_block <<<"$filtered_remote_output"
+  node_die "control-plane delete preflight probe reported an error"
+fi
+
+member_lines="$(extract_block etcd_member_simple_begin etcd_member_simple_end <<<"$filtered_remote_output")"
+endpoint_health="$(extract_block etcd_endpoint_health_begin etcd_endpoint_health_end <<<"$filtered_remote_output")"
+[[ -n "$member_lines" ]] || node_die "etcd member list was empty"
+[[ -n "$endpoint_health" ]] || node_die "etcd endpoint health output was empty"
+
+target_member_id=""
+target_member_status=""
+target_member_name=""
+target_member_peer_urls=""
+target_member_client_urls=""
+target_member_is_learner=""
+member_count=0
+matched_member_count=0
+all_member_names=()
+
+while IFS= read -r member_line; do
+  [[ -n "$member_line" ]] || continue
+  IFS=',' read -r member_id member_status member_name member_peer_urls member_client_urls member_is_learner _ <<<"$member_line"
+  member_id="$(trim "$member_id")"
+  member_status="$(trim "$member_status")"
+  member_name="$(trim "$member_name")"
+  member_peer_urls="$(trim "$member_peer_urls")"
+  member_client_urls="$(trim "$member_client_urls")"
+  member_is_learner="$(trim "$member_is_learner")"
+  ((member_count += 1))
+  all_member_names+=("$member_name")
+
+  member_matches=false
+  if [[ "$member_name" == "$kubernetes_node_name" ||
+    "$member_name" == "$inventory_node_name" ||
+    "$member_name" == "${kubernetes_node_name}-"* ||
+    "$member_name" == "${inventory_node_name}-"* ]]; then
+    member_matches=true
+  elif [[ -n "$target_ansible_host" &&
+    ("$member_peer_urls" == *"://${target_ansible_host}:"* ||
+      "$member_client_urls" == *"://${target_ansible_host}:"*) ]]; then
+    member_matches=true
+  fi
+
+  if node_bool "$member_matches"; then
+    target_member_id="$member_id"
+    target_member_status="$member_status"
+    target_member_name="$member_name"
+    target_member_peer_urls="$member_peer_urls"
+    target_member_client_urls="$member_client_urls"
+    target_member_is_learner="$member_is_learner"
+    ((matched_member_count += 1))
+  fi
+done <<<"$member_lines"
+
+((member_count > 0)) || node_die "could not parse etcd members"
+((matched_member_count == 1)) ||
+  node_die "expected exactly one etcd member for ${kubernetes_node_name}; found ${matched_member_count}"
+((member_count == inventory_master_count)) ||
+  node_die "inventory control-plane count (${inventory_master_count}) does not match etcd member count (${member_count})"
+((member_count >= 3)) ||
+  node_die "control-plane delete preflight requires an HA etcd cluster; member count is ${member_count}"
+
+current_quorum_size="$(node_etcd_quorum_size "$member_count")"
+post_remove_member_count=$((member_count - 1))
+post_remove_quorum_size="$(node_etcd_quorum_size "$post_remove_member_count")"
+remaining_ready_control_planes="$ready_control_plane_count"
+if node_bool "$target_ready"; then
+  remaining_ready_control_planes=$((remaining_ready_control_planes - 1))
+fi
+
+((remaining_ready_control_planes >= current_quorum_size)) ||
+  node_die "removing ${kubernetes_node_name} would leave ${remaining_ready_control_planes} Ready control-planes; current quorum is ${current_quorum_size}"
+((remaining_ready_control_planes >= post_remove_quorum_size)) ||
+  node_die "removing ${kubernetes_node_name} would leave ${remaining_ready_control_planes} Ready control-planes; post-remove quorum is ${post_remove_quorum_size}"
+
+printf 'profile: %s\n' "$profile"
+printf 'context: %s\n' "$context"
+printf 'inventory: %s\n' "$inventory_file"
+printf 'target_inventory_node: %s\n' "$inventory_node_name"
+printf 'target_kubernetes_node: %s\n' "$kubernetes_node_name"
+printf 'target_ansible_host: %s\n' "${target_ansible_host:-unknown}"
+printf 'target_ready: %s\n' "$target_ready"
+printf 'probe_inventory_node: %s\n' "$probe_inventory_node"
+printf 'inventory_control_planes: %s\n' "$(join_csv "${inventory_masters[@]}")"
+printf 'ready_control_planes: %s\n' "$(join_csv "${ready_control_planes[@]}")"
+printf 'etcd_members: %s\n' "$(join_csv "${all_member_names[@]}")"
+printf 'etcd_member_count: %s\n' "$member_count"
+printf 'etcd_current_quorum_size: %s\n' "$current_quorum_size"
+printf 'post_remove_member_count: %s\n' "$post_remove_member_count"
+printf 'post_remove_quorum_size: %s\n' "$post_remove_quorum_size"
+printf 'remaining_ready_control_planes_after_target_stop: %s\n' "$remaining_ready_control_planes"
+
+printf '\ntarget_etcd_member:\n'
+printf '  id: %s\n' "$target_member_id"
+printf '  name: %s\n' "$target_member_name"
+printf '  status: %s\n' "$target_member_status"
+printf '  peer_urls: %s\n' "$target_member_peer_urls"
+printf '  client_urls: %s\n' "$target_member_client_urls"
+printf '  is_learner: %s\n' "$target_member_is_learner"
+
+printf '\netcd_endpoint_health:\n'
+indent_block <<<"$endpoint_health"
+
+printf '\nplanned_member_remove:\n'
+printf '  run_on_inventory_node: %s\n' "$probe_inventory_node"
+printf '  command: /usr/local/bin/etcdctl --endpoints=https://127.0.0.1:2379 --cacert=/var/lib/rancher/k3s/server/tls/etcd/server-ca.crt --cert=/var/lib/rancher/k3s/server/tls/etcd/client.crt --key=/var/lib/rancher/k3s/server/tls/etcd/client.key member remove %s\n' "$target_member_id"
+
+printf '\npreflight_result: pass\n'

--- a/hack/bootstrap/nodes/control-plane-delete-preflight.sh
+++ b/hack/bootstrap/nodes/control-plane-delete-preflight.sh
@@ -169,7 +169,7 @@ printf 'etcd_member_simple_begin\n'
   --key="$etcd_tls_dir/client.key" \
   member list
 printf 'etcd_member_simple_end\n'
-printf 'etcd_endpoint_health_begin\n'
+printf 'etcd_endpoint_status_begin\n'
 "$etcdctl_path" \
   --endpoints=https://127.0.0.1:2379 \
   --dial-timeout=3s \
@@ -177,8 +177,8 @@ printf 'etcd_endpoint_health_begin\n'
   --cacert="$etcd_tls_dir/server-ca.crt" \
   --cert="$etcd_tls_dir/client.crt" \
   --key="$etcd_tls_dir/client.key" \
-  endpoint health
-printf 'etcd_endpoint_health_end\n'
+  endpoint status
+printf 'etcd_endpoint_status_end\n'
 EOF
 
 if remote_output="$(
@@ -204,9 +204,9 @@ if grep -q '^preflight_error=' <<<"$filtered_remote_output"; then
 fi
 
 member_lines="$(extract_block etcd_member_simple_begin etcd_member_simple_end <<<"$filtered_remote_output")"
-endpoint_health="$(extract_block etcd_endpoint_health_begin etcd_endpoint_health_end <<<"$filtered_remote_output")"
+endpoint_status="$(extract_block etcd_endpoint_status_begin etcd_endpoint_status_end <<<"$filtered_remote_output")"
 [[ -n "$member_lines" ]] || node_die "etcd member list was empty"
-[[ -n "$endpoint_health" ]] || node_die "etcd endpoint health output was empty"
+[[ -n "$endpoint_status" ]] || node_die "etcd endpoint status output was empty"
 
 target_member_id=""
 target_member_status=""
@@ -299,8 +299,8 @@ printf '  peer_urls: %s\n' "$target_member_peer_urls"
 printf '  client_urls: %s\n' "$target_member_client_urls"
 printf '  is_learner: %s\n' "$target_member_is_learner"
 
-printf '\netcd_endpoint_health:\n'
-indent_block <<<"$endpoint_health"
+printf '\netcd_endpoint_status:\n'
+indent_block <<<"$endpoint_status"
 
 printf '\nplanned_member_remove:\n'
 printf '  run_on_inventory_node: %s\n' "$probe_inventory_node"

--- a/hack/bootstrap/tests/offline-nodes.sh
+++ b/hack/bootstrap/tests/offline-nodes.sh
@@ -344,9 +344,9 @@ printf '70594c7c481c118, started, k3s-master-1-ff2e5a37, https://192.168.99.11:2
 printf 'c9e409fd1205cc0a, started, k3s-master-0-b8caf5ab, https://192.168.99.10:2380, https://192.168.99.10:2379, false\n'
 printf 'ee5329b5b8ee26b3, started, k3s-master-2-f7c0824c, https://192.168.99.12:2380, https://192.168.99.12:2379, false\n'
 printf 'etcd_member_simple_end\n'
-printf 'etcd_endpoint_health_begin\n'
-printf 'https://127.0.0.1:2379 is healthy: successfully committed proposal: took = 1.2ms\n'
-printf 'etcd_endpoint_health_end\n'
+printf 'etcd_endpoint_status_begin\n'
+printf 'https://127.0.0.1:2379, c9e409fd1205cc0a, 3.6.7, 20 kB, false, false, 9, 123, 123, \n'
+printf 'etcd_endpoint_status_end\n'
 EOF
 chmod +x "$fake_ansible"
 

--- a/hack/bootstrap/tests/offline-nodes.sh
+++ b/hack/bootstrap/tests/offline-nodes.sh
@@ -29,6 +29,12 @@ all:
             k3s-master-0:
               ansible_host: 192.168.99.10
               k3s_role: server
+            k3s-master-1:
+              ansible_host: 192.168.99.11
+              k3s_role: server
+            k3s-master-2:
+              ansible_host: 192.168.99.12
+              k3s_role: server
         node:
           hosts:
             k3s-worker-0:
@@ -83,7 +89,7 @@ master_count="$(
   NODE_LIVE_INVENTORY_DIR="$inventory" \
     bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_inventory_group_count live master"
 )"
-test "$master_count" = "1"
+test "$master_count" = "3"
 
 quorum_size="$(
   bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_etcd_quorum_size 3"
@@ -245,11 +251,12 @@ if [[ "${1:-}" == "get" && "${2:-}" == "--raw=/readyz" ]]; then
   exit 0
 fi
 
-if [[ "${1:-}" == "get" && "${2:-}" == "node/k3s-master-0" ]]; then
-  cat <<'JSON'
+if [[ "${1:-}" == "get" && "${2:-}" =~ ^node/k3s-master-[0-2]$ ]]; then
+  node_name="${2#node/}"
+  sed "s/__NODE_NAME__/${node_name}/g" <<'JSON'
 {
   "metadata": {
-    "name": "k3s-master-0",
+    "name": "__NODE_NAME__",
     "labels": {"node-role.kubernetes.io/control-plane": "true"}
   },
   "status": {
@@ -274,6 +281,20 @@ if [[ "${1:-}" == "get" && "${2:-}" == "nodes" ]]; then
       "status": {"conditions": [{"type": "Ready", "status": "True"}]}
     },
     {
+      "metadata": {
+        "name": "k3s-master-1",
+        "labels": {"node-role.kubernetes.io/control-plane": "true"}
+      },
+      "status": {"conditions": [{"type": "Ready", "status": "True"}]}
+    },
+    {
+      "metadata": {
+        "name": "k3s-master-2",
+        "labels": {"node-role.kubernetes.io/control-plane": "true"}
+      },
+      "status": {"conditions": [{"type": "Ready", "status": "True"}]}
+    },
+    {
       "metadata": {"name": "k3s-worker-0", "labels": {}},
       "status": {"conditions": [{"type": "Ready", "status": "True"}]}
     }
@@ -292,10 +313,40 @@ fake_ansible="${tmp}/ansible"
 cat > "$fake_ansible" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
-printf 'k3s-master-0 | CHANGED | rc=0 >>\n'
+target=""
+skip_next=false
+for arg in "$@"; do
+  if $skip_next; then
+    skip_next=false
+    continue
+  fi
+  case "$arg" in
+    -i)
+      skip_next=true
+      ;;
+    --*)
+      ;;
+    -*)
+      ;;
+    *)
+      target="$arg"
+      break
+      ;;
+  esac
+done
+target="${target:-k3s-master-0}"
+printf '%s | CHANGED | rc=0 >>\n' "$target"
 printf 'k3s_service_active=active\n'
 printf 'embedded_etcd_data=present\n'
-printf 'etcdctl=absent\n'
+printf 'etcdctl=/usr/local/bin/etcdctl\n'
+printf 'etcd_member_simple_begin\n'
+printf '70594c7c481c118, started, k3s-master-1-ff2e5a37, https://192.168.99.11:2380, https://192.168.99.11:2379, false\n'
+printf 'c9e409fd1205cc0a, started, k3s-master-0-b8caf5ab, https://192.168.99.10:2380, https://192.168.99.10:2379, false\n'
+printf 'ee5329b5b8ee26b3, started, k3s-master-2-f7c0824c, https://192.168.99.12:2380, https://192.168.99.12:2379, false\n'
+printf 'etcd_member_simple_end\n'
+printf 'etcd_endpoint_health_begin\n'
+printf 'https://127.0.0.1:2379 is healthy: successfully committed proposal: took = 1.2ms\n'
+printf 'etcd_endpoint_health_end\n'
 EOF
 chmod +x "$fake_ansible"
 
@@ -306,14 +357,29 @@ control_plane_output="$(
     "${ROOT}/hack/bootstrap/nodes/control-plane-status.sh" --profile live --context test k3s-master-0
 )"
 
-grep -q '^inventory_control_planes: k3s-master-0$' <<<"$control_plane_output"
-grep -q '^inventory_control_plane_count: 1$' <<<"$control_plane_output"
-grep -q '^ready_control_plane_count: 1$' <<<"$control_plane_output"
-grep -q '^etcd_quorum_size_from_inventory: 1$' <<<"$control_plane_output"
+grep -q '^inventory_control_planes: k3s-master-0,k3s-master-1,k3s-master-2$' <<<"$control_plane_output"
+grep -q '^inventory_control_plane_count: 3$' <<<"$control_plane_output"
+grep -q '^ready_control_plane_count: 3$' <<<"$control_plane_output"
+grep -q '^etcd_quorum_size_from_inventory: 2$' <<<"$control_plane_output"
 grep -q 'embedded_etcd_data=present' <<<"$control_plane_output"
+
+control_plane_preflight_output="$(
+  PATH="${tmp}:${PATH}" \
+  NODE_LIVE_INVENTORY_DIR="$inventory" \
+  NODE_KUBECTL_BIN="$fake_control_plane_kubectl" \
+    "${ROOT}/hack/bootstrap/nodes/control-plane-delete-preflight.sh" --profile live --context test k3s-master-0
+)"
+
+grep -q '^probe_inventory_node: k3s-master-1$' <<<"$control_plane_preflight_output"
+grep -q '^etcd_member_count: 3$' <<<"$control_plane_preflight_output"
+grep -q '^post_remove_member_count: 2$' <<<"$control_plane_preflight_output"
+grep -q '^preflight_result: pass$' <<<"$control_plane_preflight_output"
+grep -q '  id: c9e409fd1205cc0a$' <<<"$control_plane_preflight_output"
+grep -q 'member remove c9e409fd1205cc0a' <<<"$control_plane_preflight_output"
 
 "${ROOT}/hack/bootstrap/nodes/drain.sh" --help >/dev/null
 "${ROOT}/hack/bootstrap/nodes/control-plane-status.sh" --help >/dev/null
+"${ROOT}/hack/bootstrap/nodes/control-plane-delete-preflight.sh" --help >/dev/null
 "${ROOT}/hack/bootstrap/nodes/delete.sh" --help >/dev/null
 "${ROOT}/hack/bootstrap/nodes/longhorn-evict.sh" --help >/dev/null
 "${ROOT}/hack/bootstrap/nodes/join.sh" --help >/dev/null

--- a/justfile
+++ b/justfile
@@ -182,6 +182,11 @@ node-live-status node:
 node-live-control-plane-status node:
     ./hack/bootstrap/nodes/control-plane-status.sh --profile live --context default '{{ node }}'
 
+# Run read-only control-plane delete preflight for a live cluster node.
+[group('node-live')]
+node-live-control-plane-delete-preflight node:
+    ./hack/bootstrap/nodes/control-plane-delete-preflight.sh --profile live --context default '{{ node }}'
+
 # Drain a live worker node before deletion or maintenance.
 [group('node-live')]
 node-live-drain node:
@@ -296,6 +301,11 @@ node-lima-status node:
 [group('node-lima')]
 node-lima-control-plane-status node:
     ./hack/bootstrap/nodes/control-plane-status.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
+
+# Run read-only control-plane delete preflight for a Lima cluster node.
+[group('node-lima')]
+node-lima-control-plane-delete-preflight node:
+    ./hack/bootstrap/nodes/control-plane-delete-preflight.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
 
 # Drain a Lima worker node before deletion or maintenance.
 [group('node-lima')]


### PR DESCRIPTION
## Summary
- add a read-only control-plane delete preflight that queries etcd from an alternate Ready control-plane
- map the target Kubernetes node to exactly one etcd member and print the future member-remove command without running it
- document and test the new live/Lima just recipes

## Validation
- shellcheck hack/bootstrap/nodes/control-plane-delete-preflight.sh hack/bootstrap/tests/offline-nodes.sh
- hack/bootstrap/tests/offline-nodes.sh
- just bootstrap-test
- pre-commit run --files justfile docs/just-bootstrap.md hack/bootstrap/README.md hack/bootstrap/tests/offline-nodes.sh hack/bootstrap/nodes/control-plane-delete-preflight.sh
- just node-live-control-plane-delete-preflight k3s-master-0
- just node-live-control-plane-delete-preflight k3s-master-1
- just node-live-control-plane-delete-preflight k3s-master-2