### PR TITLE
refactor: replace shellcheck source suppressions

### DIFF
--- a/hack/bootstrap/ansible/import-token.sh
+++ b/hack/bootstrap/ansible/import-token.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/ansible/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/hack/bootstrap/ansible/lib/inventory.sh
+++ b/hack/bootstrap/ansible/lib/inventory.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
-# shellcheck disable=SC2154
 
 ansible_home_ops_cilium_tag() {
   local version

--- a/hack/bootstrap/ansible/lib/kubeconfig.sh
+++ b/hack/bootstrap/ansible/lib/kubeconfig.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
-# shellcheck disable=SC2154
 
 ansible_prepare_kubeconfig() {
   local profile="$1"

--- a/hack/bootstrap/ansible/lib/paths.sh
+++ b/hack/bootstrap/ansible/lib/paths.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
-# shellcheck disable=SC2154
 
 ansible_inventory_dir() {
   local profile="${1:-$BOOTSTRAP_ANSIBLE_PROFILE}"

--- a/hack/bootstrap/ansible/lib/playbooks.sh
+++ b/hack/bootstrap/ansible/lib/playbooks.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
-# shellcheck disable=SC2154
 
 ansible_confirm_live_run() {
   local yes="$1"

--- a/hack/bootstrap/ansible/lib/token.sh
+++ b/hack/bootstrap/ansible/lib/token.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
-# shellcheck disable=SC2154
 
 ansible_token_ref() {
   printf 'op://%s/%s/%s\n' \

--- a/hack/bootstrap/ansible/node-control-plane.sh
+++ b/hack/bootstrap/ansible/node-control-plane.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/ansible/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 if [[ "${NODE_CONTROL_PLANE_ANSIBLE_INTERNAL:-}" != true ]]; then

--- a/hack/bootstrap/ansible/node-worker.sh
+++ b/hack/bootstrap/ansible/node-worker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/ansible/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 if [[ "${NODE_WORKER_ANSIBLE_INTERNAL:-}" != true ]]; then

--- a/hack/bootstrap/ansible/render-inventory.sh
+++ b/hack/bootstrap/ansible/render-inventory.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/ansible/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/hack/bootstrap/ansible/run.sh
+++ b/hack/bootstrap/ansible/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/ansible/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/hack/bootstrap/bootstrap.sh
+++ b/hack/bootstrap/bootstrap.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 BOOTSTRAP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/lib/common.sh
 source "${BOOTSTRAP_DIR}/lib/common.sh"
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/lib/k8s.sh
 source "${BOOTSTRAP_DIR}/lib/k8s.sh"
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/lib/render.sh
 source "${BOOTSTRAP_DIR}/lib/render.sh"
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/lib/reports.sh
 source "${BOOTSTRAP_DIR}/lib/reports.sh"
 
 PHASES=(

--- a/hack/bootstrap/lima/bootstrap-home-ops.sh
+++ b/hack/bootstrap/lima/bootstrap-home-ops.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/lima/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 lima_require_common_tools

--- a/hack/bootstrap/lima/create.sh
+++ b/hack/bootstrap/lima/create.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/lima/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 lima_require_common_tools

--- a/hack/bootstrap/lima/delete.sh
+++ b/hack/bootstrap/lima/delete.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/lima/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 lima_require_common_tools
 
-lima_stop_tunnel
+lima_stop_tunnel ""
 
 deleted_any=false
 for _ in $(seq 1 5); do

--- a/hack/bootstrap/lima/inventory.sh
+++ b/hack/bootstrap/lima/inventory.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/lima/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 lima_require_common_tools

--- a/hack/bootstrap/lima/kubecontext.sh
+++ b/hack/bootstrap/lima/kubecontext.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/lima/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 lima_require_common_tools

--- a/hack/bootstrap/lima/run-ansible.sh
+++ b/hack/bootstrap/lima/run-ansible.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/lima/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 lima_require_common_tools

--- a/hack/bootstrap/lima/validate.sh
+++ b/hack/bootstrap/lima/validate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/lima/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 lima_require_common_tools

--- a/hack/bootstrap/nodes/control-plane-delete-preflight.sh
+++ b/hack/bootstrap/nodes/control-plane-delete-preflight.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/nodes/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/hack/bootstrap/nodes/control-plane-delete.sh
+++ b/hack/bootstrap/nodes/control-plane-delete.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/nodes/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/hack/bootstrap/nodes/control-plane-join.sh
+++ b/hack/bootstrap/nodes/control-plane-join.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/nodes/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/hack/bootstrap/nodes/control-plane-status.sh
+++ b/hack/bootstrap/nodes/control-plane-status.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/nodes/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/hack/bootstrap/nodes/control-plane-uncordon.sh
+++ b/hack/bootstrap/nodes/control-plane-uncordon.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/nodes/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/hack/bootstrap/nodes/delete.sh
+++ b/hack/bootstrap/nodes/delete.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/nodes/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/hack/bootstrap/nodes/drain.sh
+++ b/hack/bootstrap/nodes/drain.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/nodes/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/hack/bootstrap/nodes/join.sh
+++ b/hack/bootstrap/nodes/join.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/nodes/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/hack/bootstrap/nodes/longhorn-evict.sh
+++ b/hack/bootstrap/nodes/longhorn-evict.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/nodes/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/hack/bootstrap/nodes/refresh-ssh-host-key.sh
+++ b/hack/bootstrap/nodes/refresh-ssh-host-key.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/nodes/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/hack/bootstrap/nodes/status.sh
+++ b/hack/bootstrap/nodes/status.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/nodes/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {
@@ -184,6 +184,6 @@ if [[ "$k8s_role" == control-plane ]]; then
   printf '\netcd:\n'
   printf '  status: deferred\n'
   printf '  note: use control-plane-status for embedded-etcd member introspection\n'
-  ready_control_planes="$(node_ready_control_planes "$context" | paste -sd ',' -)"
-  printf '  ready_control_planes: %s\n' "${ready_control_planes:-none}"
+  ready_control_plane_list="$(node_ready_control_planes "$context" | paste -sd ',' -)"
+  printf '  ready_control_planes: %s\n' "${ready_control_plane_list:-none}"
 fi

--- a/hack/bootstrap/nodes/uncordon.sh
+++ b/hack/bootstrap/nodes/uncordon.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck disable=SC1091
+# shellcheck source=hack/bootstrap/nodes/lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 usage() {

--- a/justfile
+++ b/justfile
@@ -354,5 +354,5 @@ bootstrap-audit:
 # Run shellcheck and offline bootstrap parsing/rendering tests.
 [group('bootstrap')]
 bootstrap-test:
-    shellcheck hack/bootstrap/bootstrap.sh hack/bootstrap/lib/*.sh hack/bootstrap/phases/*.sh hack/bootstrap/tests/bats/*.bats hack/bootstrap/tests/helpers/*.bash hack/bootstrap/lima/*.sh hack/bootstrap/ansible/*.sh hack/bootstrap/ansible/lib/*.sh hack/bootstrap/nodes/*.sh hack/bootstrap/nodes/lib/*.sh
+    shellcheck -x hack/bootstrap/bootstrap.sh hack/bootstrap/lib/*.sh hack/bootstrap/phases/*.sh hack/bootstrap/tests/bats/*.bats hack/bootstrap/tests/helpers/*.bash hack/bootstrap/lima/*.sh hack/bootstrap/ansible/*.sh hack/bootstrap/ansible/lib/*.sh hack/bootstrap/nodes/*.sh hack/bootstrap/nodes/lib/*.sh
     bats hack/bootstrap/tests/bats


### PR DESCRIPTION
## Summary
- replace SC1091 disables with explicit shellcheck source annotations
- run bootstrap shellcheck with -x so sourced bootstrap helpers are followed
- remove stale broad SC2154 disables from Ansible helper modules
- fix the node status scalar/array ShellCheck warning exposed by following sourced files

## Audit notes
- remaining SC2016 exclusions are intentional literal jq/yq programs
- remaining BATS SC2034/SC2154 exclusions are for BATS globals and shared fixture variables
