### PR TITLE
refactor: reuse control-plane delete helpers

### DIFF
--- a/hack/bootstrap/nodes/control-plane-delete.sh
+++ b/hack/bootstrap/nodes/control-plane-delete.sh
@@ -16,49 +16,6 @@ Options:
 EOF
 }
 
-indent_block() {
-  while IFS= read -r line; do
-    printf '  %s\n' "$line"
-  done
-}
-
-filter_ansible_probe_output() {
-  local host="$1"
-  awk -v host="$host" '
-    $0 == host " | CHANGED | rc=0 >>" {next}
-    $0 == host " | SUCCESS | rc=0 >>" {next}
-    /^\[WARNING\]: / {next}
-    {print}
-  '
-}
-
-extract_block() {
-  local begin="$1"
-  local end="$2"
-  awk -v begin="$begin" -v end="$end" '
-    $0 == begin {inside = 1; next}
-    $0 == end {inside = 0}
-    inside {print}
-  '
-}
-
-contains_line() {
-  local needle="$1"
-  shift
-  local value
-  for value in "$@"; do
-    [[ "$value" == "$needle" ]] && return 0
-  done
-  return 1
-}
-
-trim() {
-  local value="$1"
-  value="${value#"${value%%[![:space:]]*}"}"
-  value="${value%"${value##*[![:space:]]}"}"
-  printf '%s\n' "$value"
-}
-
 parse_preflight_scalar() {
   local key="$1"
   awk -v key="$key" '
@@ -80,124 +37,6 @@ parse_preflight_target_member_id() {
     }
     inside && NF == 0 {inside = 0}
   '
-}
-
-assert_etcd_member_absent() {
-  local profile="$1"
-  local context="$2"
-  local inventory_node_name="$3"
-  local kubernetes_node_name="$4"
-  local inventory_file="$5"
-  local target_ansible_host probe_inventory_node probe_kubernetes_node remote_member_list
-  local remote_output filtered_remote_output member_lines member_line
-  local _member_id _member_status member_name member_peer_urls member_client_urls _member_is_learner _
-  local matched_member_count=0
-  local -a inventory_masters ready_control_planes
-
-  target_ansible_host="$(node_inventory_value "$profile" "$inventory_node_name" ansible_host 2>/dev/null || true)"
-  mapfile -t inventory_masters < <(node_inventory_group_names "$profile" master)
-  mapfile -t ready_control_planes < <(node_ready_control_planes "$context")
-
-  probe_inventory_node=""
-  for inventory_master in "${inventory_masters[@]}"; do
-    probe_kubernetes_node="$(node_expected_kubernetes_node_name "$profile" "$inventory_master" "$inventory_master")"
-    if [[ "$probe_kubernetes_node" != "$kubernetes_node_name" ]] &&
-      contains_line "$probe_kubernetes_node" "${ready_control_planes[@]}"; then
-      probe_inventory_node="$inventory_master"
-      break
-    fi
-  done
-  [[ -n "$probe_inventory_node" ]] ||
-    node_die "no alternate Ready control-plane node is available to verify etcd membership"
-
-  read -r -d '' remote_member_list <<'EOF' || true
-set -eu
-
-etcd_tls_dir=/var/lib/rancher/k3s/server/tls/etcd
-etcdctl_path="$(command -v etcdctl 2>/dev/null || true)"
-if [ -z "$etcdctl_path" ]; then
-  printf 'member_list_error=etcdctl_absent\n'
-  exit 2
-fi
-
-for cert_file in server-ca.crt client.crt client.key; do
-  if [ ! -f "$etcd_tls_dir/$cert_file" ]; then
-    printf 'member_list_error=missing_etcd_cert:%s\n' "$cert_file"
-    exit 2
-  fi
-done
-
-printf 'etcd_member_simple_begin\n'
-"$etcdctl_path" \
-  --endpoints=https://127.0.0.1:2379 \
-  --dial-timeout=3s \
-  --command-timeout=5s \
-  --cacert="$etcd_tls_dir/server-ca.crt" \
-  --cert="$etcd_tls_dir/client.crt" \
-  --key="$etcd_tls_dir/client.key" \
-  member list
-printf 'etcd_member_simple_end\n'
-EOF
-
-  node_log "verifying ${kubernetes_node_name} is absent from etcd membership using ${probe_inventory_node}"
-  remote_output="$(run_remote_shell "$inventory_file" "$probe_inventory_node" "$remote_member_list")" ||
-    node_die "failed to verify etcd membership from ${probe_inventory_node}"
-  filtered_remote_output="$remote_output"
-
-  if grep -q '^member_list_error=' <<<"$filtered_remote_output"; then
-    printf 'remote_probe:\n'
-    indent_block <<<"$filtered_remote_output"
-    node_die "etcd member-list probe reported an error"
-  fi
-
-  member_lines="$(extract_block etcd_member_simple_begin etcd_member_simple_end <<<"$filtered_remote_output")"
-  [[ -n "$member_lines" ]] || node_die "etcd member list was empty"
-
-  while IFS= read -r member_line; do
-    [[ -n "$member_line" ]] || continue
-    IFS=',' read -r _member_id _member_status member_name member_peer_urls member_client_urls _member_is_learner _ <<<"$member_line"
-    member_name="$(trim "$member_name")"
-    member_peer_urls="$(trim "$member_peer_urls")"
-    member_client_urls="$(trim "$member_client_urls")"
-
-    if [[ "$member_name" == "$kubernetes_node_name" ||
-      "$member_name" == "$inventory_node_name" ||
-      "$member_name" == "${kubernetes_node_name}-"* ||
-      "$member_name" == "${inventory_node_name}-"* ]]; then
-      ((matched_member_count += 1))
-    elif [[ -n "$target_ansible_host" &&
-      ("$member_peer_urls" == *"://${target_ansible_host}:"* ||
-        "$member_client_urls" == *"://${target_ansible_host}:"*) ]]; then
-      ((matched_member_count += 1))
-    fi
-  done <<<"$member_lines"
-
-  ((matched_member_count == 0)) ||
-    node_die "refusing deleted-node cleanup because etcd still has ${matched_member_count} member(s) for ${kubernetes_node_name}"
-}
-
-run_remote_shell() {
-  local inventory_file="$1"
-  local inventory_node="$2"
-  local remote_script="$3"
-  local output filtered_output
-
-  if output="$(
-    ANSIBLE_HOST_KEY_CHECKING=False \
-    ANSIBLE_PYTHON_INTERPRETER=auto_silent \
-      ansible -i "$inventory_file" "$inventory_node" \
-        --become \
-        -m ansible.builtin.shell \
-        -a "$remote_script" 2>&1
-  )"; then
-    filter_ansible_probe_output "$inventory_node" <<<"$output"
-    return 0
-  fi
-
-  filtered_output="$(filter_ansible_probe_output "$inventory_node" <<<"$output")"
-  printf 'remote_probe:\n'
-  indent_block <<<"$filtered_output"
-  return 1
 }
 
 profile=live
