### PR TITLE
refactor: use structured control-plane preflight

### DIFF
--- a/hack/bootstrap/nodes/control-plane-delete-preflight.sh
+++ b/hack/bootstrap/nodes/control-plane-delete-preflight.sh
@@ -11,6 +11,7 @@ Usage: hack/bootstrap/nodes/control-plane-delete-preflight.sh [options] NODE
 Options:
   --profile NAME   Node lifecycle profile: live or lima. Defaults to live.
   --context NAME   Kubernetes context. Defaults to the profile context.
+  --output FORMAT  Output format: text or json. Defaults to text.
   -h, --help       Show help.
 EOF
 }
@@ -22,6 +23,120 @@ join_csv() {
   fi
   local IFS=,
   printf '%s\n' "$*"
+}
+
+json_array() {
+  if (($# == 0)); then
+    printf '[]\n'
+    return
+  fi
+  printf '%s\n' "$@" | "$NODE_JQ_BIN" -R . | "$NODE_JQ_BIN" -s .
+}
+
+emit_text_preflight() {
+  printf 'profile: %s\n' "$profile"
+  printf 'context: %s\n' "$context"
+  printf 'inventory: %s\n' "$inventory_file"
+  printf 'target_inventory_node: %s\n' "$inventory_node_name"
+  printf 'target_kubernetes_node: %s\n' "$kubernetes_node_name"
+  printf 'target_ansible_host: %s\n' "${target_ansible_host:-unknown}"
+  printf 'target_ready: %s\n' "$target_ready"
+  printf 'probe_inventory_node: %s\n' "$probe_inventory_node"
+  printf 'inventory_control_planes: %s\n' "$(join_csv "${inventory_masters[@]}")"
+  printf 'ready_control_planes: %s\n' "$(join_csv "${ready_control_planes[@]}")"
+  printf 'etcd_members: %s\n' "$(join_csv "${all_member_names[@]}")"
+  printf 'etcd_member_count: %s\n' "$member_count"
+  printf 'etcd_current_quorum_size: %s\n' "$current_quorum_size"
+  printf 'post_remove_member_count: %s\n' "$post_remove_member_count"
+  printf 'post_remove_quorum_size: %s\n' "$post_remove_quorum_size"
+  printf 'remaining_ready_control_planes_after_target_stop: %s\n' "$remaining_ready_control_planes"
+
+  printf '\ntarget_etcd_member:\n'
+  printf '  id: %s\n' "$target_member_id"
+  printf '  name: %s\n' "$target_member_name"
+  printf '  status: %s\n' "$target_member_status"
+  printf '  peer_urls: %s\n' "$target_member_peer_urls"
+  printf '  client_urls: %s\n' "$target_member_client_urls"
+  printf '  is_learner: %s\n' "$target_member_is_learner"
+
+  printf '\netcd_endpoint_status:\n'
+  indent_block <<<"$endpoint_status"
+
+  printf '\nplanned_member_remove:\n'
+  printf '  run_on_inventory_node: %s\n' "$probe_inventory_node"
+  printf '  command: %s\n' "$planned_member_remove_command"
+
+  printf '\npreflight_result: pass\n'
+}
+
+emit_json_preflight() {
+  local human_output inventory_masters_json ready_control_planes_json etcd_members_json
+  human_output="$(emit_text_preflight)"
+  inventory_masters_json="$(json_array "${inventory_masters[@]}")"
+  ready_control_planes_json="$(json_array "${ready_control_planes[@]}")"
+  etcd_members_json="$(json_array "${all_member_names[@]}")"
+
+  # shellcheck disable=SC2016
+  "$NODE_JQ_BIN" -n \
+    --arg human_output "$human_output" \
+    --arg profile "$profile" \
+    --arg context "$context" \
+    --arg inventory "$inventory_file" \
+    --arg target_inventory_node "$inventory_node_name" \
+    --arg target_kubernetes_node "$kubernetes_node_name" \
+    --arg target_ansible_host "${target_ansible_host:-unknown}" \
+    --argjson target_ready "$target_ready" \
+    --arg probe_inventory_node "$probe_inventory_node" \
+    --argjson inventory_control_planes "$inventory_masters_json" \
+    --argjson ready_control_planes "$ready_control_planes_json" \
+    --argjson etcd_members "$etcd_members_json" \
+    --argjson etcd_member_count "$member_count" \
+    --argjson etcd_current_quorum_size "$current_quorum_size" \
+    --argjson post_remove_member_count "$post_remove_member_count" \
+    --argjson post_remove_quorum_size "$post_remove_quorum_size" \
+    --argjson remaining_ready_control_planes_after_target_stop "$remaining_ready_control_planes" \
+    --arg target_member_id "$target_member_id" \
+    --arg target_member_name "$target_member_name" \
+    --arg target_member_status "$target_member_status" \
+    --arg target_member_peer_urls "$target_member_peer_urls" \
+    --arg target_member_client_urls "$target_member_client_urls" \
+    --arg target_member_is_learner "$target_member_is_learner" \
+    --arg etcd_endpoint_status "$endpoint_status" \
+    --arg planned_member_remove_run_on_inventory_node "$probe_inventory_node" \
+    --arg planned_member_remove_command "$planned_member_remove_command" \
+    '{
+      human_output: $human_output,
+      profile: $profile,
+      context: $context,
+      inventory: $inventory,
+      target_inventory_node: $target_inventory_node,
+      target_kubernetes_node: $target_kubernetes_node,
+      target_ansible_host: $target_ansible_host,
+      target_ready: $target_ready,
+      probe_inventory_node: $probe_inventory_node,
+      inventory_control_planes: $inventory_control_planes,
+      ready_control_planes: $ready_control_planes,
+      etcd_members: $etcd_members,
+      etcd_member_count: $etcd_member_count,
+      etcd_current_quorum_size: $etcd_current_quorum_size,
+      post_remove_member_count: $post_remove_member_count,
+      post_remove_quorum_size: $post_remove_quorum_size,
+      remaining_ready_control_planes_after_target_stop: $remaining_ready_control_planes_after_target_stop,
+      target_etcd_member: {
+        id: $target_member_id,
+        name: $target_member_name,
+        status: $target_member_status,
+        peer_urls: $target_member_peer_urls,
+        client_urls: $target_member_client_urls,
+        is_learner: $target_member_is_learner
+      },
+      etcd_endpoint_status: $etcd_endpoint_status,
+      planned_member_remove: {
+        run_on_inventory_node: $planned_member_remove_run_on_inventory_node,
+        command: $planned_member_remove_command
+      },
+      preflight_result: "pass"
+    }'
 }
 
 contains_line() {
@@ -69,6 +184,7 @@ extract_block() {
 
 profile=live
 context=""
+output_format=text
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -78,6 +194,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --context)
       context="$2"
+      shift 2
+      ;;
+    --output)
+      output_format="$2"
       shift 2
       ;;
     -h|--help)
