### PR TITLE
docs: simplify bootstrap just recipes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,11 +58,11 @@ For bootstrap changes:
 
 ```bash
 just bootstrap-test
-just bootstrap-kind-fresh
-just bootstrap-kind-dry-run
-just bootstrap-live-audit default
-just bootstrap-live-dry-run default
-just bootstrap-live-phase argocd default
+just kind-fresh
+just kind-bootstrap-dry-run
+just bootstrap-audit
+just bootstrap-dry-run
+just bootstrap-phase argocd
 ```
 
 ## ArgoCD Notes
@@ -81,7 +81,7 @@ just bootstrap-live-phase argocd default
 - When Cilium CRDs are present, bootstrap must apply Hubble CA resources and wait for `Application/cilium` plus Hubble server/relay certs before applying `ApplicationSet/k3s-apps`; normal apps should not start until Cilium takeover is complete.
 - Lima foundation bootstrap validation uses `hack/bootstrap/lima/` and `--profile foundation`; it runs the selected Ansible backend, defaults to the in-repo `home-ops` backend, installs only a disposable foundation cluster, uses the server VM IP rather than kube-vip for the cluster join endpoint, imports local context `lima-home-ops-k3s-test` through a persistent SSH tunnel, applies Hubble CA resources before ArgoCD Cilium takeover, keeps Cilium masquerading enabled only for Lima's user-mode network, disables Dragonfly Operator's optional monitoring/dashboard resources in foundation mode, requires foundation Applications to be `Synced` and `Healthy`, and must fail if normal workloads or backup writers such as `powerdns`, `hass`, VolSync, Velero, external-dns, or CNPG backup resources appear.
 - Lima app bootstrap uses `--profile lima-apps`; run it with the app-sized Lima shape of four schedulable workers, each with `4` CPU, `6GiB` memory, and enough disk for Longhorn restore and replacement-eviction testing. The app `just` recipes use `120GiB` disks and preflight requires `100GiB` allocatable ephemeral storage per worker. Lima VM creation installs `open-iscsi` and `nfs-common` so Longhorn block and RWX volumes can mount. It first seeds Gateway wildcard TLS Secrets from 1Password through `ExternalSecret` resources, applies external-snapshotter before VolSync restore workloads, then applies a sanitized `ApplicationSet/k3s-apps` allowlist. Keep render-time safety patches primary and admission policies as fail-closed guardrails. Lima app bootstrap must not create `PushSecret`, ACME `Order`/`Challenge`, VolSync `ReplicationSource`, active CNPG `Cluster.spec.plugins`, CNPG backup resources, Velero backup resources, or Longhorn backup `RecurringJob` objects.
-- `bootstrap-kind-dry-run` is a post-bootstrap validation pass. It is not a clean-cluster first-boot test because server-side dry-run does not persist CRDs for later CR validation.
+- `kind-bootstrap-dry-run` is a post-bootstrap validation pass. It is not a clean-cluster first-boot test because server-side dry-run does not persist CRDs for later CR validation.
 - Live physical-node Ansible orchestration lives under `hack/bootstrap/ansible/`. The default backend is the in-repo `home-ops` Debian-family implementation for this cluster, while the external `../k3s-ansible` checkout remains available only through `BOOTSTRAP_ANSIBLE_BACKEND=k3s-ansible` or `--backend k3s-ansible`. Keep site-specific inventory rendering, 1Password token handling, and live confirmation prompts in `home-ops`.
 - Existing-cluster node lifecycle helpers live under `hack/bootstrap/nodes/`. Worker status/drain/delete/join/uncordon are explicit steps. Mutating delete must prevent immediate K3s re-registration before deleting the Kubernetes Node. Control-plane drain/delete must remain gated by the embedded-etcd preflight, Longhorn eviction when Longhorn is installed, fresh K3s etcd snapshot creation, and explicit member removal from a remaining control-plane. Control-plane join/uncordon must verify the old etcd member is absent, move any stale local K3s server DB aside before rejoin, apply a temporary joining taint, and keep the node cordoned until the finalize/uncordon step removes the taint and restores Longhorn scheduling. First-inventory-master replacement depends on stable API access: live uses the stable `default` API endpoint, while Lima retargets the local API tunnel to an alternate Ready control-plane and passes an alternate control-plane InternalIP as the temporary K3s join endpoint.
 - `hack/bootstrap/ansible/inventory/live/` may contain non-secret physical node facts. Do not commit the generated `.out/ansible-*` inventories, kubeconfigs, or any rendered secret values.

--- a/docs/just-bootstrap.md
+++ b/docs/just-bootstrap.md
@@ -1,14 +1,20 @@
 # Just Bootstrap Runbook
 
-This page documents the `just` recipes for bootstrapping a fresh cluster into
-the minimum state ArgoCD needs before it can take over normal GitOps sync.
+This is the operator-facing runbook for the bootstrap recipes in the root
+`justfile`.
 
-The bootstrap runner lives in `hack/bootstrap/`. It assumes the Ansible wrapper
-or an equivalent process has already produced a working Kubernetes API,
-kubeconfig, and initial Cilium install before this runner is used on the real
-cluster.
+Bootstrap has two jobs:
+
+1. Converge K3s nodes with the Ansible wrapper when needed.
+2. Seed the minimum Kubernetes state ArgoCD needs before it can take over.
+
+The implementation lives under `hack/bootstrap/`. Prefer `just` recipes for
+normal operation; direct scripts are implementation details except for narrow
+debugging cases.
 
 ## Prerequisites
+
+Required for all bootstrap work:
 
 - `just`
 - `kubectl`
@@ -17,365 +23,433 @@ cluster.
 - `yq`
 - `jq`
 - `op`
+
+Required for local validation:
+
 - `shellcheck`
 - `bats`
-- `ansible-playbook` and `ansible-galaxy` for Ansible-based bootstrap
-- `limactl` for the optional Lima VM bootstrap tests
-- A kubeconfig pointing at the target cluster
-- 1Password CLI signed in with access to
-  `op://Kubernetes/op-credentials/op-credentials.yaml`
 
-Run this first when validating script changes:
+Required for Ansible-backed node convergence:
 
-```sh
-just bootstrap-test
+- `ansible-playbook`
+- `ansible-galaxy`
+
+Required for Lima VM tests:
+
+- `limactl`
+
+1Password must have access to:
+
+```text
+op://Kubernetes/op-credentials/op-credentials.yaml
 ```
 
-`bootstrap-test` runs ShellCheck plus the offline BATS suite under
-`hack/bootstrap/tests/bats/`. Use Lima and live recipes only for validation
-that needs a real Kubernetes API or VM/node state.
+## Command Map
 
-## Local Kind Test
-
-Kind recipes use the repo-specific cluster name `home-ops-bootstrap`, which
-creates the kube context `kind-home-ops-bootstrap`. Override it only when needed:
+Start with the recipe list when unsure:
 
 ```sh
-KIND_CLUSTER=my-test-cluster just kind-reset
+just --list
 ```
 
-Create a clean three-node kind cluster:
+Common validation:
+
+| Goal | Recipe |
+| --- | --- |
+| Run pre-commit plus bootstrap tests | `just check` |
+| Run only bootstrap ShellCheck and BATS | `just bootstrap-test` |
+| Audit current kube context | `just bootstrap-audit` |
+| Show current and target cluster status | `just context` |
+| List ArgoCD Applications | `just argocd-apps` |
+| List ArgoCD ApplicationSets | `just argocd-appsets` |
+
+Kind:
+
+| Goal | Recipe |
+| --- | --- |
+| Create the kind cluster | `just kind-create` |
+| Show kind status | `just kind-status` |
+| Bootstrap kind | `just kind-bootstrap` |
+| Recreate and bootstrap kind | `just kind-fresh` |
+| Seed only the 1Password credential | `just kind-bootstrap-seed` |
+| Resume kind from a phase | `just kind-bootstrap-resume bootstrap-crds` |
+| Dry-run after CRDs exist | `just kind-bootstrap-dry-run` |
+| Delete kind | `just kind-delete` |
+
+Lima foundation:
+
+| Goal | Recipe |
+| --- | --- |
+| Create VMs | `just lima-create` |
+| Run Ansible | `just lima-ansible` |
+| Run Kubernetes bootstrap | `just lima-bootstrap` |
+| Validate foundation state | `just lima-validate` |
+| Full fresh flow | `just lima-fresh` |
+| Show Lima status | `just lima-status` |
+| Refresh kube context and API tunnel | `just lima-context` |
+| Delete VMs | `just lima-delete` |
+
+Lima app profile:
+
+| Goal | Recipe |
+| --- | --- |
+| Create app-sized VMs | `just lima-apps-create` |
+| Run Ansible on app-sized VMs | `just lima-apps-ansible` |
+| Run app-profile bootstrap | `just lima-apps-bootstrap` |
+| Validate app-profile safety | `just lima-apps-validate` |
+| Full fresh app flow | `just lima-apps-fresh` |
+
+Ansible and active-context bootstrap:
+
+| Goal | Recipe |
+| --- | --- |
+| Render live Ansible plan | `just ansible-plan` |
+| Import existing K3s token to 1Password | `just ansible-import-token` |
+| Run live Ansible only | `just ansible-run` |
+| Run live Ansible plus Kubernetes bootstrap | `just ansible-bootstrap` |
+| Run Kubernetes bootstrap against the active context | `just bootstrap` |
+| Audit active context state | `just bootstrap-audit` |
+| Dry-run bootstrap against the active context | `just bootstrap-dry-run` |
+| Dry-run one bootstrap phase | `just bootstrap-phase argocd` |
+
+## Validation Ladder
+
+Use the smallest validation that covers the change:
+
+1. `just bootstrap-test` for Bash parsing, rendering, and helper behavior.
+2. `just kind-fresh` for clean Kubernetes bootstrap ordering.
+3. `just kind-bootstrap-dry-run` for server-side validation after CRDs exist.
+4. `just lima-fresh` for Cilium takeover and core operators.
+5. `just lima-apps-fresh` for Longhorn, VolSync, CNPG, and app safety.
+6. `just bootstrap-audit` for active-context read-only inventory.
+7. `just bootstrap-dry-run` for active-context API/admission validation.
+
+Do not run a live non-dry-run bootstrap from an unmerged branch. Use dry-run
+from the branch, then let merged `master` and ArgoCD own steady state.
+
+## Cluster Inspection
+
+Use `context` for a quick read-only look at the target context:
 
 ```sh
-just kind-reset
+just context
+just context lima-home-ops-k3s-test
 ```
 
-Run the bootstrap against kind:
+With no argument, it targets the active kube context. Pass a context name to
+inspect a different target. It prints the current kubeconfig context, the
+target context, nodes, and an ArgoCD Application summary when ArgoCD is
+available.
+
+List ArgoCD Applications or ApplicationSets:
 
 ```sh
-just bootstrap-kind
+just argocd-apps
+just argocd-apps cilium
+just argocd-apps cilium default
+just argocd-apps cilium lima-home-ops-k3s-test
+just argocd-appsets
+just argocd-appsets k3s-apps
+just argocd-appsets k3s-apps default
+just argocd-appsets k3s-apps lima-home-ops-k3s-test
 ```
 
-Recreate kind and then run the bootstrap in one step:
+With no context argument, `argocd-apps`, `argocd-appsets`, `app-dry-run`, and
+`app-diff` target the active kube context. Pass a context name when you want a
+specific cluster.
+
+## Kind Workflow
+
+Kind uses the repo-specific cluster name `home-ops-bootstrap`, which creates
+context `kind-home-ops-bootstrap`.
+
+Override only when needed:
 
 ```sh
-just bootstrap-kind-fresh
+KIND_CLUSTER=my-test-cluster just kind-fresh
 ```
 
-To seed kind separately before resuming the remaining phases:
+Typical clean run:
 
 ```sh
-just bootstrap-kind-seed
-just bootstrap-kind-resume
+just kind-fresh
 ```
 
-After kind has been bootstrapped once and the CRDs exist, run a server-side
-dry-run validation against the local API:
+Check current kind state:
 
 ```sh
-just bootstrap-kind-dry-run
+just kind-status
 ```
 
-Delete the local kind cluster when validation is complete:
+Phase-by-phase run:
 
 ```sh
 just kind-delete