@@ -257,7 +96,12 @@ if [[ -z "$node_json" ]]; then
   node_confirm "$yes" "clean up deleted control-plane node state ${kubernetes_node_name} from ${context}"
   node_log "stopping k3s server on ${inventory_node_name} before deleted-node cleanup"
   node_stop_k3s_server "$profile" "$inventory_node_name"
-  assert_etcd_member_absent "$profile" "$context" "$inventory_node_name" "$kubernetes_node_name" "$inventory_file"
+  node_assert_control_plane_etcd_member_absent \
+    "$profile" \
+    "$context" \
+    "$inventory_node_name" \
+    "$kubernetes_node_name" \
+    "refusing deleted-node cleanup because etcd still has"
   node_cleanup_pods_for_deleted_node "$context" "$kubernetes_node_name"
   node_cleanup_longhorn_deleted_node "$context" "$kubernetes_node_name"
   node_log "control-plane delete cleanup complete: ${kubernetes_node_name}"
@@ -320,7 +164,7 @@ printf 'snapshot_list_end\n'
 EOF
 
 node_log "creating K3s etcd snapshot on ${probe_inventory_node}"
-snapshot_output="$(run_remote_shell "$inventory_file" "$probe_inventory_node" "$remote_snapshot")" ||
+snapshot_output="$(node_run_remote_shell "$inventory_file" "$probe_inventory_node" "$remote_snapshot")" ||
   node_die "failed to create K3s etcd snapshot on ${probe_inventory_node}"
 printf '%s\n' "$snapshot_output"
 if grep -q '^snapshot_error=' <<<"$snapshot_output"; then