@@ -99,6 +219,13 @@ done
 
 [[ -n "${node_name:-}" ]] || node_die "NODE is required"
 node_validate_profile "$profile"
+case "$output_format" in
+  text|json)
+    ;;
+  *)
+    node_die "unsupported output format: ${output_format}"
+    ;;
+esac
 context="${context:-$(node_context_for_profile "$profile")}"
 
 node_require_tool "$NODE_KUBECTL_BIN"
@@ -274,36 +401,13 @@ fi
 ((remaining_ready_control_planes >= post_remove_quorum_size)) ||
   node_die "removing ${kubernetes_node_name} would leave ${remaining_ready_control_planes} Ready control-planes; post-remove quorum is ${post_remove_quorum_size}"
 
-printf 'profile: %s\n' "$profile"
-printf 'context: %s\n' "$context"
-printf 'inventory: %s\n' "$inventory_file"
-printf 'target_inventory_node: %s\n' "$inventory_node_name"
-printf 'target_kubernetes_node: %s\n' "$kubernetes_node_name"
-printf 'target_ansible_host: %s\n' "${target_ansible_host:-unknown}"
-printf 'target_ready: %s\n' "$target_ready"
-printf 'probe_inventory_node: %s\n' "$probe_inventory_node"
-printf 'inventory_control_planes: %s\n' "$(join_csv "${inventory_masters[@]}")"
-printf 'ready_control_planes: %s\n' "$(join_csv "${ready_control_planes[@]}")"
-printf 'etcd_members: %s\n' "$(join_csv "${all_member_names[@]}")"
-printf 'etcd_member_count: %s\n' "$member_count"
-printf 'etcd_current_quorum_size: %s\n' "$current_quorum_size"
-printf 'post_remove_member_count: %s\n' "$post_remove_member_count"
-printf 'post_remove_quorum_size: %s\n' "$post_remove_quorum_size"
-printf 'remaining_ready_control_planes_after_target_stop: %s\n' "$remaining_ready_control_planes"
+planned_member_remove_command="/usr/local/bin/etcdctl --endpoints=https://127.0.0.1:2379 --cacert=/var/lib/rancher/k3s/server/tls/etcd/server-ca.crt --cert=/var/lib/rancher/k3s/server/tls/etcd/client.crt --key=/var/lib/rancher/k3s/server/tls/etcd/client.key member remove ${target_member_id}"
 