+just kind-create
+just kind-bootstrap-seed
+just kind-bootstrap-resume bootstrap-crds
 ```
 
-Do not use `bootstrap-kind-dry-run` as the first command after `kind-reset`.
-Server-side dry-run validates objects but does not persist CRDs, so later dry-run
-phases cannot validate CRs such as `ClusterSecretStore` or ArgoCD `Application`
-until those CRDs already exist.
+After the first successful bootstrap:
 
-The kind path is intentionally narrower than the real cluster path. If the
-target cluster does not have `ciliumnetworkpolicies.cilium.io`, the bootstrap
-omits the real-cluster `ApplicationSet/k3s-apps`, Cilium applications, and
-Longhorn application. It also omits `crd-schema-publisher` so a local kind test
-does not publish schemas over the live schema index. That keeps kind focused on
-bootstrap dependency ordering instead of trying to run every homelab workload
-without Cilium, Longhorn, and real infrastructure.
+```sh
+just kind-bootstrap-dry-run
+```
 
-If the target cluster already has Cilium CRDs, bootstrap still delays
-`ApplicationSet/k3s-apps`. The ArgoCD phase applies Hubble CA resources and the
-explicit foundation Applications first; the wait phase then waits for
-`Application/cilium` to be `Synced` and `Healthy`, waits for Hubble server and
-relay certificates, restarts Cilium/Hubble when stale takeover certs were
-replaced, and applies `ApplicationSet/k3s-apps` only after that completes.
+Do not use `kind-bootstrap-dry-run` as the first command after `kind-delete`.
+Server-side dry-run validates objects but does not persist CRDs, so later CRs
+cannot validate until their CRDs exist.
 
-## Local Lima Foundation Test
+Kind intentionally omits real-cluster-only resources when Cilium CRDs are
+absent: `ApplicationSet/k3s-apps`, Cilium apps, Longhorn, and
+`crd-schema-publisher`.
 
-The Lima path is a closer end-to-end bootstrap rehearsal for Apple Silicon. It
-creates one K3s server and two K3s agents, runs the selected Ansible backend,
-then runs home-ops bootstrap with `--profile foundation`.
+## Lima Foundation Workflow
+
+The foundation profile is the closer end-to-end rehearsal for a fresh cluster.
+It creates disposable VMs, runs Ansible, imports kubeconfig through an SSH API
+tunnel, and bootstraps with `--profile foundation`.
 
 Defaults:
 
-- Lima cluster prefix: `home-ops-k3s-test`
-- foundation VM shape: one server and two agents
-- Ansible backend: `home-ops` by default, using
-  `hack/bootstrap/ansible/home-ops/`
-- home-ops checkout: the current working tree
-- server VM size: `4` CPU and `6GiB` memory
-- foundation agent VM size: `2` CPU and `3GiB` memory
-- guest storage prerequisites: `open-iscsi` and `nfs-common` are installed on
-  each VM before Ansible runs so Longhorn block and RWX volumes can mount
-- Cilium version: derived from `Application/cilium.spec.source.targetRevision`
-  and rendered into the selected Ansible backend
-- Cilium datapath mode: `netkit`, matching the steady-state ArgoCD values
-- Cilium takeover: Hubble CA resources are applied before ArgoCD Cilium, and
-  stale Hubble cert Secrets from the initial Ansible install are rotated
-- Dragonfly Operator: reconciled through ArgoCD without optional
-  `ServiceMonitor` or `GrafanaDashboard` resources in foundation mode
-- K3s API endpoint: the server VM IP, not kube-vip
-- Local kube context: `lima-home-ops-k3s-test`
+| Setting | Default |
+| --- | --- |
+| Cluster prefix | `home-ops-k3s-test` |
+| Local context | `lima-home-ops-k3s-test` |
+| Server shape | one VM, `4` CPU, `6GiB` memory |
+| Agent shape | two VMs, `2` CPU, `3GiB` memory |
+| Disk | `30GiB` |
+| Master taint | enabled |
+| Ansible backend | `home-ops` |
 
-The shape and size can be overridden with `LIMA_SERVER_COUNT`,
-`LIMA_SERVER_CPUS`, `LIMA_SERVER_MEMORY_GIB`, `LIMA_AGENT_COUNT`,
-`LIMA_AGENT_CPUS`, `LIMA_AGENT_MEMORY_GIB`, and `LIMA_K3S_MASTER_TAINT`.
-
-Run the full disposable VM flow:
+Run everything:
 
 ```sh
-just bootstrap-lima-fresh
+just lima-fresh
+```
+
+Or run phase by phase:
+
+```sh
+just lima-create
+just lima-ansible
+just lima-bootstrap
+just lima-validate
+```
+
+The Lima Ansible recipe imports or updates the local kube context and keeps the
+API tunnel running. Refresh only that context and tunnel with:
+
+```sh
+just lima-context
+```
+
+Delete the VMs and recorded tunnel:
+
+```sh
+just lima-delete
+```
+
+Check current Lima state:
+
+```sh
+just lima-status
+```
+
+Useful overrides:
+
+- `LIMA_CLUSTER_NAME`
+- `LIMA_SERVER_COUNT`
+- `LIMA_SERVER_CPUS`
+- `LIMA_SERVER_MEMORY_GIB`
+- `LIMA_AGENT_COUNT`
+- `LIMA_AGENT_CPUS`
+- `LIMA_AGENT_MEMORY_GIB`
+- `LIMA_DISK_GIB`
+- `LIMA_K3S_MASTER_TAINT`
+
+The Lima wrapper installs `open-iscsi` and `nfs-common` before Ansible so
+Longhorn block and RWX volumes can mount.
+
+## Lima App Workflow
+
+The app profile should use the app-sized Lima shape, not the smaller
+foundation shape.
+
+Run the full app-sized flow:
+
+```sh
+just lima-apps-fresh
 ```
 
 Or run it phase by phase:
 
 ```sh
-just bootstrap-lima-create
-just bootstrap-lima-ansible
-just bootstrap-lima-bootstrap
-just bootstrap-lima-validate
+just lima-apps-delete
+just lima-apps-create
+just lima-apps-ansible
+just lima-apps-bootstrap
+just lima-apps-validate
 ```
 
-The external compatibility backend can be tested through the same Lima flow:
-
-```sh
-BOOTSTRAP_ANSIBLE_BACKEND=k3s-ansible just bootstrap-lima-ansible
-```
-
-`bootstrap-lima-ansible` imports or updates the local kube context and starts a
-persistent SSH tunnel for the K3s API. Re-run this if you only need to refresh
-the context:
-
-```sh
-just bootstrap-lima-kubecontext
-kubectl --context lima-home-ops-k3s-test get nodes
-```
-
-If this agent process is not signed in to 1Password, stream the seed Secret from
-your own shell instead:
-
-```sh
-op read op://Kubernetes/op-credentials/op-credentials.yaml \
-  | just bootstrap-lima-bootstrap-stdin
-```
-
-Use the app-profile variant for the same stdin seed flow:
-
-```sh
-op read op://Kubernetes/op-credentials/op-credentials.yaml \
-  | just bootstrap-lima-bootstrap-apps-stdin
-```
-
-Delete the VMs:
-
-```sh
-just bootstrap-lima-delete
-```
-
-Deleting the Lima VMs also stops the recorded local API tunnel.
-
-Foundation mode always omits the broad `ApplicationSet/k3s-apps`. The Lima
-validation requires the foundation Cilium and Dragonfly Operator Applications to
-be `Synced` and `Healthy`. It also fails if backup-writing or real-workload
-resources appear, including `Application/powerdns`, `Application/hass`, CNPG
-`ScheduledBackup` and `ObjectStore` resources, VolSync `ReplicationSource`,
-Velero `Schedule`, and the external-dns deployment. The real 1Password seed may
-be used because the profile does not create those writers.
-
-The Lima inventory deliberately disables kube-vip while keeping the same
-K3s/Cilium/BGP versions as the real bootstrap path. The live inventory still
-pins kube-vip to `v1.1.2`; Lima's default user-mode networking is not a
-reliable validation target for ARP VIP behavior.
-
-The Lima wrapper also keeps Cilium masquerading enabled when it applies the
-foundation ArgoCD resources. The real cluster disables Cilium masquerading
-because its network can route pod CIDRs; Lima's user-mode network cannot route
-pod CIDRs back to pods, so pod DNS and external egress require masquerading in
-the disposable test cluster.
-
-## Local Lima App Test
-
-After the foundation profile is healthy, run the app profile against the same
-Lima cluster. The app profile is materially heavier than foundation mode and
-defaults to four schedulable worker nodes with `4` CPU, `6GiB` memory,
-and enough disk for Longhorn restore, replica scheduling, and one-node
-replacement testing. The app-specific recipes create `120GiB` VM disks and
-preflight requires at least `100GiB`
-allocatable ephemeral storage per schedulable worker. Use the app-specific
-create/ansible recipes if running phase by phase:
-
-```sh
-just bootstrap-lima-delete
-just bootstrap-lima-create-apps
-just bootstrap-lima-ansible-apps
-```
-
-Then bootstrap and validate:
-
-```sh
-just bootstrap-lima-bootstrap-apps
-just bootstrap-lima-validate-apps
-```
-
-Or recreate the VMs and run the app profile in one step:
-
-```sh
-just bootstrap-lima-fresh-apps
-```
-
-To validate app-level changes from a branch before they merge to `master`, push
-the branch first and point the generated Applications at it:
-
-```sh
-LIMA_APPSET_TARGET_REVISION=feat/my-branch just bootstrap-lima-fresh-apps
-```
-
-The app profile uses `--profile lima-apps`. It is intentionally still scoped:
-it restores Gateway wildcard TLS Secrets from 1Password, waits for
-`gateway/external-wildcard`, `gateway/mgmt-wildcard`, and
-`gateway/guest-wildcard` to contain `tls.crt` and `tls.key`, applies
-external-snapshotter from `apps/kube-system/external-snapshotter`, then applies
-the existing `ApplicationSet/k3s-apps` name with a Lima-only allowlist.
-Validation waits for allowlisted ArgoCD Application sync operations and then
-requires those Applications to become `Synced` and `Healthy`. It then requires
-all non-completed pods to settle to Running and Ready.
-
-The first allowlist includes cert-manager, external-secrets, kube-system
-support resources, Longhorn support resources, CNPG, Envoy Gateway, Gateway,
-`hass`, and `powerdns`. The rendered desired state removes Gateway ACME
-annotations, removes `PushSecret` resources, removes VolSync
-`ReplicationSource`, removes CNPG backup schedules, removes active CNPG
-Cluster plugins while keeping externalCluster recovery configuration, removes
-the Longhorn backup `RecurringJob`, and removes kube-vip from the disposable
-Lima cluster. VolSync restore destinations keep their retain storage class
-because the restored snapshot must survive long enough to populate the final
-PVC.
-
-The app profile also installs Lima-only `ValidatingAdmissionPolicy` guardrails
-that deny known external writer resources such as `PushSecret`,
-`ClusterPushSecret`, ACME `Order`/`Challenge`, VolSync `ReplicationSource`,
-CNPG backup resources, Velero backup resources, external-dns `DNSEndpoint`, and
-Longhorn backup `RecurringJob`, plus active CNPG Cluster plugins. The
-render-time patches are the primary safety control; admission is there to fail
-closed if a future manifest reintroduces a writer or archive-backed active
-plugin.
-
-## Real Cluster Bootstrap
-
-### Live Ansible Wrapper
-
-The physical-node Ansible wrapper lives in `hack/bootstrap/ansible/`. It uses
-the in-repo `home-ops` backend by default and renders site-specific inventory
-and values from home-ops. The external `../k3s-ansible` checkout remains
-available as an explicit compatibility backend with
-`BOOTSTRAP_ANSIBLE_BACKEND=k3s-ansible`.
-
-Render the live plan without changing nodes:
-
-```sh
-just bootstrap-live-ansible-plan
-```
-
-Render through the external compatibility backend:
-
-```sh
-BOOTSTRAP_ANSIBLE_BACKEND=k3s-ansible just bootstrap-live-ansible-plan
-```
-
-This writes non-secret generated inventory under
-`hack/bootstrap/.out/ansible-live/` and prints the target hosts, first
-control-plane node, K3s version, Cilium version/config, kube-vip tag, and API
-endpoint.
-
-The live `k3s_token` is stored in 1Password at:
+The app recipes set:
 
 ```text
