### PR TITLE
fix: harden Longhorn node deletion cleanup

### DIFF
--- a/hack/bootstrap/nodes/control-plane-delete.sh
+++ b/hack/bootstrap/nodes/control-plane-delete.sh
@@ -42,6 +42,23 @@ extract_block() {
   '
 }
 
+contains_line() {
+  local needle="$1"
+  shift
+  local value
+  for value in "$@"; do
+    [[ "$value" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s\n' "$value"
+}
+
 parse_preflight_scalar() {
   local key="$1"
   awk -v key="$key" '
@@ -63,6 +80,100 @@ parse_preflight_target_member_id() {
     }
     inside && NF == 0 {inside = 0}
   '
+}
+
+assert_etcd_member_absent() {
+  local profile="$1"
+  local context="$2"
+  local inventory_node_name="$3"
+  local kubernetes_node_name="$4"
+  local inventory_file="$5"
+  local target_ansible_host probe_inventory_node probe_kubernetes_node remote_member_list
+  local remote_output filtered_remote_output member_lines member_line
+  local _member_id _member_status member_name member_peer_urls member_client_urls _member_is_learner _
+  local matched_member_count=0
+  local -a inventory_masters ready_control_planes
+
+  target_ansible_host="$(node_inventory_value "$profile" "$inventory_node_name" ansible_host 2>/dev/null || true)"
+  mapfile -t inventory_masters < <(node_inventory_group_names "$profile" master)
+  mapfile -t ready_control_planes < <(node_ready_control_planes "$context")
+
+  probe_inventory_node=""
+  for inventory_master in "${inventory_masters[@]}"; do
+    probe_kubernetes_node="$(node_expected_kubernetes_node_name "$profile" "$inventory_master" "$inventory_master")"
+    if [[ "$probe_kubernetes_node" != "$kubernetes_node_name" ]] &&
+      contains_line "$probe_kubernetes_node" "${ready_control_planes[@]}"; then
+      probe_inventory_node="$inventory_master"
+      break
+    fi
+  done
+  [[ -n "$probe_inventory_node" ]] ||
+    node_die "no alternate Ready control-plane node is available to verify etcd membership"
+
+  read -r -d '' remote_member_list <<'EOF' || true
+set -eu
+
+etcd_tls_dir=/var/lib/rancher/k3s/server/tls/etcd
+etcdctl_path="$(command -v etcdctl 2>/dev/null || true)"
+if [ -z "$etcdctl_path" ]; then
+  printf 'member_list_error=etcdctl_absent\n'
+  exit 2
+fi
+
+for cert_file in server-ca.crt client.crt client.key; do
+  if [ ! -f "$etcd_tls_dir/$cert_file" ]; then
+    printf 'member_list_error=missing_etcd_cert:%s\n' "$cert_file"
+    exit 2
+  fi
+done
+
+printf 'etcd_member_simple_begin\n'
+"$etcdctl_path" \
+  --endpoints=https://127.0.0.1:2379 \
+  --dial-timeout=3s \
+  --command-timeout=5s \
+  --cacert="$etcd_tls_dir/server-ca.crt" \
+  --cert="$etcd_tls_dir/client.crt" \
+  --key="$etcd_tls_dir/client.key" \
+  member list
+printf 'etcd_member_simple_end\n'
+EOF
+
+  node_log "verifying ${kubernetes_node_name} is absent from etcd membership using ${probe_inventory_node}"
+  remote_output="$(run_remote_shell "$inventory_file" "$probe_inventory_node" "$remote_member_list")" ||
+    node_die "failed to verify etcd membership from ${probe_inventory_node}"
+  filtered_remote_output="$remote_output"
+
+  if grep -q '^member_list_error=' <<<"$filtered_remote_output"; then
+    printf 'remote_probe:\n'
+    indent_block <<<"$filtered_remote_output"
+    node_die "etcd member-list probe reported an error"
+  fi
+
+  member_lines="$(extract_block etcd_member_simple_begin etcd_member_simple_end <<<"$filtered_remote_output")"
+  [[ -n "$member_lines" ]] || node_die "etcd member list was empty"
+
+  while IFS= read -r member_line; do
+    [[ -n "$member_line" ]] || continue
+    IFS=',' read -r _member_id _member_status member_name member_peer_urls member_client_urls _member_is_learner _ <<<"$member_line"
+    member_name="$(trim "$member_name")"
+    member_peer_urls="$(trim "$member_peer_urls")"
+    member_client_urls="$(trim "$member_client_urls")"
+
+    if [[ "$member_name" == "$kubernetes_node_name" ||
+      "$member_name" == "$inventory_node_name" ||
+      "$member_name" == "${kubernetes_node_name}-"* ||
+      "$member_name" == "${inventory_node_name}-"* ]]; then
+      ((matched_member_count += 1))
+    elif [[ -n "$target_ansible_host" &&
+      ("$member_peer_urls" == *"://${target_ansible_host}:"* ||
+        "$member_client_urls" == *"://${target_ansible_host}:"*) ]]; then
+      ((matched_member_count += 1))
+    fi
+  done <<<"$member_lines"
+
+  ((matched_member_count == 0)) ||
+    node_die "refusing deleted-node cleanup because etcd still has ${matched_member_count} member(s) for ${kubernetes_node_name}"
 }
 
 run_remote_shell() {
@@ -145,7 +256,16 @@ fi
 
 node_assert_api_reachable "$context"
 node_json="$(node_node_json_if_present "$context" "$kubernetes_node_name")"
-[[ -n "$node_json" ]] || node_die "Kubernetes node is already absent: ${kubernetes_node_name}"
+if [[ -z "$node_json" ]]; then
+  node_confirm "$yes" "clean up deleted control-plane node state ${kubernetes_node_name} from ${context}"
+  node_log "stopping k3s server on ${inventory_node_name} before deleted-node cleanup"
+  node_stop_k3s_server "$profile" "$inventory_node_name"
+  assert_etcd_member_absent "$profile" "$context" "$inventory_node_name" "$kubernetes_node_name" "$inventory_file"
+  node_cleanup_pods_for_deleted_node "$context" "$kubernetes_node_name"
+  node_cleanup_longhorn_deleted_node "$context" "$kubernetes_node_name"
+  node_log "control-plane delete cleanup complete: ${kubernetes_node_name}"
+  exit 0
+fi
 node_assert_kubernetes_control_plane "$node_json" "$kubernetes_node_name"
 node_assert_cordoned "$node_json" "$kubernetes_node_name"
 node_assert_no_ordinary_pods "$context" "$kubernetes_node_name"
@@ -274,5 +394,5 @@ node_kubectl "$context" delete "node/${kubernetes_node_name}" --wait=false
 node_kubectl "$context" -n kube-system delete "secret/${kubernetes_node_name}.node-password.k3s" --ignore-not-found
 node_wait_for_node_absent "$context" "$kubernetes_node_name"
 node_cleanup_pods_for_deleted_node "$context" "$kubernetes_node_name"
-node_wait_for_longhorn_node_absent "$context" "$kubernetes_node_name"
+node_cleanup_longhorn_deleted_node "$context" "$kubernetes_node_name"
 node_log "control-plane delete complete: ${kubernetes_node_name}"

--- a/hack/bootstrap/nodes/delete.sh
+++ b/hack/bootstrap/nodes/delete.sh
@@ -74,7 +74,15 @@ kubernetes_node_name="$(node_expected_kubernetes_node_name "$profile" "$inventor
 
 node_assert_api_reachable "$context"
 node_json="$(node_node_json_if_present "$context" "$kubernetes_node_name")"
-[[ -n "$node_json" ]] || node_die "Kubernetes node is already absent: ${kubernetes_node_name}"
+if [[ -z "$node_json" ]]; then
+  node_confirm "$yes" "clean up deleted node state ${kubernetes_node_name} from ${context}"
+  node_log "stopping k3s agent on ${inventory_node_name} before deleted-node cleanup"
+  node_stop_k3s_agent "$profile" "$inventory_node_name"
+  node_cleanup_pods_for_deleted_node "$context" "$kubernetes_node_name"
+  node_cleanup_longhorn_deleted_node "$context" "$kubernetes_node_name"
+  node_log "delete cleanup complete: ${kubernetes_node_name}"
+  exit 0
+fi
 node_assert_kubernetes_worker "$node_json" "$kubernetes_node_name"
 node_assert_cordoned "$node_json" "$kubernetes_node_name"
 node_assert_no_ordinary_pods "$context" "$kubernetes_node_name"
@@ -89,5 +97,5 @@ node_kubectl "$context" delete "node/${kubernetes_node_name}" --wait=false
 node_kubectl "$context" -n kube-system delete "secret/${kubernetes_node_name}.node-password.k3s" --ignore-not-found
 node_wait_for_node_absent "$context" "$kubernetes_node_name"
 node_cleanup_pods_for_deleted_node "$context" "$kubernetes_node_name"
-node_wait_for_longhorn_node_absent "$context" "$kubernetes_node_name"
+node_cleanup_longhorn_deleted_node "$context" "$kubernetes_node_name"
 node_log "delete complete: ${kubernetes_node_name}"

--- a/hack/bootstrap/nodes/lib.sh
+++ b/hack/bootstrap/nodes/lib.sh
@@ -819,6 +819,34 @@ node_longhorn_attached_volumes_on_node() {
   ' <<<"$volumes_json"
 }
 
+node_longhorn_volume_delete_blockers() {
+  local context="$1"
+  local node="$2"
+  local volumes_json
+
+  volumes_json="$(node_get_json "$context" -n longhorn-system volumes.longhorn.io 2>/dev/null || true)"
+  [[ -n "$volumes_json" ]] || {
+    printf 'Longhorn volumes not readable\n'
+    return 0
+  }
+
+  # shellcheck disable=SC2016
+  "$NODE_JQ_BIN" -r --arg node "$node" '
+    [
+      .items[]
+      | {
+          name: .metadata.name,
+          state: (.status.state // "unknown"),
+          robustness: (.status.robustness // "unknown"),
+          specNode: (.spec.nodeID // ""),
+          currentNode: (.status.currentNodeID // "")
+        }
+      | select(.specNode == $node or .currentNode == $node)
+      | "\(.name) state=\(.state) robustness=\(.robustness) specNode=\(.specNode) currentNode=\(.currentNode) reason=volume-still-targets-node"
+    ] | .[]
+  ' <<<"$volumes_json"
+}
+
 node_longhorn_volume_problems() {
   local context="$1"
   local volumes_json
@@ -1002,6 +1030,101 @@ node_longhorn_replica_delete_blockers() {
       else
         empty
       end
+  ' <<<"$replicas_json"
+}
+
+node_longhorn_engine_delete_blockers() {
+  local context="$1"
+  local node="$2"
+  local engines_json
+
+  engines_json="$(node_get_json "$context" -n longhorn-system engines.longhorn.io 2>/dev/null || true)"
+  [[ -n "$engines_json" ]] || {
+    printf 'Longhorn engines not readable\n'
+    return 0
+  }
+
+  # shellcheck disable=SC2016
+  "$NODE_JQ_BIN" -r --arg node "$node" '
+    [
+      .items[]
+      | {
+          name: .metadata.name,
+          volume: (.spec.volumeName // .metadata.labels.longhornvolume // ""),
+          state: (.status.currentState // .status.state // "unknown"),
+          desireState: (.spec.desireState // ""),
+          specNode: (.spec.nodeID // ""),
+          currentNode: (.status.currentNodeID // ""),
+          ownerNode: (.status.ownerID // "")
+        }
+      | select(.specNode == $node or .currentNode == $node or .ownerNode == $node)
+      | "\(.name) volume=\(.volume) state=\(.state) desired=\(.desireState) specNode=\(.specNode) currentNode=\(.currentNode) owner=\(.ownerNode) reason=engine-still-targets-node"
+    ] | .[]
+  ' <<<"$engines_json"
+}
+
+node_longhorn_safe_stale_replicas_for_deleted_node() {
+  local context="$1"
+  local node="$2"
+  local replicas_json volumes_json
+
+  replicas_json="$(node_get_json "$context" -n longhorn-system replicas.longhorn.io 2>/dev/null || true)"
+  [[ -n "$replicas_json" ]] || {
+    printf 'Longhorn replicas not readable\n'
+    return 0
+  }
+
+  volumes_json="$(node_get_json "$context" -n longhorn-system volumes.longhorn.io 2>/dev/null || true)"
+  [[ -n "$volumes_json" ]] || {
+    printf 'Longhorn volumes not readable\n'
+    return 0
+  }
+
+  # Keep this predicate in lockstep with node_longhorn_replica_delete_blockers.
+  # These replicas are safe to delete only after the Kubernetes node is gone.
+  # shellcheck disable=SC2016
+  "$NODE_JQ_BIN" -r --arg node "$node" --slurpfile volumes <(printf '%s\n' "$volumes_json") '
+    ($volumes[0].items // []) as $volume_items |
+    def node_id:
+      (.spec.nodeID // .status.currentNodeID // .metadata.labels.longhornnode // "");
+    def volume_name:
+      (.spec.volumeName // .metadata.labels.longhornvolume // "");
+    def replica_state:
+      (.status.currentState // .status.state // "unknown");
+    def desire_state:
+      (.spec.desireState // "");
+    def failed_at:
+      (.spec.failedAt // .status.failedAt // "");
+    def healthy_at:
+      (.spec.healthyAt // .status.healthyAt // "");
+    def healthy_replica:
+      failed_at == "" and
+      healthy_at != "" and
+      (replica_state == "running" or replica_state == "stopped");
+    def running_replica:
+      replica_state == "running" or
+      (.status.started // false) == true or
+      ((.status.instanceManagerName // "") != "");
+    def volume_by_name($name):
+      first($volume_items[]? | select(.metadata.name == $name)) // null;
+    (.items // []) as $all_replicas |
+    $all_replicas[]
+    | select(node_id == $node)
+    | . as $replica
+    | (volume_name) as $volume_name
+    | (volume_by_name($volume_name)) as $volume
+    | ($volume.spec.numberOfReplicas // 1 | tonumber? // 1) as $desired_replicas
+    | ([ $all_replicas[]
+        | select(volume_name == $volume_name)
+        | select(node_id != $node)
+        | select(healthy_replica)
+      ] | length) as $healthy_elsewhere
+    | select($volume != null)
+    | select(running_replica | not)
+    | select(replica_state == "stopped")
+    | select(desire_state == "stopped")
+    | select($healthy_elsewhere >= $desired_replicas)
+    | .metadata.name
   ' <<<"$replicas_json"
 }
 
@@ -1212,13 +1335,15 @@ node_assert_longhorn_empty_for_delete() {
     {
       node_longhorn_scheduling_problem "$context" "$node"
       node_longhorn_attached_volumes_on_node "$context" "$node"
+      node_longhorn_volume_delete_blockers "$context" "$node"
+      node_longhorn_engine_delete_blockers "$context" "$node"
       node_longhorn_replica_delete_blockers "$context" "$node"
     } | sed '/^$/d'
   )"
 
   if [[ -n "$problems" ]]; then
     printf '%s\n' "$problems" >&2
-    node_die "Longhorn still has target-node state; run the explicit Longhorn eviction helper before deleting ${node}"
+    node_die "Longhorn still has target-node state; run the explicit Longhorn eviction helper before deleting ${node}, or wait for reported deleted-node blockers to clear before resuming cleanup"
   fi
 }
 
@@ -1331,6 +1456,65 @@ node_wait_for_longhorn_node_absent() {
     ((SECONDS < deadline)) || node_die "timed out waiting for Longhorn node deletion: ${node}"
     sleep 5
   done
+}
+
+node_wait_for_longhorn_replicas_absent() {
+  local context="$1"
+  local node="$2"
+  local timeout="${3:-300}"
+  local deadline=$((SECONDS + timeout))
+  local replicas
+
+  while true; do
+    replicas="$(node_longhorn_replicas_on_node "$context" "$node" | sed '/^$/d')"
+    if [[ -z "$replicas" ]]; then
+      return 0
+    fi
+    ((SECONDS < deadline)) || {
+      printf '%s\n' "$replicas" >&2
+      node_die "timed out waiting for Longhorn replicas to disappear from deleted node: ${node}"
+    }
+    sleep 5
+  done
+}
+
+node_cleanup_longhorn_deleted_node() {
+  local context="$1"
+  local node="$2"
+  local timeout="${3:-300}"
+  local state stale_replicas replica
+
+  state="$(node_assert_longhorn_discovery "$context")"
+  if [[ "$state" == absent ]]; then
+    return
+  fi
+
+  if node_has_resource "$context" "node/${node}"; then
+    node_die "refusing to clean Longhorn deleted-node state while Kubernetes node still exists: ${node}"
+  fi
+
+  if ! node_has_resource "$context" -n longhorn-system "nodes.longhorn.io/${node}"; then
+    return
+  fi
+
+  node_assert_longhorn_empty_for_delete "$context" "$node"
+  stale_replicas="$(node_longhorn_safe_stale_replicas_for_deleted_node "$context" "$node" | sed '/^$/d')"
+  if [[ -n "$stale_replicas" ]]; then
+    while IFS= read -r replica; do
+      [[ -n "$replica" ]] || continue
+      node_log "deleting safe stale Longhorn replica ${replica} from deleted node ${node}"
+      node_kubectl "$context" -n longhorn-system delete replicas.longhorn.io "$replica" \
+        --wait=false \
+        --ignore-not-found
+    done <<<"$stale_replicas"
+    node_wait_for_longhorn_replicas_absent "$context" "$node" "$timeout"
+  fi
+
+  node_log "deleting Longhorn node resource for deleted node ${node}"
+  node_kubectl "$context" -n longhorn-system delete "nodes.longhorn.io/${node}" \
+    --wait=false \
+    --ignore-not-found
+  node_wait_for_longhorn_node_absent "$context" "$node" "$timeout"
 }
 
 node_longhorn_uncordon_problems() {

--- a/hack/bootstrap/tests/offline-nodes.sh
+++ b/hack/bootstrap/tests/offline-nodes.sh
@@ -417,13 +417,20 @@ if [[ "$joined_args" == *"member remove"* ]]; then
   exit 0
 fi
 
+removed_member_id="${FAKE_ETCD_ABSENT_MEMBER_ID:-}"
 printf 'k3s_service_active=active\n'
 printf 'embedded_etcd_data=present\n'
 printf 'etcdctl=/usr/local/bin/etcdctl\n'
 printf 'etcd_member_simple_begin\n'
-printf '70594c7c481c118, started, k3s-master-1-ff2e5a37, https://192.168.99.11:2380, https://192.168.99.11:2379, false\n'
-printf 'c9e409fd1205cc0a, started, k3s-master-0-b8caf5ab, https://192.168.99.10:2380, https://192.168.99.10:2379, false\n'
-printf 'ee5329b5b8ee26b3, started, k3s-master-2-f7c0824c, https://192.168.99.12:2380, https://192.168.99.12:2379, false\n'
+if [[ "$removed_member_id" != "70594c7c481c118" ]]; then
+  printf '70594c7c481c118, started, k3s-master-1-ff2e5a37, https://192.168.99.11:2380, https://192.168.99.11:2379, false\n'
+fi
+if [[ "$removed_member_id" != "c9e409fd1205cc0a" ]]; then
+  printf 'c9e409fd1205cc0a, started, k3s-master-0-b8caf5ab, https://192.168.99.10:2380, https://192.168.99.10:2379, false\n'
+fi
+if [[ "$removed_member_id" != "ee5329b5b8ee26b3" ]]; then
+  printf 'ee5329b5b8ee26b3, started, k3s-master-2-f7c0824c, https://192.168.99.12:2380, https://192.168.99.12:2379, false\n'
+fi
 printf 'etcd_member_simple_end\n'
 printf 'etcd_endpoint_status_begin\n'
 printf 'https://127.0.0.1:2379, c9e409fd1205cc0a, 3.6.7, 20 kB, false, false, 9, 123, 123, \n'
@@ -491,6 +498,189 @@ grep -q 'snapshot_name=pre-remove-k3s-master-1-' <<<"$control_plane_delete_outpu
 grep -q 'Member 70594c7c481c118 removed from cluster' <<<"$control_plane_delete_output"
 grep -q 'node "k3s-master-1" deleted' <<<"$control_plane_delete_output"
 grep -q 'control-plane delete complete: k3s-master-1' <<<"$control_plane_delete_output"
+
+control_plane_cleanup_output="$(
+  PATH="${tmp}:${PATH}" \
+  FAKE_KUBECTL_STATE_DIR="${tmp}/control-plane-state" \
+  FAKE_ETCD_ABSENT_MEMBER_ID=70594c7c481c118 \
+  NODE_LIVE_INVENTORY_DIR="$inventory" \
+  NODE_KUBECTL_BIN="$fake_control_plane_kubectl" \
+    "${ROOT}/hack/bootstrap/nodes/delete.sh" --profile live --context test --yes k3s-master-1
+)"
+
+grep -q 'stopping k3s server on k3s-master-1 before deleted-node cleanup' <<<"$control_plane_cleanup_output"
+grep -q 'verifying k3s-master-1 is absent from etcd membership using k3s-master-0' <<<"$control_plane_cleanup_output"
+grep -q 'control-plane delete cleanup complete: k3s-master-1' <<<"$control_plane_cleanup_output"
+
+fake_longhorn_kubectl="${tmp}/kubectl-longhorn"
+cat > "$fake_longhorn_kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--context" ]]; then
+  shift 2
+fi
+
+state_dir="${FAKE_KUBECTL_STATE_DIR:?}"
+mode="${FAKE_LONGHORN_MODE:-cleanup}"
+
+if [[ "${1:-}" == "get" && "${2:-}" == "--raw=/readyz" ]]; then
+  printf 'ok\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "crd" && "${3:-}" == "volumes.longhorn.io" ]]; then
+  printf '{"metadata":{"name":"volumes.longhorn.io"}}\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "node/deleted-node" ]]; then
+  printf 'Error from server (NotFound): nodes "deleted-node" not found\n' >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "-n" && "${3:-}" == "longhorn-system" && "${4:-}" == "nodes.longhorn.io/deleted-node" ]]; then
+  if [[ -f "${state_dir}/longhorn-node-deleted" ]]; then
+    printf 'Error from server (NotFound): nodes.longhorn.io "deleted-node" not found\n' >&2
+    exit 1
+  fi
+  cat <<'JSON'
+{
+  "metadata": {"name": "deleted-node"},
+  "spec": {"allowScheduling": false, "evictionRequested": true},
+  "status": {
+    "conditions": [
+      {"type": "Ready", "status": "False", "reason": "KubernetesNodeGone"},
+      {"type": "Schedulable", "status": "False", "reason": "KubernetesNodeCordoned"}
+    ]
+  }
+}
+JSON
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "-n" && "${3:-}" == "longhorn-system" && "${4:-}" == "volumes.longhorn.io" ]]; then
+  if [[ "$mode" == blockers ]]; then
+    cat <<'JSON'
+{
+  "items": [
+    {
+      "metadata": {"name": "volume-a"},
+      "spec": {"numberOfReplicas": 2, "nodeID": "deleted-node"},
+      "status": {"state": "attaching", "robustness": "unknown", "currentNodeID": ""}
+    }
+  ]
+}
+JSON
+  else
+    cat <<'JSON'
+{
+  "items": [
+    {
+      "metadata": {"name": "volume-a"},
+      "spec": {"numberOfReplicas": 2, "nodeID": "other-a"},
+      "status": {"state": "attached", "robustness": "healthy", "currentNodeID": "other-a"}
+    }
+  ]
+}
+JSON
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "-n" && "${3:-}" == "longhorn-system" && "${4:-}" == "engines.longhorn.io" ]]; then
+  if [[ "$mode" == blockers ]]; then
+    cat <<'JSON'
+{
+  "items": [
+    {
+      "metadata": {"name": "volume-a-e-0"},
+      "spec": {"volumeName": "volume-a", "nodeID": "deleted-node", "desireState": "running"},
+      "status": {"currentState": "stopped", "currentNodeID": "", "ownerID": "other-a"}
+    },
+    {
+      "metadata": {"name": "volume-b-e-0"},
+      "spec": {"volumeName": "volume-b", "nodeID": "other-a", "desireState": "running"},
+      "status": {"currentState": "stopped", "currentNodeID": "", "ownerID": "deleted-node"}
+    }
+  ]
+}
+JSON
+  else
+    printf '{"items":[]}\n'
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "-n" && "${3:-}" == "longhorn-system" && "${4:-}" == "replicas.longhorn.io" ]]; then
+  if [[ -f "${state_dir}/stale-replica-deleted" || "$mode" == blockers ]]; then
+    printf '{"items":[]}\n'
+  else
+    cat <<'JSON'
+{
+  "items": [
+    {
+      "metadata": {"name": "stale-replica", "labels": {"longhornnode": "deleted-node", "longhornvolume": "volume-a"}},
+      "spec": {"nodeID": "deleted-node", "volumeName": "volume-a", "desireState": "stopped", "failedAt": "2026-05-12T00:00:00Z"},
+      "status": {"currentState": "stopped", "started": false, "instanceManagerName": "", "healthyAt": "2026-05-11T00:00:00Z"}
+    },
+    {
+      "metadata": {"name": "healthy-a", "labels": {"longhornnode": "other-a", "longhornvolume": "volume-a"}},
+      "spec": {"nodeID": "other-a", "volumeName": "volume-a", "desireState": "running", "failedAt": "", "healthyAt": "2026-05-12T00:00:00Z"},
+      "status": {"currentState": "running", "started": true, "instanceManagerName": "im-a"}
+    },
+    {
+      "metadata": {"name": "healthy-b", "labels": {"longhornnode": "other-b", "longhornvolume": "volume-a"}},
+      "spec": {"nodeID": "other-b", "volumeName": "volume-a", "desireState": "running", "failedAt": "", "healthyAt": "2026-05-12T00:00:00Z"},
+      "status": {"currentState": "running", "started": true, "instanceManagerName": "im-b"}
+    }
+  ]
+}
+JSON
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "-n" && "${2:-}" == "longhorn-system" && "${3:-}" == "delete" && "${4:-}" == "replicas.longhorn.io" && "${5:-}" == "stale-replica" ]]; then
+  touch "${state_dir}/stale-replica-deleted"
+  printf 'replica.longhorn.io "stale-replica" deleted\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "-n" && "${2:-}" == "longhorn-system" && "${3:-}" == "delete" && "${4:-}" == "nodes.longhorn.io/deleted-node" ]]; then
+  [[ -f "${state_dir}/stale-replica-deleted" ]] || exit 1
+  touch "${state_dir}/longhorn-node-deleted"
+  printf 'node.longhorn.io "deleted-node" deleted\n'
+  exit 0
+fi
+
+printf 'unexpected fake Longhorn kubectl args: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$fake_longhorn_kubectl"
+
+mkdir -p "${tmp}/longhorn-state"
+longhorn_cleanup_output="$(
+  FAKE_KUBECTL_STATE_DIR="${tmp}/longhorn-state" \
+  NODE_KUBECTL_BIN="$fake_longhorn_kubectl" \
+    bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_cleanup_longhorn_deleted_node test deleted-node 1"
+)"
+grep -q 'deleting safe stale Longhorn replica stale-replica' <<<"$longhorn_cleanup_output"
+grep -q 'replica.longhorn.io "stale-replica" deleted' <<<"$longhorn_cleanup_output"
+grep -q 'node.longhorn.io "deleted-node" deleted' <<<"$longhorn_cleanup_output"
+
+if FAKE_KUBECTL_STATE_DIR="${tmp}/longhorn-state" \
+  FAKE_LONGHORN_MODE=blockers \
+  NODE_KUBECTL_BIN="$fake_longhorn_kubectl" \
+  bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_assert_longhorn_empty_for_delete test deleted-node" \
+  >"${tmp}/longhorn-blockers.out" \
+  2>"${tmp}/longhorn-blockers.err"; then
+  echo "expected Longhorn target-node blockers to fail delete safety" >&2
+  exit 1
+fi
+grep -q 'reason=volume-still-targets-node' "${tmp}/longhorn-blockers.err"
+grep -q 'reason=engine-still-targets-node' "${tmp}/longhorn-blockers.err"
+grep -q 'volume-b-e-0.*owner=deleted-node.*reason=engine-still-targets-node' "${tmp}/longhorn-blockers.err"
 
 if PATH="${tmp}:${PATH}" \
   NODE_LIVE_INVENTORY_DIR="$inventory" \
@@ -571,6 +761,11 @@ JSON
 }
 JSON
   fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "-n" && "${3:-}" == "longhorn-system" && "${4:-}" == "engines.longhorn.io" ]]; then
+  printf '{"items":[]}\n'
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- make worker/control-plane delete cleanup resumable only after stopping K3s again
- verify deleted control-plane nodes are absent from etcd before Longhorn cleanup
- block Longhorn cleanup when volumes or engines still target the removed node, including engine ownerID
- delete only safe stale stopped replicas before deleting the Longhorn node CR

## Validation
- shellcheck hack/bootstrap/nodes/lib.sh hack/bootstrap/nodes/delete.sh hack/bootstrap/nodes/control-plane-delete.sh hack/bootstrap/tests/offline-nodes.sh
- hack/bootstrap/tests/offline-nodes.sh
- just bootstrap-test
- pre-commit run --files hack/bootstrap/nodes/lib.sh hack/bootstrap/nodes/delete.sh hack/bootstrap/nodes/control-plane-delete.sh hack/bootstrap/tests/offline-nodes.sh
- live Lima recipe rerun: stops deleted control-plane k3s, verifies etcd absence, then fails hard on remaining Longhorn volume/engine blockers