-printf '\ntarget_etcd_member:\n'
-printf '  id: %s\n' "$target_member_id"
-printf '  name: %s\n' "$target_member_name"
-printf '  status: %s\n' "$target_member_status"
-printf '  peer_urls: %s\n' "$target_member_peer_urls"
-printf '  client_urls: %s\n' "$target_member_client_urls"
-printf '  is_learner: %s\n' "$target_member_is_learner"
-
-printf '\netcd_endpoint_status:\n'
-indent_block <<<"$endpoint_status"
-
-printf '\nplanned_member_remove:\n'
-printf '  run_on_inventory_node: %s\n' "$probe_inventory_node"
-printf '  command: /usr/local/bin/etcdctl --endpoints=https://127.0.0.1:2379 --cacert=/var/lib/rancher/k3s/server/tls/etcd/server-ca.crt --cert=/var/lib/rancher/k3s/server/tls/etcd/client.crt --key=/var/lib/rancher/k3s/server/tls/etcd/client.key member remove %s\n' "$target_member_id"
-
-printf '\npreflight_result: pass\n'
+case "$output_format" in
+  text)
+    emit_text_preflight
+    ;;
+  json)
+    emit_json_preflight
+    ;;
+esac

--- a/hack/bootstrap/nodes/control-plane-delete.sh
+++ b/hack/bootstrap/nodes/control-plane-delete.sh
@@ -16,27 +16,10 @@ Options:
 EOF
 }
 