-op://Kubernetes/k3s-bootstrap/k3s_token
+LIMA_AGENT_COUNT=4
+LIMA_AGENT_CPUS=4
+LIMA_AGENT_MEMORY_GIB=6
+LIMA_DISK_GIB=120
+LIMA_VALIDATE_APP_WAIT_SECONDS=3600
 ```
 
-For an existing cluster, import the already-running server token explicitly
-before the first wrapper-managed run:
+The app-profile preflight requires at least `100GiB` allocatable ephemeral
+storage per schedulable worker.
+
+To test app manifests from an unmerged branch, push the branch first:
 
 ```sh
-just bootstrap-ansible-import-token
+LIMA_APPSET_TARGET_REVISION=feat/my-branch just lima-apps-fresh
 ```
 
-The import command reads the token from the first control-plane node and writes
-it to 1Password. It does not run Ansible or Kubernetes bootstrap and does not
-log the token.
+The `lima-apps` profile transforms `ApplicationSet/k3s-apps` before ArgoCD
+sees it. It first applies an infrastructure allowlist, waits for those apps,
+then releases the workload allowlist.
 
-Run Ansible convergence only:
+Allowlisted app Applications:
+
+- `cert-manager`
+- `cnpg-system`
+- `envoy-gateway-system`
+- `external-secrets`
+- `gateway`
+- `hass`
+- `kube-system`
+- `longhorn-system`
+- `powerdns`
+
+The Lima validator also expects explicit platform Applications such as
+`cilium` and `dragonfly-operator` to be healthy before app safety checks pass.
+
+The app profile must not create external writers:
+
+- `PushSecret` or `ClusterPushSecret`
+- ACME `Order` or `Challenge`
+- VolSync `ReplicationSource`
+- CNPG `Backup` or `ScheduledBackup`
+- active CNPG `Cluster.spec.plugins`
+- Velero backup resources
+- external-dns `DNSEndpoint`
+- Longhorn backup `RecurringJob`
+
+Render-time patches are the primary safety control. Lima-only
+`ValidatingAdmissionPolicy` resources are fail-closed guardrails.
+
+## Cilium And App Ordering
+
+Bootstrap withholds `ApplicationSet/k3s-apps` until Cilium takeover is ready.
+
+When Cilium CRDs exist, the ArgoCD phase applies Hubble CA resources and the
+explicit Cilium Application first. The wait phase then waits for Cilium sync,
+Hubble server and relay certificates, and Cilium health.
+
+If stale Hubble cert Secrets from the bootstrap install were replaced,
+bootstrap restarts Cilium and Hubble relay so they load the new certs.
+
+Before normal apps are released, bootstrap applies
+`apps/kube-system/external-snapshotter` so VolSync restore workloads have the
+snapshot CRDs and controller.
+
+Lima keeps Cilium masquerading enabled because user-mode networking cannot
+route pod CIDRs back to pods. The live cluster can route pod CIDRs and does not
+need that Lima-only setting.
+
+## Live Bootstrap Workflow
+
+The live wrapper uses the in-repo `home-ops` Ansible backend by default. It
+renders site-specific inventory and values from home-ops before running
+Ansible.
+
+The external `../k3s-ansible` checkout is still available for comparison:
 
 ```sh
-just bootstrap-live-ansible
+BOOTSTRAP_ANSIBLE_BACKEND=k3s-ansible just ansible-plan
 ```
 
-Run the Kubernetes bootstrap only, after K3s already exists:
+Render before mutating nodes:
 
 ```sh
-just bootstrap-live-kube default
+just ansible-plan
 ```
 
-Run both behind one wrapper-level confirmation prompt:
+For an existing cluster, import the already-running server token before the
+first wrapper-managed run:
 
 ```sh
-just bootstrap-live-full
+just ansible-import-token
 ```
 
-The live wrapper derives values that must match GitOps desired state, including
-the K3s version from `apps/system-upgrade`, Cilium Helm values from the explicit
-ArgoCD Application, Cilium BGP resources from `apps/kube-system/cilium`, and
-the kube-vip tag/API VIP from `apps/kube-system/kube-vip`. If the checked-in
-live overrides try to set one of those derived-owned values differently, the
-render fails instead of silently choosing one.
-
-Keep `../k3s-ansible` close to upstream when using the external compatibility
-backend. The wrapper does not require its sample defaults to match the homelab;
-it renders the homelab values as an overlay. The default `home-ops` backend
-does not use the external checkout.
-
-### Node Lifecycle
-
-Node lifecycle helpers live in `hack/bootstrap/nodes/` and are for existing
-clusters, not first-boot bootstrap. Worker lifecycle is intentionally split
-into explicit operator steps. Control-plane nodes support status, read-only
-delete preflight, drain, optional Longhorn eviction, delete, join, and
-uncordon:
+Run Ansible only:
 
 ```sh
-just node-live-status k3s-worker-0
-just node-live-control-plane-status k3s-master-0
-just node-live-control-plane-delete-preflight k3s-master-0
-just node-live-drain k3s-master-1
-just node-live-longhorn-evict k3s-master-1
-just node-live-delete k3s-master-1
-just node-live-refresh-ssh-host-key k3s-master-1
-just node-live-join k3s-master-1
-just node-live-uncordon k3s-master-1
-just node-live-drain k3s-worker-0
-just node-live-longhorn-evict k3s-worker-0
-just node-live-delete k3s-worker-0
-just node-live-refresh-ssh-host-key k3s-worker-0
-just node-live-join k3s-worker-0
-just node-live-uncordon k3s-worker-0
+just ansible-run
 ```
 
-The Lima equivalents use the `node-lima-*` group:
+Run Kubernetes bootstrap only after K3s exists. It targets the active kube
+context:
 
 ```sh
+just bootstrap
+```
+
+Run Ansible and Kubernetes bootstrap together:
+
+```sh
+just ansible-bootstrap
+```
+
+The live wrapper derives values that must match GitOps desired state:
+
+- K3s version from `apps/system-upgrade`.
+- Cilium version and values from the explicit ArgoCD Application.
+- Cilium BGP resources from `apps/kube-system/cilium`.
+- kube-vip tag and API VIP from `apps/kube-system/kube-vip`.
+
+If checked-in live overrides conflict with a derived-owned value, rendering
+fails instead of silently choosing one.
+
+Initial K3s server args leave kube-proxy enabled so Ansible can complete before
+Cilium owns Service routing. The post-Cilium playbook disables kube-proxy when
+the derived Cilium config has `kube_proxy_replacement: true`.
+
+Generated live inventory, vars, kubeconfigs, and run output are written under
+`hack/bootstrap/.out/ansible-live/`.
+
+## Node Lifecycle
+
+Node lifecycle helpers are for existing clusters, not first boot.
+
+Live examples:
+
+```sh
+just node-list
+just node-status k3s-worker-0
+just node-pods k3s-worker-0
+just node-control-plane-status k3s-master-0
+just node-control-plane-delete-preflight k3s-master-0
+just node-drain k3s-worker-0
+just node-longhorn-evict k3s-worker-0
+just node-delete k3s-worker-0
+just node-refresh-ssh-host-key k3s-worker-0
+just node-join k3s-worker-0
+just node-uncordon k3s-worker-0
+```
+
+Lima examples:
+
+```sh
+just node-lima-list
 just node-lima-status home-ops-k3s-test-agent-1
+just node-lima-pods home-ops-k3s-test-agent-1
 just node-lima-control-plane-status home-ops-k3s-test-server-1
 just node-lima-control-plane-delete-preflight home-ops-k3s-test-server-1
 just node-lima-drain home-ops-k3s-test-server-2
@@ -384,175 +458,99 @@ just node-lima-delete home-ops-k3s-test-server-2
 just node-lima-refresh-ssh-host-key home-ops-k3s-test-server-2
 just node-lima-join home-ops-k3s-test-server-2
 just node-lima-uncordon home-ops-k3s-test-server-2
-just node-lima-drain home-ops-k3s-test-agent-1
-just node-lima-longhorn-evict home-ops-k3s-test-agent-1
-just node-lima-delete home-ops-k3s-test-agent-1
-just node-lima-refresh-ssh-host-key home-ops-k3s-test-agent-1
-just node-lima-join home-ops-k3s-test-agent-1
-just node-lima-uncordon home-ops-k3s-test-agent-1
 ```
 
-Control-plane drain, Longhorn eviction, and delete are guarded by the
-embedded-etcd member preflight.
-The control-plane status command is read-only and exists to validate that future
-procedure: it reports inventory/Ready quorum math and probes the selected server
-for K3s service state, datastore files, etcd listeners, and `etcdctl`
-availability. The home-ops Ansible backend derives the upstream `etcdctl`
-version from the K3s release's embedded Etcd version, verifies the release
-archive checksum, and installs `etcdctl` on control-plane nodes so
-embedded-etcd member inspection is available after node convergence.
-The control-plane delete preflight is also read-only. It queries etcd from an
-alternate Ready control-plane, maps the target node to exactly one etcd member,
-checks quorum math, and prints the future `etcdctl member remove` command
-without running it. Single-server Lima clusters cannot pass that HA preflight
-because there is no alternate etcd member to query.
+For normal maintenance or reboots, use drain and uncordon only.
+`longhorn-evict` is for node replacement.
 
-For normal node maintenance or reboots, run drain and then uncordon. Drain only
-requires ordinary workloads to move and Longhorn volumes to detach from the
-target node. It does not require every Longhorn volume to stay healthy, because
-three-replica volumes on exactly three storage nodes will be temporarily
-degraded while one node is drained.
+Control-plane delete is gated by read-only preflight, quorum checks, Longhorn
+eviction when installed, fresh K3s etcd snapshot creation, and explicit
+embedded-etcd member removal from a remaining control-plane.
 
-The delete step is deliberately conservative. Worker delete stops and disables
-`k3s-node` through Ansible before deleting the Kubernetes `Node` and the K3s
-node-password Secret, so the old node cannot immediately re-register.
-For control-plane nodes, run the same Longhorn eviction helper after drain and
-before delete when Longhorn is installed. Delete requires the node to be
-cordoned and empty, stops and disables `k3s`, rechecks the preflight from a
-remaining control-plane, creates a fresh K3s etcd snapshot, removes the target
-etcd member, then deletes the Kubernetes `Node` and node-password Secret. If
-the target is the first inventory master, live runs require the `default`
-context to use the stable API endpoint; Lima runs retarget the local API tunnel
-to an alternate Ready control-plane before stopping the target and may update
-the Lima kubeconfig context to a different local port if the default tunnel
-port is already occupied. For node replacement, run `node-*-longhorn-evict`
-after drain and before delete. The eviction helper disables Longhorn scheduling
-for the target, requests replica eviction, and fails before mutating anything if
-the remaining eligible storage nodes cannot hold the maximum configured replica
-count. Delete and eviction completion allow stopped stale target-node replica
-records only after the desired healthy replica count exists on other nodes.
-Delete also clears stale pod objects still bound to the removed node and waits
-for the Longhorn node resource to disappear before a same-name join can
-proceed.
+Join starts K3s with `node.home-ops.sh/joining=true:NoSchedule`, then cordons
+the node. Uncordon removes the temporary taint, waits for Cilium, checks
+Longhorn scheduling readiness, and restores scheduling.
 
-Join uses the generated home-ops Ansible playbook for the node role and starts
-the K3s service with `node.home-ops.sh/joining=true:NoSchedule`. First-master
-control-plane rejoin passes an alternate Ready control-plane InternalIP as the
-temporary K3s `--server` endpoint so the replacement does not try to join
-through itself. After the node object appears, the helper cordons it while
-Cilium settles. The uncordon helper removes the taint from the rendered K3s
-service and finalizes the server back to the normal stable endpoint, restarts
-the service if needed, removes the live taint, waits for Cilium, verifies
-Longhorn is ready to schedule on the node, uncordons, and then verifies
-Longhorn marks the node schedulable.
+## Live Validation
 
-Review the active context:
+Live bootstrap recipes use the active kube context. Switch to the intended
+context before running them, and inspect it first when in doubt.
+
+Check the live target explicitly when needed:
 
 ```sh