@@ -371,14 +215,14 @@ printf 'member_list_after_end\n'
 EOF
 
 node_log "removing etcd member ${target_member_id} from ${probe_inventory_node}"
-member_remove_output="$(run_remote_shell "$inventory_file" "$probe_inventory_node" "$remote_member_remove")" ||
+member_remove_output="$(node_run_remote_shell "$inventory_file" "$probe_inventory_node" "$remote_member_remove")" ||
   node_die "failed to remove etcd member ${target_member_id} from ${probe_inventory_node}"
 printf '%s\n' "$member_remove_output"
 if grep -q '^remove_error=' <<<"$member_remove_output"; then
   node_die "etcd member remove reported an error"
 fi
 
-post_remove_member_lines="$(extract_block member_list_after_begin member_list_after_end <<<"$member_remove_output")"
+post_remove_member_lines="$(node_extract_block member_list_after_begin member_list_after_end <<<"$member_remove_output")"
 [[ -n "$post_remove_member_lines" ]] || node_die "post-remove etcd member list was empty"
 if grep -Fq "$target_member_id" <<<"$post_remove_member_lines"; then
   node_die "target etcd member is still present after remove: ${target_member_id}"

--- a/hack/bootstrap/nodes/lib/common.sh
+++ b/hack/bootstrap/nodes/lib/common.sh
@@ -35,6 +35,11 @@ node_confirm() {
   [[ "$answer" == "$expected" ]] || node_die "confirmation failed"
 }
 
+node_indent_block() {
+  while IFS= read -r line; do
+    printf '  %s\n' "$line"
+  done
+}
 
 node_contains_line() {
   local needle="$1"
@@ -71,4 +76,30 @@ node_filter_ansible_probe_output() {
     /^\[WARNING\]: / {next}
     {print}
   '
+}
+
+node_run_remote_shell() {
+  local inventory_file="$1"
+  local inventory_node="$2"
+  local remote_script="$3"
+  local output filtered_output
+
+  if output="$(
+    ANSIBLE_HOST_KEY_CHECKING=False \
+    ANSIBLE_PYTHON_INTERPRETER=auto_silent \
+      ansible -i "$inventory_file" "$inventory_node" \
+        --become \
+        -m ansible.builtin.shell \
+        -a "$remote_script" 2>&1
+  )"; then
+    node_filter_ansible_probe_output "$inventory_node" <<<"$output"
+    return 0
+  fi
+
+  filtered_output="$(node_filter_ansible_probe_output "$inventory_node" <<<"$output")"
+  {
+    printf 'remote_probe:\n'
+    node_indent_block <<<"$filtered_output"
+  } >&2
+  return 1
 }