-parse_preflight_scalar() {
-  local key="$1"
-  awk -v key="$key" '
-    index($0, key ": ") == 1 {
-      sub("^[^:]+: ", "")
-      print
-      exit
-    }
-  '
-}
-
-parse_preflight_target_member_id() {
-  awk '
-    $0 == "target_etcd_member:" {inside = 1; next}
-    inside && /^  id: / {
-      sub(/^  id: /, "")
-      print
-      exit
-    }
-    inside && NF == 0 {inside = 0}
-  '
+preflight_json_field() {
+  local json="$1"
+  local filter="$2"
+  "$NODE_JQ_BIN" -er "$filter" <<<"$json"
 }
 
 profile=live
@@ -113,12 +96,13 @@ node_assert_no_ordinary_pods "$context" "$kubernetes_node_name"
 node_assert_longhorn_empty_for_delete "$context" "$kubernetes_node_name"
 
 node_log "running control-plane delete preflight before mutation"
-preflight_output="$("$preflight_script" --profile "$profile" --context "$context" "$node_name")"
-printf '%s\n' "$preflight_output"
+preflight_json="$("$preflight_script" --profile "$profile" --context "$context" --output json "$node_name")"
+preflight_human_output="$(preflight_json_field "$preflight_json" '.human_output')"
+printf '%s\n' "$preflight_human_output"
 
-probe_inventory_node="$(parse_preflight_scalar probe_inventory_node <<<"$preflight_output")"
-target_member_id="$(parse_preflight_target_member_id <<<"$preflight_output")"
-member_count="$(parse_preflight_scalar etcd_member_count <<<"$preflight_output")"
+probe_inventory_node="$(preflight_json_field "$preflight_json" '.probe_inventory_node')"
+target_member_id="$(preflight_json_field "$preflight_json" '.target_etcd_member.id')"
+member_count="$(preflight_json_field "$preflight_json" '.etcd_member_count | tostring')"
 [[ -n "$probe_inventory_node" ]] || node_die "could not parse preflight probe node"
 [[ "$target_member_id" =~ ^[0-9a-f]+$ ]] || node_die "could not parse target etcd member id"
 [[ "$member_count" =~ ^[0-9]+$ ]] || node_die "could not parse etcd member count"
@@ -132,12 +116,13 @@ node_log "waiting for Kubernetes API after stopping ${kubernetes_node_name}"
 node_wait_for_api_reachable "$context" 180
 
 node_log "rechecking control-plane delete preflight after stopping ${kubernetes_node_name}"
-post_stop_preflight_output="$("$preflight_script" --profile "$profile" --context "$context" "$node_name")"
-printf '%s\n' "$post_stop_preflight_output"
+post_stop_preflight_json="$("$preflight_script" --profile "$profile" --context "$context" --output json "$node_name")"
+post_stop_preflight_human_output="$(preflight_json_field "$post_stop_preflight_json" '.human_output')"
+printf '%s\n' "$post_stop_preflight_human_output"
 
-probe_inventory_node="$(parse_preflight_scalar probe_inventory_node <<<"$post_stop_preflight_output")"
-target_member_id="$(parse_preflight_target_member_id <<<"$post_stop_preflight_output")"
-member_count="$(parse_preflight_scalar etcd_member_count <<<"$post_stop_preflight_output")"
+probe_inventory_node="$(preflight_json_field "$post_stop_preflight_json" '.probe_inventory_node')"
+target_member_id="$(preflight_json_field "$post_stop_preflight_json" '.target_etcd_member.id')"
+member_count="$(preflight_json_field "$post_stop_preflight_json" '.etcd_member_count | tostring')"
 [[ -n "$probe_inventory_node" ]] || node_die "could not parse post-stop preflight probe node"
 [[ "$target_member_id" =~ ^[0-9a-f]+$ ]] || node_die "could not parse post-stop target etcd member id"
 [[ "$member_count" =~ ^[0-9]+$ ]] || node_die "could not parse post-stop etcd member count"

--- a/hack/bootstrap/tests/bats/offline-nodes.bats
+++ b/hack/bootstrap/tests/bats/offline-nodes.bats
@@ -122,6 +122,32 @@ JSON
   assert_output_contains 'member remove c9e409fd1205cc0a'
 
   run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_control_plane_kubectl" \
+    "${ROOT}/hack/bootstrap/nodes/control-plane-delete-preflight.sh" --profile live --context test --output json k3s-master-0
+  assert_success
+  printf '%s\n' "$output" > "${tmp}/control-plane-delete-preflight.json"
+
+  run jq -r '.probe_inventory_node' "${tmp}/control-plane-delete-preflight.json"
+  assert_success
+  [[ "$output" == "k3s-master-1" ]]
+
+  run jq -r '.target_etcd_member.id' "${tmp}/control-plane-delete-preflight.json"
+  assert_success
+  [[ "$output" == "c9e409fd1205cc0a" ]]
+
+  run jq -r '.remaining_ready_control_planes_after_target_stop' "${tmp}/control-plane-delete-preflight.json"
+  assert_success
+  [[ "$output" == "2" ]]
+
+  run jq -r '.planned_member_remove.command' "${tmp}/control-plane-delete-preflight.json"
+  assert_success
+  assert_output_contains 'member remove c9e409fd1205cc0a'
+
+  run jq -r '.human_output' "${tmp}/control-plane-delete-preflight.json"
+  assert_success
+  assert_output_contains 'probe_inventory_node: k3s-master-1'
+  assert_output_contains 'member remove c9e409fd1205cc0a'
+
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_control_plane_kubectl" \
     bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_alternate_ready_control_plane_internal_ip live test k3s-master-0"
   assert_success
   [[ "$output" == "192.168.99.11" ]]


### PR DESCRIPTION
## Summary
- add text/json output modes to control-plane delete preflight, keeping text as the default
- make control-plane delete consume structured JSON fields instead of scraping human text
- preserve human preflight logs by embedding and printing human_output from the same JSON preflight result
- add BATS coverage for JSON fields and human output

## Review
- review agent approved with no required edits

## Validation
- just bootstrap-test
- pre-commit run --files hack/bootstrap/nodes/control-plane-delete-preflight.sh hack/bootstrap/nodes/control-plane-delete.sh hack/bootstrap/tests/bats/offline-nodes.bats
- git diff --check
- just node-lima-control-plane-status home-ops-k3s-test-server-1
- just node-lima-control-plane-delete-preflight home-ops-k3s-test-server-1
- ./hack/bootstrap/nodes/control-plane-delete-preflight.sh --profile lima --context lima-home-ops-k3s-test --output json home-ops-k3s-test-server-1