-kubectl config current-context
+just context default
 ```
 
-Dry-run against the current context:
+Run read-only bootstrap inventory against the active context:
+
+```sh
+just bootstrap-audit
+```
+
+Run server-side dry-run against the active context:
 
 ```sh
 just bootstrap-dry-run
 ```
 
-Run with confirmation prompts:
+This starts at `bootstrap-crds`, skips rollout waits, and validates rendered
+resources against the real API server, installed CRDs, admission webhooks, and
+RBAC. It does not prove first-boot timing because the live cluster already has
+CRDs, controllers, namespaces, and secrets.
+
+If the all-in-one dry-run stops on one object, continue coverage phase by
+phase:
 
 ```sh
-just bootstrap
+just bootstrap-phase dragonfly-operator
+just bootstrap-phase argocd-dependencies
+just bootstrap-phase argocd
+just bootstrap-phase wait-argocd
+just bootstrap-phase takeover-cleanup
 ```
 
-Run non-interactively after confirming the context is correct:
-
-```sh
-just bootstrap-yes
-```
-
-Run against an explicit local repo path:
-
-```sh
-just bootstrap /path/to/home-ops
-```
-
-## Live Cluster Validation
-
-Use the `default` context for the live homelab cluster unless kubeconfig has
-been changed deliberately:
-
-```sh
-kubectl --context default get nodes -o wide
-```
-
-Run a read-only inventory of Helm release storage, ArgoCD applications, and core
-deployments:
-
-```sh
-just bootstrap-live-audit default
-```
-
-Run the live API validation without reading the 1Password seed secret and
-without persisting changes:
-
-```sh
-just bootstrap-live-dry-run default
-```
-
-This starts at `bootstrap-crds`, uses server-side dry-run for rendered resources,
-and skips rollout waits. It validates the manifests against the real API server,
-installed CRDs, admission webhooks, and RBAC. It does not prove first-boot timing
-because the real cluster already has CRDs, controllers, namespaces, and secrets.
-Use a clean kind reset for first-boot ordering.
-
-Live dry-run can fail on existing managed-field ownership that does not affect
-the currently synced live cluster. For example, older resources may have fields
-owned by `argocd-controller` through an `Update` operation, and a server-side
-dry-run apply from the bootstrap script may report a conflict on that field. Treat
-that as managed-field drift to investigate, not as a bootstrap ordering failure.
-
-If the all-in-one dry-run stops on one object, continue coverage phase by phase:
-
-```sh
-just bootstrap-live-phase dragonfly-operator default
-just bootstrap-live-phase argocd-dependencies default
-just bootstrap-live-phase argocd default
-just bootstrap-live-phase wait-argocd default
-just bootstrap-live-phase takeover-cleanup default
-```
-
-Do not run a live non-dry-run bootstrap from an unmerged branch. For the live
-cluster, use dry-run from a branch and let merged `master` plus ArgoCD own
-steady-state changes.
+Managed-field conflicts in live dry-run are drift to investigate. They are not
+automatically bootstrap ordering failures.
 
 ## 1Password Seed Secret
 
-The seed phase creates `Secret/external-secrets/op-credentials`. The secret
-manifest is read from 1Password, validated, normalized to Secret `data`, and
-streamed to Kubernetes with server-side apply. It is not written to disk or
-included in the local run report, and the bootstrap removes any old
-`kubectl.kubernetes.io/last-applied-configuration` annotation from the seed
-Secret. This one apply path uses scoped server-side `--force-conflicts` because
-the 1Password item is authoritative for the bootstrap seed Secret and older
-clusters may have created it with client-side apply.
+The seed phase creates `Secret/external-secrets/op-credentials`.
 
-The seed phase first tries `op read`. If that fails and the run is interactive,
-it runs `op signin`, evaluates the returned session export inside the bootstrap
-process without logging it, and then retries the read. Only the Secret manifest
-is written to stdout for the YAML pipeline.
+The manifest is read from 1Password, validated, normalized to Secret `data`,
+and streamed to Kubernetes with server-side apply. It is not written to disk,
+logs, reports, or client-side last-applied annotations.
 
-If the automatic prompt is not appropriate, authenticate first:
+The seed apply uses narrow server-side `--force-conflicts` because the
+1Password item is authoritative and older clusters may have created the Secret
+with client-side apply.
+
+The seed phase tries `op read`. If that fails in an interactive run, it runs
+`op signin`, evaluates the returned session export inside the bootstrap
+process without logging it, and retries.
+
+That interactive fallback is scoped to the bootstrap process. If you want
+later bootstrap runs to avoid another password prompt, run the signin in your
+shell.
+
+If automatic `op` auth is not appropriate, authenticate first:
 
 ```sh
 eval "$(op signin)"
 ```
 
-Then rerun bootstrap. You can also pipe the seed manifest directly to bypass
-all script-managed `op` calls:
+For Lima, you can also pipe the seed manifest to a stdin recipe:
 
 ```sh
 op read op://Kubernetes/op-credentials/op-credentials.yaml \
-  | ./hack/bootstrap/bootstrap.sh --only-phase seed-secret --seed-secret-stdin --yes
+  | just lima-bootstrap-stdin
+```
+
+For Lima app-profile runs:
+
+```sh
+op read op://Kubernetes/op-credentials/op-credentials.yaml \
+  | just lima-apps-bootstrap-stdin
 ```
 
 Use `--op-account` only when multiple accounts require disambiguation. Prefer
@@ -560,7 +558,7 @@ the shorthand from `op account list`.
 
 ## Phases
 
-The runner logs each phase name and makes every phase idempotent:
+Bootstrap phases run in this order:
 
 1. `preflight`
 2. `seed-secret`
@@ -575,34 +573,40 @@ The runner logs each phase name and makes every phase idempotent:
 11. `takeover-cleanup`
 12. `audit`
 
-Run only one phase when debugging:
+For live phase debugging, use:
 
 ```sh
-./hack/bootstrap/bootstrap.sh --only-phase audit
+just bootstrap-phase argocd
 ```
 
-Start from a later phase:
+For current-context operation, the generic recipes are:
 
 ```sh
-./hack/bootstrap/bootstrap.sh --from-phase argocd --yes
+just bootstrap-dry-run
+just bootstrap
+just bootstrap-yes
 ```
 
 ## Reports
 
-Each run writes non-secret output under `hack/bootstrap/.out/`. The directory is
-gitignored. Use the report when comparing a kind test to a real-cluster run.
+Each run writes non-secret output under `hack/bootstrap/.out/`. The directory
+is gitignored.
+
+Use reports to compare kind, Lima, and live dry-run behavior. Secret manifests
+must never be written there.
 
 ## After Bootstrap
 
-On the real cluster, ArgoCD should own the steady-state sync after bootstrap.
-Check Application status:
+On the real cluster, ArgoCD should own steady-state sync after bootstrap.
 
-```sh
-kubectl -n argocd get applications.argoproj.io
-```
-
-Run the audit phase after takeover cleanup or after manual investigation:
+Start with:
 
 ```sh
 just bootstrap-audit
+```
+
+For direct ArgoCD status inspection:
+
+```sh
+just argocd-apps
 ```

--- a/hack/bootstrap/AGENTS.md
+++ b/hack/bootstrap/AGENTS.md
@@ -129,7 +129,7 @@ Keep this list in sync with `PHASES` in `bootstrap.sh` and the phase list in
   validation recipe.
 - Validation ladder:
   `just bootstrap-test` for Bash and offline behavior,
-  `just bootstrap-kind-fresh` for disposable Kubernetes bootstrap behavior,
+  `just kind-fresh` for disposable Kubernetes bootstrap behavior,
   Lima foundation recipes for Cilium and ArgoCD takeover behavior,
   Lima app recipes for Longhorn, VolSync, CNPG restore, and workload safety,
   live audit/dry-run recipes for real-cluster field ownership and drift.

--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -1,389 +1,259 @@
 # Home Ops Bootstrap
 
-This directory contains the local bootstrap tooling for fresh-cluster takeover.
-It covers two layers:
+This directory contains the guarded tooling used before ArgoCD can fully take
+over a fresh or disposable cluster.
 
-1. a guarded Ansible wrapper for physical node convergence
-2. the Kubernetes bootstrap runner that seeds the minimum dependencies needed
-   before ArgoCD can take over
+Use the root `justfile` for operator workflows. Direct scripts in this
+directory are implementation details behind those recipes.
 
-For the operator-facing `just` runbook, see
+```sh
+just --list
+```
+
+For the longer operator runbook, see
 [`docs/just-bootstrap.md`](../../docs/just-bootstrap.md).
 
-For local script validation, run:
+## What Lives Here
+
+| Path | Purpose |
+| --- | --- |
+| `bootstrap.sh` | Phase runner for Kubernetes takeover dependencies. |
+| `phases/` | Idempotent bootstrap phases sourced by `bootstrap.sh`. |
+| `lib/` | Shared bootstrap logging, rendering, apply, and report helpers. |
+| `ansible/` | Live and Lima K3s node convergence wrapper. |
+| `lima/` | Disposable VM harness for foundation and app-profile testing. |
+| `nodes/` | Existing-cluster node lifecycle helpers. |
+| `tests/bats/` | Offline regression tests for parsing, rendering, and helpers. |
+| `.out/` | Disposable local reports, inventories, kubeconfigs, and renders. |
+
+Do not commit `.out/`.
+
+## Fast Path
+
+| Goal | Recipe |
+| --- | --- |
+| List available commands | `just --list` |
+| Show active cluster status | `just context` |
+| Run full local checks | `just check` |
+| Test bootstrap Bash and offline behavior | `just bootstrap-test` |
+| Recreate kind and bootstrap from scratch | `just kind-fresh` |
+| Show kind status | `just kind-status` |
+| Dry-run an already bootstrapped kind cluster | `just kind-bootstrap-dry-run` |
+| Run Lima foundation bootstrap | `just lima-fresh` |
+| Show Lima status | `just lima-status` |
+| Run larger Lima app-profile bootstrap | `just lima-apps-fresh` |
+| Render live Ansible inventory and vars | `just ansible-plan` |
+| Audit active bootstrap/takeover state | `just bootstrap-audit` |
+| Dry-run Kubernetes bootstrap on the active context | `just bootstrap-dry-run` |
+| Run live Ansible plus Kubernetes bootstrap | `just ansible-bootstrap` |
+
+Use the smallest validation that proves the change. Most script edits only
+need `just bootstrap-test`; Cilium, Longhorn, VolSync, CNPG, and ArgoCD
+behavior need Lima or live dry-run/audit validation.
+
+## Bootstrap Scope
+
+Bootstrap installs only what ArgoCD needs before it can reconcile the rest of
+the repository:
+
+1. 1Password seed Secret for External Secrets.
+2. Required CRDs.
+3. cert-manager.
+4. External Secrets and 1Password Connect.
+5. Gateway wildcard TLS Secrets when normal apps are in scope.
+6. Dragonfly Operator.
+7. Narrow ArgoCD dependencies.
+8. Canonical `apps/argocd` render.
+9. ArgoCD readiness gates.
+10. Helm takeover cleanup and audit.
+
+Normal workloads should stay out of `hack/bootstrap/` unless they are required
+before ArgoCD can take over.
+
+## Profiles
+
+| Profile | Use |
+| --- | --- |
+| `full` | Real-cluster takeover profile. Applies dependencies, ArgoCD, readiness waits, and audit. |
+| `foundation` | Lima foundation profile. Validates K3s, Cilium takeover, core operators, and ArgoCD without normal apps. |
+| `lima-apps` | Disposable app-profile validation with a sanitized app allowlist and external-writer guardrails. |
+
+## Kind
+
+Kind is the fastest disposable Kubernetes check.
+
+| Goal | Recipe |
+| --- | --- |
+| Create the three-node kind cluster | `just kind-create` |
+| Show kind status | `just kind-status` |
+| Bootstrap the configured kind cluster | `just kind-bootstrap` |
+| Resume from a phase | `just kind-bootstrap-resume bootstrap-crds` |
+| Seed only the 1Password credential | `just kind-bootstrap-seed` |
+| Delete the kind cluster | `just kind-delete` |
+
+When Cilium CRDs are absent, bootstrap omits real-cluster-only resources such
+as the full `ApplicationSet/k3s-apps`, Cilium, Longhorn, and
+`crd-schema-publisher`.
+
+Server-side dry-run does not persist CRDs on a clean cluster. Use
+`just kind-fresh` for first-boot behavior, then
+`just kind-bootstrap-dry-run` after CRDs exist.
+
+## Lima
+
+Lima is the Apple Silicon VM harness for end-to-end behavior.
+
+| Goal | Foundation Recipe | App-Profile Recipe |
+| --- | --- | --- |
+| Create VMs | `just lima-create` | `just lima-apps-create` |
+| Run Ansible | `just lima-ansible` | `just lima-apps-ansible` |
+| Run Kubernetes bootstrap | `just lima-bootstrap` | `just lima-apps-bootstrap` |
+| Validate | `just lima-validate` | `just lima-apps-validate` |
+| Full fresh run | `just lima-fresh` | `just lima-apps-fresh` |
+
+Useful maintenance recipes:
 
 ```sh