--- a/hack/bootstrap/nodes/lib/etcd.sh
+++ b/hack/bootstrap/nodes/lib/etcd.sh
@@ -5,8 +5,9 @@ node_assert_control_plane_etcd_member_absent() {
   local context="$2"
   local inventory_node_name="$3"
   local kubernetes_node_name="$4"
+  local absent_message_prefix="${5:-etcd still has}"
   local inventory_file target_ansible_host probe_inventory_node probe_kubernetes_node remote_member_list
-  local remote_output filtered_remote_output member_lines member_line
+  local filtered_remote_output member_lines member_line
   local _member_id _member_status member_name member_peer_urls member_client_urls _member_is_learner _
   local matched_member_count=0
   local -a inventory_masters ready_control_planes
@@ -58,29 +59,13 @@ printf 'etcd_member_simple_end\n'
 EOF
 
   node_log "verifying ${kubernetes_node_name} is absent from etcd membership using ${probe_inventory_node}"
-  if remote_output="$(
-    ANSIBLE_HOST_KEY_CHECKING=False \
-    ANSIBLE_PYTHON_INTERPRETER=auto_silent \
-      ansible -i "$inventory_file" "$probe_inventory_node" \
-        --become \
-        -m ansible.builtin.shell \
-        -a "$remote_member_list" 2>&1
-  )"; then
-    filtered_remote_output="$(node_filter_ansible_probe_output "$probe_inventory_node" <<<"$remote_output")"
-  else
-    filtered_remote_output="$(node_filter_ansible_probe_output "$probe_inventory_node" <<<"$remote_output")"
-    printf 'remote_probe:\n'
-    while IFS= read -r line; do
-      printf '  %s\n' "$line"
-    done <<<"$filtered_remote_output"
+  if ! filtered_remote_output="$(node_run_remote_shell "$inventory_file" "$probe_inventory_node" "$remote_member_list")"; then
     node_die "failed to verify etcd membership from ${probe_inventory_node}"
   fi
 
   if grep -q '^member_list_error=' <<<"$filtered_remote_output"; then
     printf 'remote_probe:\n'
-    while IFS= read -r line; do
-      printf '  %s\n' "$line"
-    done <<<"$filtered_remote_output"
+    node_indent_block <<<"$filtered_remote_output"
     node_die "etcd member-list probe reported an error"
   fi
 
@@ -106,6 +91,7 @@ EOF
     fi
   done <<<"$member_lines"
 
-  ((matched_member_count == 0)) ||
-    node_die "etcd still has ${matched_member_count} member(s) for ${kubernetes_node_name}"
+  if ((matched_member_count != 0)); then
+    node_die "${absent_message_prefix} ${matched_member_count} member(s) for ${kubernetes_node_name}"
+  fi
 }

--- a/hack/bootstrap/tests/bats/offline-nodes.bats
+++ b/hack/bootstrap/tests/bats/offline-nodes.bats
@@ -190,6 +190,13 @@ EOF
   assert_output_contains 'stopping k3s server on k3s-master-1 before deleted-node cleanup'
   assert_output_contains 'verifying k3s-master-1 is absent from etcd membership using k3s-master-0'
   assert_output_contains 'control-plane delete cleanup complete: k3s-master-1'
+
+  mkdir -p "${tmp}/blocked-control-plane-cleanup-state"
+  touch "${tmp}/blocked-control-plane-cleanup-state/deleted-k3s-master-1"
+  run env PATH="${tmp}:${PATH}" FAKE_KUBECTL_STATE_DIR="${tmp}/blocked-control-plane-cleanup-state" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_control_plane_kubectl" \
+    "${ROOT}/hack/bootstrap/nodes/delete.sh" --profile live --context test --yes k3s-master-1
+  assert_failure
+  assert_output_contains 'refusing deleted-node cleanup because etcd still has 1 member(s) for k3s-master-1'
 }
 
 @test "control-plane join/uncordon and etcd membership checks fail closed" {


### PR DESCRIPTION
## Summary
- move shared node remote-shell/indent behavior into the node common library
- make control-plane delete reuse the shared etcd-member absence assertion while preserving its deleted-node cleanup error message
- add BATS coverage for the cleanup-blocked failure path

## Review
- review agent approved with no required edits

## Validation
- just bootstrap-test
- pre-commit run --files hack/bootstrap/nodes/control-plane-delete.sh hack/bootstrap/nodes/lib/common.sh hack/bootstrap/nodes/lib/etcd.sh hack/bootstrap/tests/bats/offline-nodes.bats
- git diff --check