-just bootstrap-test
+just lima-status
+just lima-context
+just lima-delete
 ```
 
-This runs ShellCheck plus the offline BATS suite in
-`hack/bootstrap/tests/bats/`. The BATS suite covers parse/render checks,
-Ansible inventory and command construction, node lifecycle helper behavior,
-and bootstrap library safety checks. Use Lima or live recipes only for
-validation that needs real Kubernetes, Longhorn, ArgoCD, or VM/node state.
+Foundation defaults to one server VM with `4` CPU and `6GiB` memory plus two
+agent VMs with `2` CPU and `3GiB` memory.
 
-The Kubernetes runner is intentionally outside normal GitOps app state. It
-seeds the minimum dependencies needed for ArgoCD to take over:
+The app-profile recipes create four larger agent VMs with `4` CPU, `6GiB`
+memory, and `120GiB` disks for topology spread, Longhorn, VolSync restores,
+database operators, and node replacement testing.
 
-1. Seed `Secret/external-secrets/op-credentials` from 1Password CLI.
-2. Install required CRDs.
-3. Bootstrap cert-manager.
-4. Bootstrap External Secrets and 1Password Connect.
-5. Seed Gateway wildcard TLS Secrets from 1Password when the selected profile
-   will apply normal apps.
-6. Bootstrap Dragonfly Operator.
-7. Apply narrow ArgoCD dependencies.
-8. Apply the canonical `apps/argocd` render.
-9. Wait for ArgoCD components.
-10. Run conservative Helm takeover cleanup and audit.
-
-The physical-node Ansible wrapper is the supported way to converge K3s nodes
-for this repo. It renders the homelab inventory and GitOps-owned values before
-calling Ansible. The default backend is the in-repo
-`hack/bootstrap/ansible/home-ops/` implementation. The external
-`../k3s-ansible` checkout remains available as an explicit compatibility
-backend for side-by-side comparison.
-
-Render the live Ansible plan without changing nodes:
-
-```sh
-just bootstrap-live-ansible-plan
-```
-
-Run a Kubernetes bootstrap dry-run against the current kube context:
-
-```sh
-./hack/bootstrap/bootstrap.sh --dry-run
-```
-
-On a clean cluster, dry-run does not persist CRDs. Use a real guarded kind
-bootstrap for first-boot validation, then dry-run later phases after the CRDs
-exist.
-
-Run against an explicit context:
-
-```sh
-./hack/bootstrap/bootstrap.sh --kube-context kind-home-ops-bootstrap --yes
-```
-
-Run the safety-scoped foundation profile:
-
-```sh
-./hack/bootstrap/bootstrap.sh --profile foundation --kube-context kind-home-ops-bootstrap --yes
-```
-
-The foundation profile always omits the broad `ApplicationSet/k3s-apps` and
-applies only the explicit ArgoCD Applications needed for bootstrap takeover.
-It is intended for disposable VM validation where Cilium is already present but
-normal workloads and external backup writers must not start.
-In this profile, Dragonfly Operator's optional `ServiceMonitor` and
-`GrafanaDashboard` outputs are disabled because the monitoring and Grafana
-operators are intentionally left to steady-state ArgoCD.
-
-For local bootstrap testing, recreate kind as one control-plane plus two worker
-nodes so required pod anti-affinity can schedule:
-
-```sh
-just kind-reset
-```
-
-When `ciliumnetworkpolicies.cilium.io` is absent, the ArgoCD phase omits
-real-cluster-only applications such as the full `k3s-apps` ApplicationSet,
-Longhorn, Cilium, and `crd-schema-publisher`.
-
-When Cilium CRDs are present, bootstrap still withholds
-`ApplicationSet/k3s-apps` from the first ArgoCD apply. It applies the Hubble CA
-chain, reconciles `Application/cilium`, waits for the Hubble server and relay
-certificates, restarts Cilium/Hubble if stale takeover certs were replaced, and
-then waits for the explicit platform Applications for Dragonfly Operator,
-Grafana Operator, Longhorn, Reloader, and VolSync. Before releasing
-`ApplicationSet/k3s-apps`, it also applies external-snapshotter from
-`apps/kube-system/external-snapshotter` so VolSync restore workloads have
-snapshot CRDs/controller available.
-
-For a closer foundation test on Apple Silicon, use the Lima harness under
-`hack/bootstrap/lima/`. It creates one K3s server and two agents, runs the
-selected Ansible backend, bootstraps home-ops with `--profile foundation`,
-validates current Cilium BGP CRDs/manifests, and fails if backup writers such
-as `powerdns`, `hass`, VolSync, Velero, or CNPG backup resources are created.
-It also requires the foundation ArgoCD Applications for Cilium and Dragonfly
-Operator to be `Synced` and `Healthy`.
-
-The foundation profile applies the Hubble cert-manager issuer chain before
-ArgoCD reconciles the Cilium Helm chart. During takeover from the initial
-Ansible-installed Cilium, it rotates stale Hubble cert Secrets that were not
-issued by `Issuer/cilium-hubble-ca` and restarts Cilium/Hubble after the
-replacement certs are ready.
-
-After foundation is working, the Lima harness can run the narrower app profile:
-
-```sh
-just bootstrap-lima-bootstrap-apps
-just bootstrap-lima-validate-apps
-```
-
-If an app-profile test needs app manifests from a branch before they merge to
-`master`, push the branch and set `LIMA_APPSET_TARGET_REVISION` for the Lima
-bootstrap run.
-
-The `lima-apps` profile restores Gateway wildcard TLS Secrets from 1Password
-through `ExternalSecret` resources before applying normal apps. It then applies
-external-snapshotter from `apps/kube-system/external-snapshotter` so VolSync
-restore workloads have snapshot CRDs/controller available, then applies the
-existing `ApplicationSet/k3s-apps` name with a Lima-only allowlist and
-render-time patches. The first app profile includes cert-manager,
-external-secrets, kube-system support resources, Longhorn support resources,
-CNPG, Envoy Gateway, Gateway, `hass`, and `powerdns`. It removes Gateway ACME
-annotations, removes active CNPG Cluster plugins while keeping externalCluster
-recovery configuration, deletes backup schedules and VolSync upload sources,
-and applies Lima-only admission policies that deny known external writer
-resources. VolSync restore destinations keep retain storage so the restored
-snapshot can populate the final PVC.
-
-By default the disposable foundation shape is one server VM using `4` CPU and
-`6GiB` memory plus two agent VMs using `2` CPU and `3GiB` memory. The app-profile
-`just` recipes create four larger agent VMs using `4` CPU and `6GiB` memory
-each with `120GiB` disks, because the allowed app set includes topology-spread
-workloads, Longhorn, VolSync restores, retained restore source volumes,
-database operators, and one-node replacement testing. Override with
-`LIMA_SERVER_COUNT`, `LIMA_SERVER_CPUS`,
+Override the shape with `LIMA_SERVER_COUNT`, `LIMA_SERVER_CPUS`,
 `LIMA_SERVER_MEMORY_GIB`, `LIMA_AGENT_COUNT`, `LIMA_AGENT_CPUS`,
-`LIMA_AGENT_MEMORY_GIB`, `LIMA_K3S_MASTER_TAINT`, or `LIMA_DISK_GIB` when
-needed.
+`LIMA_AGENT_MEMORY_GIB`, `LIMA_K3S_MASTER_TAINT`, or `LIMA_DISK_GIB`.
 
-Lima VM creation installs `open-iscsi` and `nfs-common` before Ansible runs.
-Longhorn needs the iSCSI initiator for block volumes, and RWX volumes need the
-NFS mount helper on each node.
+Lima VM creation installs `open-iscsi` and `nfs-common` before Ansible runs so
+Longhorn block and RWX volumes can mount.
 
-The Lima inventory uses the server VM IP as the K3s API endpoint. Lima's
-default user-mode networking is not a reliable place to validate an ARP VIP
-join path, so the Lima overlay disables kube-vip while still using the same
-K3s/Cilium/BGP values as the live wrapper where they matter. The initial Cilium
-install uses `netkit` so pod endpoints are created with the same datapath mode
-used by the steady-state ArgoCD Cilium chart.
+## App-Profile Safety
 
-The Lima wrapper keeps Cilium masquerading enabled when it applies the
-foundation ArgoCD resources. This is intentionally Lima-only: the real cluster
-can route pod CIDRs, but Lima's user-mode network cannot route pod CIDRs back
-to pods, so pod DNS and external egress require masquerading.
+The `lima-apps` profile transforms the existing `ApplicationSet/k3s-apps`
+before ArgoCD sees it. Render-time patches and fail-closed admission policies
+prevent external writes while still testing restores.
 
-After the Lima Ansible phase, the Lima harness imports the context
-`lima-home-ops-k3s-test` into the local kubeconfig and keeps an SSH tunnel open
-for the K3s API. Use `just bootstrap-lima-kubecontext` to refresh only that
-context and tunnel. `just bootstrap-lima-delete` stops the recorded tunnel.
+The profile must not create:
 
-## Live Ansible Bootstrap
+- `PushSecret`
+- ACME `Order` or `Challenge`
+- VolSync `ReplicationSource`
+- active CNPG `Cluster.spec.plugins`
+- CNPG backup resources
+- Velero backup resources
+- Longhorn backup jobs
 
-`hack/bootstrap/ansible/` orchestrates physical-node K3s convergence for the
-cluster. By default it uses the in-repo `home-ops` backend, while the external
-`../k3s-ansible` checkout remains available with
-`BOOTSTRAP_ANSIBLE_BACKEND=k3s-ansible` or `--backend k3s-ansible`.
+If a Lima app-profile run needs app manifests from an unmerged branch, push
+the branch and set `LIMA_APPSET_TARGET_REVISION` for the run.
 
-The `home-ops` backend is a small home-ops-specific playbook for Debian-family,
-systemd nodes. It supports the current live and Lima shapes, installs kube-vip
-and a minimal bootstrap Cilium, fetches kubeconfig into the same `.out/` flow,
-and leaves ArgoCD takeover plus the post-Cilium kube-proxy disable phase to the
-existing wrapper. It is intentionally not a broad replacement for
-`k3s-ansible`: it does not support reset/destroy, K3s upgrades, non-Debian OS
-families, or alternate CNIs.
+## Cilium Ordering
 
-The live inventory is intentionally non-secret and checked in under
-`hack/bootstrap/ansible/inventory/live/`. Generated inventory, group vars, and
-kubeconfigs are written under `hack/bootstrap/.out/ansible-live/`.
+Bootstrap withholds `ApplicationSet/k3s-apps` until Cilium takeover is ready.
 
-Render a non-mutating plan:
+When Cilium CRDs are present, bootstrap applies the Hubble issuer chain,
+reconciles `Application/cilium`, waits for Hubble server and relay certs,
+restarts Cilium/Hubble if stale takeover certs were replaced, and then releases
+apps.
 
-```sh
-just bootstrap-live-ansible-plan
-```
+Before normal apps are released, bootstrap applies
+`apps/kube-system/external-snapshotter` so VolSync restore workloads have the
+snapshot CRDs and controller.
 
-Render the same plan through the external compatibility backend:
+Lima keeps Cilium masquerading enabled because Lima user-mode networking cannot
+route pod CIDRs back to pods. The live cluster does not need that Lima-only
+setting.
 
-```sh
-BOOTSTRAP_ANSIBLE_BACKEND=k3s-ansible just bootstrap-live-ansible-plan
-```
+## Live Bootstrap
 
-For the external `k3s-ansible` backend, the rendered vars are a deterministic
-merge of:
+The live wrapper renders this repo's inventory and GitOps-derived values before
+calling Ansible.
 
-1. `k3s-ansible` sample vars.
-2. live home-ops overrides such as host facts, SSH user, interface names, and
-   timezone.
-3. values derived from home-ops manifests, including K3s version, Cilium
-   version/config, Cilium BGP settings, kube-vip tag, and API VIP.
-4. runtime secret references.
+| Goal | Recipe |
+| --- | --- |
+| Render a non-mutating plan | `just ansible-plan` |
+| Import an existing K3s token into 1Password | `just ansible-import-token` |
+| Run live Ansible only | `just ansible-run` |
+| Run Kubernetes bootstrap only on the active context | `just bootstrap` |
+| Run Ansible and Kubernetes bootstrap | `just ansible-bootstrap` |
 
-For the default `home-ops` backend, the external sample vars are omitted; the
-same live overrides, derived values, and runtime secret references are merged
-directly.
+The default Ansible backend is the in-repo `home-ops` backend for
+Debian-family, systemd nodes. The external `../k3s-ansible` backend remains
+available for comparison with `BOOTSTRAP_ANSIBLE_BACKEND=k3s-ansible`.
 
-For live inventory, derived-owned values fail on conflict instead of silently
-overriding human input. This keeps Ansible bootstrap aligned with the GitOps
-state ArgoCD will enforce later.
+Generated live inventory, group vars, kubeconfigs, and run output are written
+under `hack/bootstrap/.out/ansible-live/`. The checked-in live inventory under
+`hack/bootstrap/ansible/inventory/live/` is intentionally non-secret.
 
-The external `k3s-ansible` defaults do not need to match home-ops versions or
-network settings when that backend is explicitly selected. Keep that checkout
-close to upstream and let this wrapper render the homelab-specific K3s, Cilium,
-BGP, kube-vip, API endpoint, and control-plane taint values.
+The live K3s token lives at `op://Kubernetes/k3s-bootstrap/k3s_token`. Normal
+runs load it from 1Password. If an existing cluster already has a token, import
+it before the next run.
 
-Initial K3s server args intentionally leave kube-proxy enabled so Ansible
-bootstrap can complete before Cilium owns Service routing. After the selected
-backend installs and waits for Cilium, the wrapper runs a home-ops post-Cilium
-playbook. When the derived Cilium config has
-`kube_proxy_replacement: true`, that playbook writes
-`/etc/rancher/k3s/config.yaml.d/90-home-ops-kube-proxy.yaml` with
-`disable-kube-proxy: true`, then restarts K3s servers one at a time and waits
-for each node plus Cilium to become ready.
-
-The live K3s token is stored at `op://Kubernetes/k3s-bootstrap/k3s_token`.
-Normal runs load it from 1Password. If a fresh cluster has no remote token and
-the 1Password item is missing, the wrapper generates and stores a token. If an
-existing cluster already has a token, import it explicitly first:
-
-```sh
-just bootstrap-ansible-import-token
-```
-
-Then converge nodes with Ansible:
-
-```sh
-just bootstrap-live-ansible
-```
-
-Use the external compatibility backend explicitly when comparing behavior:
-
-```sh
-BOOTSTRAP_ANSIBLE_BACKEND=k3s-ansible just bootstrap-live-ansible
-```
-
-Run only the Kubernetes bootstrap after K3s already exists:
-
-```sh
-just bootstrap-live-kube default
-```
-
-Or run Ansible and then the home-ops Kubernetes bootstrap in one guarded
-command:
-
-```sh
-just bootstrap-live-full
-```
-
-The live Ansible run prompts for explicit confirmation by default and prints
-the target hosts, first control-plane host, derived K3s/Cilium versions, and API
-endpoint before making changes.
+Initial K3s server args leave kube-proxy enabled so Ansible can complete before
+Cilium owns Service routing. After Cilium is ready, the wrapper runs the
+post-Cilium playbook that disables kube-proxy when the derived Cilium config
+has `kube_proxy_replacement: true`.
 
 ## Node Lifecycle
 
-`hack/bootstrap/nodes/` contains existing-cluster node lifecycle helpers. The
-worker path is split into explicit status, drain, optional Longhorn eviction,
-delete, join, and uncordon steps. Control-plane nodes also support
-status, read-only delete preflight, drain, optional Longhorn eviction, delete,
-join, and uncordon:
+Node lifecycle commands operate on an existing cluster and are intentionally
+explicit.
 
-```sh
-just node-live-status k3s-worker-0
-just node-live-control-plane-status k3s-master-0
-just node-live-control-plane-delete-preflight k3s-master-0
-just node-live-drain k3s-master-1
-just node-live-longhorn-evict k3s-master-1
-just node-live-delete k3s-master-1
-just node-live-drain k3s-worker-0
-just node-live-longhorn-evict k3s-worker-0
-just node-live-delete k3s-worker-0
-just node-live-refresh-ssh-host-key k3s-worker-0
-just node-live-join k3s-worker-0
-just node-live-uncordon k3s-worker-0
-just node-live-refresh-ssh-host-key k3s-master-1
-just node-live-join k3s-master-1
-just node-live-uncordon k3s-master-1
-just node-lima-status home-ops-k3s-test-agent-1
-just node-lima-control-plane-status home-ops-k3s-test-server-1
-just node-lima-control-plane-delete-preflight home-ops-k3s-test-server-1
-just node-lima-drain home-ops-k3s-test-server-2
-just node-lima-longhorn-evict home-ops-k3s-test-server-2
-just node-lima-delete home-ops-k3s-test-server-2
-just node-lima-refresh-ssh-host-key home-ops-k3s-test-server-2
-just node-lima-join home-ops-k3s-test-server-2
-just node-lima-uncordon home-ops-k3s-test-server-2
-```
+| Goal | Live Recipe | Lima Recipe |
+| --- | --- | --- |
+| List nodes | `just node-list` | `just node-lima-list` |
+| Node status | `just node-status <node>` | `just node-lima-status <node>` |
+| Pods bound to node | `just node-pods <node>` | `just node-lima-pods <node>` |
+| Control-plane status | `just node-control-plane-status <node>` | `just node-lima-control-plane-status <node>` |
+| Control-plane delete preflight | `just node-control-plane-delete-preflight <node>` | `just node-lima-control-plane-delete-preflight <node>` |
+| Drain | `just node-drain <node>` | `just node-lima-drain <node>` |
+| Evict Longhorn replicas | `just node-longhorn-evict <node>` | `just node-lima-longhorn-evict <node>` |
+| Delete | `just node-delete <node>` | `just node-lima-delete <node>` |
+| Refresh SSH host key | `just node-refresh-ssh-host-key <node>` | `just node-lima-refresh-ssh-host-key <node>` |
+| Join from inventory | `just node-join <node>` | `just node-lima-join <node>` |
+| Remove joining taint and uncordon | `just node-uncordon <node>` | `just node-lima-uncordon <node>` |
 
-The control-plane status helper is read-only: it checks the inventory
-control-plane set, Ready control-plane nodes, quorum math, K3s service state,
-local datastore indicators, etcd listeners, and whether `etcdctl` is available
-for member inspection. The home-ops Ansible backend derives the upstream
-`etcdctl` version from the K3s release's embedded Etcd version, verifies the
-release archive checksum, and installs `etcdctl` on control-plane nodes so this
-probe can list members once embedded etcd is present. The control-plane delete
-preflight is also read-only: it must query etcd from an alternate Ready
-control-plane, match the target Kubernetes node to exactly one etcd member,
-check quorum math, and print the future `etcdctl member remove` command without
-running it. Single-server Lima clusters cannot pass that HA preflight because
-there is no alternate etcd member to query.
+For maintenance or reboot work, use `drain` and `uncordon` only.
+`longhorn-evict` is for node replacement and fails before mutating Longhorn if
+remaining storage nodes cannot hold the maximum configured replica count.
 
-For control-plane nodes, run the same Longhorn eviction helper after drain and
-before delete when Longhorn is installed. Delete requires the target to be
-cordoned and empty, stops/disables `k3s`, rechecks the preflight from a
-remaining control-plane, creates a fresh K3s etcd snapshot, removes the target
-etcd member, then deletes the Kubernetes Node and node-password Secret. If the
-target is the first inventory master, live runs require the `default` context
-to use the stable API endpoint; Lima runs retarget the local API tunnel to an
-alternate Ready control-plane before stopping the target and may update the
-Lima kubeconfig context to a different local port if the default tunnel port is
-already occupied. Worker delete stops and disables `k3s-node` before deleting
-the Kubernetes Node and node-password Secret. If Longhorn is installed, delete
-also requires Longhorn scheduling to be disabled for the target node, no
-attached volumes on the target node, and no active or unsafe target-node
-replica state. Stopped stale replica records are allowed only when Longhorn
-already has the desired healthy replica count on other nodes. Delete then
-clears stale pod objects still bound to the deleted node and waits for the
-Longhorn node resource to disappear before the same node name can be joined
-again.
+Control-plane delete is gated by read-only preflight, quorum checks, Longhorn
+eviction when Longhorn is installed, fresh K3s etcd snapshot creation, and
+explicit embedded-etcd member removal from a remaining control-plane.
 
-For normal maintenance or reboot work, use `drain` and `uncordon` only. The
-drain helper allows the expected temporary Longhorn degraded state after
-workloads leave the node, which matters when three-replica volumes are spread
-across exactly three storage nodes. The `longhorn-evict` helper is only for
-node replacement; it fails before mutating Longhorn if the remaining storage
-nodes cannot hold the maximum configured replica count.
+Join starts K3s with `node.home-ops.sh/joining=true:NoSchedule`, then cordons
+the node. Uncordon removes the temporary taint, waits for Cilium, checks
+Longhorn scheduling readiness, and restores scheduling.
 
-Join starts the K3s service with
-`node.home-ops.sh/joining=true:NoSchedule`, then cordons the node. Control-plane
-join also verifies the old etcd member is absent and moves any stale local K3s
-server DB aside before starting `k3s`; this is required when reusing a
-previously deleted control-plane node name. First-master control-plane rejoin
-passes an alternate Ready control-plane InternalIP as the temporary K3s
-`--server` endpoint so the replacement does not try to join through itself.
-The uncordon helper removes the joining taint from the rendered service and
-finalizes the server back to the normal stable endpoint, removes the live taint,
-waits for Cilium, verifies Longhorn is ready to schedule on the node,
-uncordons, and then verifies Longhorn marks the node schedulable.
+## Secrets
 
-If more than one 1Password account is configured and the default account is
-wrong, pin the account explicitly:
+Secret manifests read from 1Password are streamed directly to Kubernetes. They
+must not be written to disk, logs, reports, or client-side last-applied
+annotations.
 
-```sh
-./hack/bootstrap/bootstrap.sh --kube-context kind-home-ops-bootstrap --op-account my --yes
-```
+Keep 1Password CLI desktop app integration enabled and the app unlocked for
+interactive runs, or authenticate `op` before invoking a recipe. Leave
+`--op-account` unset unless you need to disambiguate accounts.
 
-The script writes local run logs under `.out/`. Secret manifests read from
-1Password are validated and streamed directly to Kubernetes; they are never
-written to disk or stored in the local run report. The seed Secret is normalized
-to `data`, applied server-side, and cleaned of any old
-`kubectl.kubernetes.io/last-applied-configuration` annotation. That seed apply
-uses scoped server-side `--force-conflicts` because the 1Password item is
-authoritative. The seed phase tries `op read` and, when that fails with
-interactive stdin, falls back to `op signin` without logging the returned
-session export. Keep 1Password CLI desktop app integration enabled and the app
-unlocked for local interactive bootstrap runs, or authenticate `op` before
-invoking the script. Leave `--op-account` unset unless you need to
-disambiguate accounts; when you do set it, use the shorthand from
-`op account list`, such as `my`.
+Interactive `op signin` fallback is scoped to the recipe process. Run
+`eval "$(op signin)"` in your shell first if repeated prompts are annoying.
 
-If script-managed `op` auth is not appropriate, let your shell run `op read`
-and pipe the manifest to the seed phase:
+If script-managed `op` auth is not appropriate, pipe the seed manifest to a
+stdin recipe:
 
 ```sh
 op read op://Kubernetes/op-credentials/op-credentials.yaml \
-  | ./hack/bootstrap/bootstrap.sh --kube-context kind-home-ops-bootstrap --only-phase seed-secret --seed-secret-stdin --yes
+  | just lima-bootstrap-stdin
+```
+
+For app-profile Lima runs:
+
+```sh
+op read op://Kubernetes/op-credentials/op-credentials.yaml \
+  | just lima-apps-bootstrap-stdin
 ```

--- a/hack/bootstrap/ansible/node-control-plane.sh
+++ b/hack/bootstrap/ansible/node-control-plane.sh
@@ -9,7 +9,7 @@ if [[ "${NODE_CONTROL_PLANE_ANSIBLE_INTERNAL:-}" != true ]]; then
     *" --help "*|*" -h "*)
       ;;
     *)
-      ansible_die "node-control-plane.sh is an internal helper; use the node-live/node-lima just recipes"
+      ansible_die "node-control-plane.sh is an internal helper; use the node-* or node-lima-* just recipes"
       ;;
   esac
 fi

--- a/hack/bootstrap/ansible/node-worker.sh
+++ b/hack/bootstrap/ansible/node-worker.sh
@@ -9,7 +9,7 @@ if [[ "${NODE_WORKER_ANSIBLE_INTERNAL:-}" != true ]]; then
     *" --help "*|*" -h "*)
       ;;
     *)
-      ansible_die "node-worker.sh is an internal helper; use the node-live/node-lima just recipes"
+      ansible_die "node-worker.sh is an internal helper; use the node-* or node-lima-* just recipes"
       ;;
   esac
 fi

--- a/justfile
+++ b/justfile
@@ -21,6 +21,71 @@ check:
 pre-commit:
     pre-commit run --all-files
 
+# Show current and target cluster status without mutating anything.
+[group('cluster')]
+context context='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    current="$(kubectl config current-context 2>/dev/null || true)"
+    target='{{ context }}'
+    if [[ -z "${target}" ]]; then
+      target="${current}"
+    fi
+    if [[ -z "${target}" ]]; then
+      echo "ERROR: no target context provided and no current kube context is set" >&2
+      exit 2
+    fi
+    printf 'current_context: '
+    if [[ -n "${current}" ]]; then
+      printf '%s\n' "${current}"
+    else
+      printf 'unavailable\n'
+    fi
+    printf 'target_context: %s\n\n' "${target}"
+    kubectl --context "${target}" get nodes -o wide
+    printf '\nargocd_applications:\n'
+    if ! kubectl --context "${target}" -n argocd get applications.argoproj.io -o wide; then
+      printf 'ArgoCD applications unavailable\n'
+    fi
+
+# List ArgoCD Applications, or one named Application, in a target context.
+[group('cluster')]
+argocd-apps app='' context='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target='{{ context }}'
+    if [[ -z "${target}" ]]; then
+      target="$(kubectl config current-context 2>/dev/null || true)"
+    fi
+    if [[ -z "${target}" ]]; then
+      echo "ERROR: no target context provided and no current kube context is set" >&2
+      exit 2
+    fi
+    if [[ -n '{{ app }}' ]]; then
+      kubectl --context "${target}" -n argocd get 'application/{{ app }}' -o wide
+    else
+      kubectl --context "${target}" -n argocd get applications.argoproj.io -o wide
+    fi
+
+# List ArgoCD ApplicationSets, or one named ApplicationSet, in a target context.
+[group('cluster')]
+argocd-appsets appset='' context='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+    target='{{ context }}'
+    if [[ -z "${target}" ]]; then
+      target="$(kubectl config current-context 2>/dev/null || true)"
+    fi
+    if [[ -z "${target}" ]]; then
+      echo "ERROR: no target context provided and no current kube context is set" >&2
+      exit 2
+    fi
+    if [[ -n '{{ appset }}' ]]; then
+      kubectl --context "${target}" -n argocd get 'applicationset/{{ appset }}' -o wide
+    else
+      kubectl --context "${target}" -n argocd get applicationsets.argoproj.io -o wide
+    fi
+
 # Render one top-level app directory with the same Kustomize Helm settings used by CI.
 [group('apps')]
 app-build $app:
@@ -43,9 +108,17 @@ app-build $app:
 
 # Server-side dry-run one top-level app with ArgoCD's field manager.
 [group('apps')]
-app-dry-run $app $context='default':
+app-dry-run $app $context='':
     #!/usr/bin/env bash
     set -euo pipefail
+    target="${context}"
+    if [[ -z "${target}" ]]; then
+      target="$(kubectl config current-context 2>/dev/null || true)"
+    fi
+    if [[ -z "${target}" ]]; then
+      echo "ERROR: no target context provided and no current kube context is set" >&2
+      exit 2
+    fi
     case "${app}" in
       ""|.*|*/*|*[^A-Za-z0-9_-]*)
         echo "ERROR: app must be a top-level directory name under apps/" >&2
@@ -60,13 +133,21 @@ app-dry-run $app $context='default':
     trap 'rm -rf "${dir}/charts"' EXIT
     rm -rf "${dir}/charts"
     kustomize build --enable-helm --helm-api-versions '{{ helm_api_version }}' "${dir}" \
-      | kubectl --context "${context}" apply --server-side --dry-run=server --field-manager=argocd-controller -f -
+      | kubectl --context "${target}" apply --server-side --dry-run=server --field-manager=argocd-controller -f -
 
 # Diff one top-level app against a cluster using ArgoCD's field manager.
 [group('apps')]
-app-diff $app $context='default':
+app-diff $app $context='':
     #!/usr/bin/env bash
     set -euo pipefail
+    target="${context}"
+    if [[ -z "${target}" ]]; then
+      target="$(kubectl config current-context 2>/dev/null || true)"
+    fi
+    if [[ -z "${target}" ]]; then
+      echo "ERROR: no target context provided and no current kube context is set" >&2
+      exit 2
+    fi
     case "${app}" in
       ""|.*|*/*|*[^A-Za-z0-9_-]*)
         echo "ERROR: app must be a top-level directory name under apps/" >&2
@@ -84,7 +165,7 @@ app-diff $app $context='default':
     kustomize build --enable-helm --helm-api-versions '{{ helm_api_version }}' "${dir}" > "${render}"
     set +e
     KUBECTL_EXTERNAL_DIFF="${PWD}/hack/kubectl-git-diff.sh" \
-      kubectl --context "${context}" diff --server-side --field-manager=argocd-controller -f "${render}"
+      kubectl --context "${target}" diff --server-side --field-manager=argocd-controller -f "${render}"
     status="$?"
     set -e
     if [[ "${status}" == 1 ]]; then
@@ -105,197 +186,253 @@ bootstrap-yes repo='.':
 # Server-side dry-run the bootstrap flow against the current kube context.
 [group('bootstrap')]
 bootstrap-dry-run repo='.':
-    ./hack/bootstrap/bootstrap.sh --repo '{{ repo }}' --dry-run
+    ./hack/bootstrap/bootstrap.sh --repo '{{ repo }}' --from-phase bootstrap-crds --dry-run --yes
+
+# Server-side dry-run one bootstrap phase against the current kube context.
+[group('bootstrap')]
+bootstrap-phase phase repo='.':
+    ./hack/bootstrap/bootstrap.sh --repo '{{ repo }}' --only-phase '{{ phase }}' --dry-run --yes
+
+# Show best-effort status for the configured kind cluster.
+[group('kind')]
+kind-status:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    printf 'kind_clusters:\n'
+    if ! kind get clusters; then
+      printf 'kind clusters unavailable\n'
+    fi
+    printf '\nnodes ({{ kind_context }}):\n'
+    if ! kubectl --context '{{ kind_context }}' get nodes -o wide; then
+      printf 'nodes unavailable\n'
+    fi
+    printf '\nargocd_applications ({{ kind_context }}):\n'
+    if ! kubectl --context '{{ kind_context }}' -n argocd get applications.argoproj.io -o wide; then
+      printf 'ArgoCD applications unavailable\n'
+    fi
+
+# Create the configured kind cluster.
+[group('kind')]
+kind-create:
+    kind create cluster --name '{{ kind_cluster }}' --config hack/bootstrap/kind-three-node.yaml
 
 # Run bootstrap against the configured kind cluster.
-[group('bootstrap-kind')]
-bootstrap-kind:
+[group('kind')]
+kind-bootstrap:
     ./hack/bootstrap/bootstrap.sh --kube-context '{{ kind_context }}' --yes
-
-# Recreate the configured kind cluster and run bootstrap from scratch.
-[group('bootstrap-kind')]
-bootstrap-kind-fresh: kind-reset
-    ./hack/bootstrap/bootstrap.sh --kube-context '{{ kind_context }}' --yes
-
-# Server-side dry-run bootstrap against an already bootstrapped kind cluster.
-[group('bootstrap-kind')]
-bootstrap-kind-dry-run:
-    ./hack/bootstrap/bootstrap.sh --kube-context '{{ kind_context }}' --from-phase bootstrap-crds --dry-run --yes
 
 # Seed only the 1Password External Secrets credential into kind.
-[group('bootstrap-kind')]
-bootstrap-kind-seed:
+[group('kind')]
+kind-bootstrap-seed:
     ./hack/bootstrap/bootstrap.sh --kube-context '{{ kind_context }}' --only-phase seed-secret --yes
 
 # Resume kind bootstrap from a specific phase.
-[group('bootstrap-kind')]
-bootstrap-kind-resume phase='bootstrap-crds':
+[group('kind')]
+kind-bootstrap-resume phase='bootstrap-crds':
     ./hack/bootstrap/bootstrap.sh --kube-context '{{ kind_context }}' --from-phase '{{ phase }}' --yes
 
-# Audit a live cluster for bootstrap/takeover state without applying changes.
-[group('bootstrap-live')]
-bootstrap-live-audit context='default':
-    ./hack/bootstrap/bootstrap.sh --kube-context '{{ context }}' --audit-only
+# Server-side dry-run bootstrap against an already bootstrapped kind cluster.
+[group('kind')]
+kind-bootstrap-dry-run:
+    ./hack/bootstrap/bootstrap.sh --kube-context '{{ kind_context }}' --from-phase bootstrap-crds --dry-run --yes
 
-# Server-side dry-run the bootstrap flow against a live cluster.
-[group('bootstrap-live')]
-bootstrap-live-dry-run context='default':
-    ./hack/bootstrap/bootstrap.sh --kube-context '{{ context }}' --from-phase bootstrap-crds --dry-run --yes
-
-# Server-side dry-run one bootstrap phase against a live cluster.
-[group('bootstrap-live')]
-bootstrap-live-phase phase context='default':
-    ./hack/bootstrap/bootstrap.sh --kube-context '{{ context }}' --only-phase '{{ phase }}' --dry-run --yes
+# Delete, recreate, and bootstrap the configured kind cluster.
+[group('kind')]
+kind-fresh: kind-delete kind-create kind-bootstrap
 
 # Render live Ansible inventory and derived vars without changing nodes.
-[group('bootstrap-live')]
-bootstrap-live-ansible-plan:
+[group('ansible')]
+ansible-plan:
     ./hack/bootstrap/ansible/render-inventory.sh --profile live --summary
 
 # Import the existing live K3s server token into 1Password.
-[group('bootstrap-live')]
-bootstrap-ansible-import-token:
+[group('ansible')]
+ansible-import-token:
     ./hack/bootstrap/ansible/import-token.sh
 
 # Run the live Ansible convergence wrapper.
-[group('bootstrap-live')]
-bootstrap-live-ansible:
+[group('ansible')]
+ansible-run:
     ./hack/bootstrap/ansible/run.sh --profile live
 
-# Run the Kubernetes bootstrap phase against the live default context.
-[group('bootstrap-live')]
-bootstrap-live-kube context='default':
-    ./hack/bootstrap/bootstrap.sh --kube-context '{{ context }}' --profile full --yes
-
 # Run live Ansible convergence, then home-ops Kubernetes bootstrap.
-[group('bootstrap-live')]
-bootstrap-live-full:
+[group('ansible')]
+ansible-bootstrap:
     ./hack/bootstrap/ansible/run.sh --profile live --kube-bootstrap
 
 # Show read-only node lifecycle status for a live cluster node.
-[group('node-live')]
-node-live-status node:
+[group('node')]
+node-status node:
     ./hack/bootstrap/nodes/status.sh --profile live --context default '{{ node }}'
 
+# List live cluster nodes.
+[group('node')]
+node-list:
+    kubectl --context default get nodes -o wide
+
+# List non-succeeded pods bound to a live cluster node.
+[group('node')]
+node-pods node:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    kubectl --context default get pods -A --field-selector 'spec.nodeName={{ node }},status.phase!=Succeeded' -o wide
+
 # Show read-only control-plane quorum and embedded-etcd status for a live cluster node.
-[group('node-live')]
-node-live-control-plane-status node:
+[group('node')]
+node-control-plane-status node:
     ./hack/bootstrap/nodes/control-plane-status.sh --profile live --context default '{{ node }}'
 
 # Run read-only control-plane delete preflight for a live cluster node.
-[group('node-live')]
-node-live-control-plane-delete-preflight node:
+[group('node')]
+node-control-plane-delete-preflight node:
     ./hack/bootstrap/nodes/control-plane-delete-preflight.sh --profile live --context default '{{ node }}'
 
 # Drain a live worker or control-plane node before deletion or maintenance.
-[group('node-live')]
-node-live-drain node:
+[group('node')]
+node-drain node:
     ./hack/bootstrap/nodes/drain.sh --profile live --context default '{{ node }}'
 
 # Delete a drained live worker or control-plane node after Longhorn state has been evacuated.
-[group('node-live')]
-node-live-delete node:
+[group('node')]
+node-delete node:
     ./hack/bootstrap/nodes/delete.sh --profile live --context default '{{ node }}'
 
 # Evict Longhorn replicas from a drained live node before replacement.
-[group('node-live')]
-node-live-longhorn-evict node:
+[group('node')]
+node-longhorn-evict node:
     ./hack/bootstrap/nodes/longhorn-evict.sh --profile live --context default '{{ node }}'
 
 # Refresh a rebuilt live worker's SSH host key in known_hosts.
-[group('node-live')]
-node-live-refresh-ssh-host-key node:
+[group('node')]
+node-refresh-ssh-host-key node:
     ./hack/bootstrap/nodes/refresh-ssh-host-key.sh --profile live '{{ node }}'
 
 # Join a live worker or control-plane node from inventory with a temporary scheduling taint.
-[group('node-live')]
-node-live-join node:
+[group('node')]
+node-join node:
     ./hack/bootstrap/nodes/join.sh --profile live --context default '{{ node }}'
 
 # Remove the temporary live node taint and restore scheduling.
-[group('node-live')]
-node-live-uncordon node:
+[group('node')]
+node-uncordon node:
     ./hack/bootstrap/nodes/uncordon.sh --profile live --context default '{{ node }}'
 
-# Delete and recreate the configured three-node kind cluster.
-[group('bootstrap-kind')]
-kind-reset:
-    kind delete cluster --name '{{ kind_cluster }}'
-    kind create cluster --name '{{ kind_cluster }}' --config hack/bootstrap/kind-three-node.yaml
-
 # Delete the configured kind cluster.
-[group('bootstrap-kind')]
+[group('kind')]
 kind-delete:
     kind delete cluster --name '{{ kind_cluster }}'
 
+# Show best-effort status for the configured Lima cluster.
+[group('lima')]
+lima-status:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cluster='{{ lima_cluster }}'
+    printf 'lima_instances (%s):\n' "${cluster}"
+    if command -v limactl >/dev/null 2>&1; then
+      if ! limactl list | awk -v cluster="${cluster}" 'NR == 1 || $1 ~ "^" cluster "-(server|agent)-[0-9]+$"'; then
+        printf 'lima instances unavailable\n'
+      fi
+    else
+      printf 'limactl unavailable\n'
+    fi
+    printf '\nnodes ({{ lima_context }}):\n'
+    if ! kubectl --context '{{ lima_context }}' get nodes -o wide; then
+      printf 'nodes unavailable\n'
+    fi
+    printf '\nargocd_applications ({{ lima_context }}):\n'
+    if ! kubectl --context '{{ lima_context }}' -n argocd get applications.argoproj.io -o wide; then
+      printf 'ArgoCD applications unavailable\n'
+    fi
+
 # Create the configured Lima VMs for a foundation bootstrap test.
-[group('bootstrap-lima')]
-bootstrap-lima-create:
+[group('lima')]
+lima-create:
     ./hack/bootstrap/lima/create.sh
 
-# Create larger Lima VMs for the app bootstrap profile.
-[group('bootstrap-lima-apps')]
-bootstrap-lima-create-apps:
-    {{ lima_app_env }} ./hack/bootstrap/lima/create.sh
-
 # Run the selected Ansible backend against the configured Lima VMs.
-[group('bootstrap-lima')]
-bootstrap-lima-ansible:
+[group('lima')]
+lima-ansible:
     ./hack/bootstrap/lima/run-ansible.sh
 
-# Run the selected Ansible backend against the larger Lima app-profile VM shape.
-[group('bootstrap-lima-apps')]
-bootstrap-lima-ansible-apps:
-    {{ lima_app_env }} ./hack/bootstrap/lima/run-ansible.sh
-
 # Import/update the Lima K3s context in the local kubeconfig and keep its API tunnel running.
-[group('bootstrap-lima')]
-bootstrap-lima-kubecontext:
+[group('lima')]
+lima-context:
     ./hack/bootstrap/lima/kubecontext.sh
 
 # Run home-ops foundation bootstrap against the Lima K3s cluster.
-[group('bootstrap-lima')]
-bootstrap-lima-bootstrap:
+[group('lima')]
+lima-bootstrap:
     ./hack/bootstrap/lima/bootstrap-home-ops.sh
 
-# Run home-ops app bootstrap profile against the Lima K3s cluster.
-[group('bootstrap-lima-apps')]
-bootstrap-lima-bootstrap-apps:
-    LIMA_BOOTSTRAP_PROFILE=lima-apps ./hack/bootstrap/lima/bootstrap-home-ops.sh
-
-# Run Lima app bootstrap with the seed Secret manifest provided on stdin.
-[group('bootstrap-lima-apps')]
-bootstrap-lima-bootstrap-apps-stdin:
-    LIMA_BOOTSTRAP_PROFILE=lima-apps ./hack/bootstrap/lima/bootstrap-home-ops.sh --seed-secret-stdin
-
 # Run Lima foundation bootstrap with the seed Secret manifest provided on stdin.
-[group('bootstrap-lima')]
-bootstrap-lima-bootstrap-stdin:
+[group('lima')]
+lima-bootstrap-stdin:
     ./hack/bootstrap/lima/bootstrap-home-ops.sh --seed-secret-stdin
 
 # Validate Cilium BGP APIs and backup-safety invariants in the Lima cluster.
-[group('bootstrap-lima')]
-bootstrap-lima-validate:
+[group('lima')]
+lima-validate:
     ./hack/bootstrap/lima/validate.sh
 
-# Validate app-profile safety invariants in the Lima cluster.
-[group('bootstrap-lima-apps')]
-bootstrap-lima-validate-apps:
-    LIMA_VALIDATE_PROFILE=lima-apps ./hack/bootstrap/lima/validate.sh
-
 # Delete the configured Lima VMs.
-[group('bootstrap-lima')]
-bootstrap-lima-delete:
+[group('lima')]
+lima-delete:
     ./hack/bootstrap/lima/delete.sh
 
 # Recreate Lima VMs, run Ansible, bootstrap home-ops, and validate foundation state.
-[group('bootstrap-lima')]
-bootstrap-lima-fresh: bootstrap-lima-delete bootstrap-lima-create bootstrap-lima-ansible bootstrap-lima-bootstrap bootstrap-lima-validate
+[group('lima')]
+lima-fresh: lima-delete lima-create lima-ansible lima-bootstrap lima-validate
+
+# Show best-effort status for the configured Lima app-profile cluster.
+[group('lima-apps')]
+lima-apps-status: lima-status
+
+# Create larger Lima VMs for the app bootstrap profile.
+[group('lima-apps')]
+lima-apps-create:
+    {{ lima_app_env }} ./hack/bootstrap/lima/create.sh
+
+# Run the selected Ansible backend against the larger Lima app-profile VM shape.
+[group('lima-apps')]
+lima-apps-ansible:
+    {{ lima_app_env }} ./hack/bootstrap/lima/run-ansible.sh
+
+# Run home-ops app bootstrap profile against the Lima K3s cluster.
+[group('lima-apps')]
+lima-apps-bootstrap:
+    LIMA_BOOTSTRAP_PROFILE=lima-apps ./hack/bootstrap/lima/bootstrap-home-ops.sh
+
+# Run Lima app bootstrap with the seed Secret manifest provided on stdin.
+[group('lima-apps')]
+lima-apps-bootstrap-stdin:
+    LIMA_BOOTSTRAP_PROFILE=lima-apps ./hack/bootstrap/lima/bootstrap-home-ops.sh --seed-secret-stdin
+
+# Validate app-profile safety invariants in the Lima cluster.
+[group('lima-apps')]
+lima-apps-validate:
+    LIMA_VALIDATE_PROFILE=lima-apps ./hack/bootstrap/lima/validate.sh
+
+# Delete the configured Lima app-profile VMs.
+[group('lima-apps')]
+lima-apps-delete: lima-delete
 
 # Show read-only node lifecycle status for a Lima cluster node.
 [group('node-lima')]
 node-lima-status node:
     ./hack/bootstrap/nodes/status.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
+
+# List Lima cluster nodes.
+[group('node-lima')]
+node-lima-list:
+    kubectl --context '{{ lima_context }}' get nodes -o wide
+
+# List non-succeeded pods bound to a Lima cluster node.
+[group('node-lima')]
+node-lima-pods node:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    kubectl --context '{{ lima_context }}' get pods -A --field-selector 'spec.nodeName={{ node }},status.phase!=Succeeded' -o wide
 
 # Show read-only control-plane quorum and embedded-etcd status for a Lima cluster node.
 [group('node-lima')]
@@ -338,8 +475,8 @@ node-lima-uncordon node:
     ./hack/bootstrap/nodes/uncordon.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
 
 # Recreate larger Lima VMs, run Ansible, bootstrap app profile, and validate app safety.
-[group('bootstrap-lima-apps')]
-bootstrap-lima-fresh-apps:
+[group('lima-apps')]
+lima-apps-fresh:
     {{ lima_app_env }} ./hack/bootstrap/lima/delete.sh
     {{ lima_app_env }} ./hack/bootstrap/lima/create.sh
     {{ lima_app_env }} ./hack/bootstrap/lima/run-ansible.sh


### PR DESCRIPTION
## Summary
- simplify the root just recipe surface into clearer groups: bootstrap, kind, lima, lima-apps, ansible, node, and node-lima
- rename live node lifecycle recipes from node-live-* to node-* while keeping node-lima-* explicit
- refresh bootstrap runbooks and agent guidance to remove stale recipe names

## Validation
- just --summary
- just bootstrap-test
- pre-commit run --files justfile AGENTS.md README.md docs/just-bootstrap.md hack/bootstrap/README.md hack/bootstrap/AGENTS.md
- pre-commit run --files justfile docs/just-bootstrap.md hack/bootstrap/README.md hack/bootstrap/ansible/node-worker.sh hack/bootstrap/ansible/node-control-plane.sh
- git diff --check

Review agent approved the recipe UX cleanup with no findings.