### PR TITLE
fix: disable kube-proxy during control-plane join

### DIFF
--- a/docs/just-bootstrap.md
+++ b/docs/just-bootstrap.md
@@ -471,6 +471,9 @@ Join starts K3s with `node.home-ops.sh/joining=true:NoSchedule`, then cordons
 the node. Uncordon removes the temporary taint, waits for Cilium, checks
 Longhorn scheduling readiness, and restores scheduling.
 
+Control-plane joins also install and verify the K3s kube-proxy disable drop-in
+when the derived Cilium config has `kube_proxy_replacement: true`.
+
 ## Live Validation
 
 Live bootstrap recipes use the active kube context. Switch to the intended

--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -230,6 +230,9 @@ Join starts K3s with `node.home-ops.sh/joining=true:NoSchedule`, then cordons
 the node. Uncordon removes the temporary taint, waits for Cilium, checks
 Longhorn scheduling readiness, and restores scheduling.
 
+Control-plane joins also install and verify the K3s kube-proxy disable drop-in
+when `kube_proxy_replacement: true`.
+
 ## Secrets
 
 Secret manifests read from 1Password are streamed directly to Kubernetes. They

--- a/hack/bootstrap/ansible/home-ops/control-plane-finalize.yml
+++ b/hack/bootstrap/ansible/home-ops/control-plane-finalize.yml
@@ -12,5 +12,8 @@
     - name: Write K3s token file
       ansible.builtin.import_tasks: tasks/token.yml
 
+    - name: Ensure K3s kube-proxy stays disabled
+      ansible.builtin.import_tasks: tasks/kube-proxy-disable.yml
+
     - name: Render K3s server service without temporary taint
       ansible.builtin.import_tasks: tasks/join-servers.yml

--- a/hack/bootstrap/ansible/home-ops/control-plane-join.yml
+++ b/hack/bootstrap/ansible/home-ops/control-plane-join.yml
@@ -28,5 +28,8 @@
     - name: Reset stale local K3s server database
       ansible.builtin.import_tasks: tasks/reset-server-db.yml
 
+    - name: Disable K3s kube-proxy before server join
+      ansible.builtin.import_tasks: tasks/kube-proxy-disable.yml
+
     - name: Join K3s server with temporary taint
       ansible.builtin.import_tasks: tasks/join-servers.yml

--- a/hack/bootstrap/ansible/home-ops/tasks/join-servers.yml
+++ b/hack/bootstrap/ansible/home-ops/tasks/join-servers.yml
@@ -21,7 +21,12 @@
     name: "{{ home_ops_k3s_server_service_name }}"
     daemon_reload: true
     enabled: true
-    state: "{{ 'restarted' if home_ops_k3s_server_service.changed else 'started' }}"
+    state: >-
+      {{
+        'restarted'
+        if home_ops_k3s_server_service.changed or (home_ops_kube_proxy_config.changed | default(false))
+        else 'started'
+      }}
 
 - name: Wait for local K3s API port
   ansible.builtin.wait_for:

--- a/hack/bootstrap/ansible/home-ops/tasks/kube-proxy-disable.yml
+++ b/hack/bootstrap/ansible/home-ops/tasks/kube-proxy-disable.yml
@@ -1,0 +1,27 @@
+---
+- name: Verify kube-proxy replacement setting is defined
+  ansible.builtin.assert:
+    that:
+      - kube_proxy_replacement is defined
+    fail_msg: "kube_proxy_replacement must be defined before managing K3s kube-proxy config"
+
+- name: Create K3s config drop-in directory for kube-proxy disable
+  ansible.builtin.file:
+    path: "{{ home_ops_k3s_config_dir | default('/etc/rancher/k3s') }}/config.yaml.d"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: kube_proxy_replacement | bool
+
+- name: Write K3s kube-proxy disable drop-in
+  ansible.builtin.copy:
+    dest: "{{ home_ops_k3s_config_dir | default('/etc/rancher/k3s') }}/config.yaml.d/90-home-ops-kube-proxy.yaml"
+    content: |
+      disable-kube-proxy: true
+    owner: root
+    group: root
+    mode: "0644"
+  register: home_ops_kube_proxy_config
+  notify: "{{ home_ops_kube_proxy_disable_notify | default(omit) }}"
+  when: kube_proxy_replacement | bool

--- a/hack/bootstrap/ansible/playbooks/disable-kube-proxy.yml
+++ b/hack/bootstrap/ansible/playbooks/disable-kube-proxy.yml
@@ -5,12 +5,9 @@
   gather_facts: true
   serial: 1
   vars:
-    kube_proxy_config_dir: /etc/rancher/k3s/config.yaml.d
-    kube_proxy_config_file: "{{ kube_proxy_config_dir }}/90-home-ops-kube-proxy.yaml"
-    kube_proxy_config_content: |
-      disable-kube-proxy: true
     bootstrap_first_master: "{{ groups[group_name_master | default('master')][0] }}"
     bootstrap_node_name: "{{ ansible_facts.hostname | default(inventory_hostname) }}"
+    home_ops_kube_proxy_disable_notify: Converge K3s after kube-proxy config
 
   pre_tasks:
     - name: Skip when Cilium kube-proxy replacement is disabled
@@ -32,23 +29,8 @@
       changed_when: false
 
   tasks:
-    - name: Create K3s config drop-in directory
-      ansible.builtin.file:
-        path: "{{ kube_proxy_config_dir }}"
-        state: directory
-        owner: root
-        group: root
-        mode: "0755"
-
-    - name: Write K3s kube-proxy disable drop-in
-      ansible.builtin.copy:
-        dest: "{{ kube_proxy_config_file }}"
-        content: "{{ kube_proxy_config_content }}"
-        owner: root
-        group: root
-        mode: "0644"
-      register: kube_proxy_config
-      notify: Converge K3s after kube-proxy config
+    - name: Manage K3s kube-proxy disable config
+      ansible.builtin.import_tasks: ../home-ops/tasks/kube-proxy-disable.yml
 
   handlers:
     - name: Restart K3s after kube-proxy config

--- a/hack/bootstrap/nodes/control-plane-delete.sh
+++ b/hack/bootstrap/nodes/control-plane-delete.sh
@@ -72,7 +72,7 @@ kubernetes_node_name="$(node_expected_kubernetes_node_name "$profile" "$inventor
 inventory_file="$(node_ansible_inventory_file "$profile")"
 preflight_script="${NODE_SCRIPT_DIR}/control-plane-delete-preflight.sh"
 
-node_handoff_first_master_api_if_needed "$profile" "$context" "$inventory_node_name" "$kubernetes_node_name"
+node_handoff_control_plane_api_if_needed "$profile" "$context" "$inventory_node_name" "$kubernetes_node_name"
 node_assert_api_reachable "$context"
 node_json="$(node_node_json_if_present "$context" "$kubernetes_node_name")"
 if [[ -z "$node_json" ]]; then

--- a/hack/bootstrap/nodes/control-plane-join.sh
+++ b/hack/bootstrap/nodes/control-plane-join.sh
@@ -64,7 +64,7 @@ IFS=$'\t' read -r inventory_node_name inventory_role < <(node_resolve_inventory_
 node_assert_inventory_control_plane "$inventory_node_name" "$inventory_role"
 kubernetes_node_name="$(node_expected_kubernetes_node_name "$profile" "$inventory_node_name" "$node_name")"
 
-node_handoff_first_master_api_if_needed "$profile" "$context" "$inventory_node_name" "$kubernetes_node_name"
+node_handoff_control_plane_api_if_needed "$profile" "$context" "$inventory_node_name" "$kubernetes_node_name"
 node_assert_api_reachable "$context"
 if node_has_resource "$context" "node/${kubernetes_node_name}"; then
   node_die "Kubernetes node already exists; drain/delete it before joining: ${kubernetes_node_name}"
@@ -88,6 +88,7 @@ fi
 
 node_log "joining control-plane node ${inventory_node_name} with temporary scheduling taint"
 node_run_control_plane_ansible_action "$profile" "$inventory_node_name" join "$join_ip"
+node_assert_kube_proxy_disable_dropin "$profile" "$inventory_node_name"
 
 node_json="$(node_wait_for_node_json "$context" "$kubernetes_node_name" 600)"
 node_assert_kubernetes_control_plane "$node_json" "$kubernetes_node_name"

--- a/hack/bootstrap/nodes/control-plane-uncordon.sh
+++ b/hack/bootstrap/nodes/control-plane-uncordon.sh
@@ -64,7 +64,7 @@ IFS=$'\t' read -r inventory_node_name inventory_role < <(node_resolve_inventory_
 node_assert_inventory_control_plane "$inventory_node_name" "$inventory_role"
 kubernetes_node_name="$(node_expected_kubernetes_node_name "$profile" "$inventory_node_name" "$node_name")"
 
-node_handoff_first_master_api_if_needed "$profile" "$context" "$inventory_node_name" "$kubernetes_node_name"
+node_handoff_control_plane_api_if_needed "$profile" "$context" "$inventory_node_name" "$kubernetes_node_name"
 node_assert_api_reachable "$context"
 node_json="$(node_node_json_if_present "$context" "$kubernetes_node_name")"
 [[ -n "$node_json" ]] || node_die "Kubernetes node is absent: ${kubernetes_node_name}"

--- a/hack/bootstrap/nodes/drain.sh
+++ b/hack/bootstrap/nodes/drain.sh
@@ -62,6 +62,9 @@ node_require_tool "$NODE_JQ_BIN"
 IFS=$'\t' read -r inventory_node_name inventory_role < <(node_resolve_inventory_node "$profile" "$node_name")
 kubernetes_node_name="$(node_expected_kubernetes_node_name "$profile" "$inventory_node_name" "$node_name")"
 
+if [[ "$inventory_role" == master ]]; then
+  node_handoff_control_plane_api_if_needed "$profile" "$context" "$inventory_node_name" "$kubernetes_node_name"
+fi
 node_assert_api_reachable "$context"
 node_json="$(node_node_json_if_present "$context" "$kubernetes_node_name")"
 [[ -n "$node_json" ]] || node_die "Kubernetes node is absent: ${kubernetes_node_name}"

--- a/hack/bootstrap/nodes/lib/ansible.sh
+++ b/hack/bootstrap/nodes/lib/ansible.sh
@@ -87,3 +87,90 @@ node_run_control_plane_ansible_action() {
 
   NODE_CONTROL_PLANE_ANSIBLE_INTERNAL=true "${BOOTSTRAP_DIR}/ansible/node-control-plane.sh" "${args[@]}" "$inventory_node"
 }
+
+node_effective_ansible_inventory_dir() {
+  local profile="$1"
+  local rendered_dir
+
+  case "$profile" in
+    live)
+      rendered_dir="${BOOTSTRAP_ANSIBLE_OUT_DIR:-${BOOTSTRAP_DIR}/.out/ansible-live}/inventory/live"
+      if [[ -f "${rendered_dir}/hosts.yml" && -f "${rendered_dir}/group_vars/all.yml" ]]; then
+        printf '%s\n' "$rendered_dir"
+        return 0
+      fi
+      ;;
+    lima)
+      ;;
+    *)
+      node_die "unknown node lifecycle profile: ${profile}"
+      ;;
+  esac
+
+  node_inventory_dir "$profile"
+}
+
+node_effective_ansible_inventory_file() {
+  printf '%s/hosts.yml\n' "$(node_effective_ansible_inventory_dir "$1")"
+}
+
+node_effective_ansible_group_var() {
+  local profile="$1"
+  local key="$2"
+  local group_vars
+  group_vars="$(node_effective_ansible_inventory_dir "$profile")/group_vars/all.yml"
+  [[ -f "$group_vars" ]] || return 1
+  "$NODE_YQ_BIN" -r ".${key}" "$group_vars"
+}
+
+node_kube_proxy_replacement_enabled() {
+  local profile="$1"
+  local value
+  value="$(node_effective_ansible_group_var "$profile" kube_proxy_replacement 2>/dev/null || true)"
+  case "$value" in
+    true)
+      return 0
+      ;;
+    false)
+      return 1
+      ;;
+    ""|null)
+      node_die "kube_proxy_replacement is missing from $(node_effective_ansible_inventory_dir "$profile")/group_vars/all.yml"
+      ;;
+    *)
+      node_die "kube_proxy_replacement must be true or false in $(node_effective_ansible_inventory_dir "$profile")/group_vars/all.yml: ${value}"
+      ;;
+  esac
+}
+
+node_assert_kube_proxy_disable_dropin() {
+  local profile="$1"
+  local inventory_node="$2"
+  local inventory_file
+  local remote_check
+
+  if ! node_kube_proxy_replacement_enabled "$profile"; then
+    node_log "kube_proxy_replacement is false; skipping K3s kube-proxy disable drop-in check"
+    return 0
+  fi
+
+  inventory_file="$(node_effective_ansible_inventory_file "$profile")"
+  read -r -d '' remote_check <<'EOF' || true
+set -eu
+
+dropin=/etc/rancher/k3s/config.yaml.d/90-home-ops-kube-proxy.yaml
+if [ ! -f "$dropin" ]; then
+  printf 'kube_proxy_disable_dropin=missing\n'
+  exit 2
+fi
+if ! grep -Fxq 'disable-kube-proxy: true' "$dropin"; then
+  printf 'kube_proxy_disable_dropin=invalid\n'
+  exit 2
+fi
+printf 'kube_proxy_disable_dropin=present\n'
+EOF
+
+  node_log "validating K3s kube-proxy disable drop-in on ${inventory_node}"
+  node_run_remote_shell "$inventory_file" "$inventory_node" "$remote_check" >/dev/null ||
+    node_die "K3s kube-proxy disable drop-in is missing or invalid on ${inventory_node}"
+}

--- a/hack/bootstrap/nodes/lib/inventory.sh
+++ b/hack/bootstrap/nodes/lib/inventory.sh
@@ -199,7 +199,7 @@ node_group_var() {
   local group_vars
   group_vars="$(node_group_vars_file "$profile")"
   [[ -f "$group_vars" ]] || return 1
-  "$NODE_YQ_BIN" -r ".${key} // \"\"" "$group_vars"
+  "$NODE_YQ_BIN" -r ".${key}" "$group_vars"
 }
 
 node_effective_ansible_user() {

--- a/hack/bootstrap/nodes/lib/lima.sh
+++ b/hack/bootstrap/nodes/lib/lima.sh
@@ -75,21 +75,19 @@ node_start_lima_api_tunnel_to_inventory_node() {
   node_die "timed out waiting for Lima API tunnel through ${inventory_node}"
 }
 
-node_handoff_first_master_api_if_needed() {
+node_handoff_control_plane_api_if_needed() {
   local profile="$1"
   local context="$2"
   local inventory_node="$3"
   local kubernetes_node="$4"
   local alternate_inventory_node alternate_kubernetes_node alternate_node_json
 
-  node_is_first_inventory_master "$profile" "$inventory_node" || return 0
-
   case "$profile" in
     lima)
       alternate_inventory_node="$(node_alternate_ready_control_plane_inventory_node "$profile" "$context" "$kubernetes_node" true)" ||
         node_die "no alternate inventory control-plane is available for API handoff"
       alternate_kubernetes_node="$(node_expected_kubernetes_node_name "$profile" "$alternate_inventory_node" "$alternate_inventory_node")"
-      node_log "retargeting Lima API tunnel from first master ${inventory_node} to ${alternate_inventory_node}"
+      node_log "retargeting Lima API tunnel away from ${inventory_node} to ${alternate_inventory_node}"
       node_start_lima_api_tunnel_to_inventory_node "$alternate_inventory_node" "$context" >/dev/null
       node_assert_api_reachable "$context"
       alternate_node_json="$(node_node_json_if_present "$context" "$alternate_kubernetes_node")"
@@ -99,6 +97,7 @@ node_handoff_first_master_api_if_needed() {
       node_assert_ready "$alternate_node_json" "$alternate_kubernetes_node"
       ;;
     live)
+      node_is_first_inventory_master "$profile" "$inventory_node" || return 0
       node_assert_live_first_master_api_is_stable "$profile" "$context" "$inventory_node" "$kubernetes_node"
       node_log "first inventory master selected; live context must remain reachable through the stable API endpoint"
       node_assert_api_reachable "$context"

--- a/hack/bootstrap/nodes/longhorn-evict.sh
+++ b/hack/bootstrap/nodes/longhorn-evict.sh
@@ -62,7 +62,7 @@ node_require_tool "$NODE_JQ_BIN"
 IFS=$'\t' read -r inventory_node_name inventory_role < <(node_resolve_inventory_node "$profile" "$node_name")
 kubernetes_node_name="$(node_expected_kubernetes_node_name "$profile" "$inventory_node_name" "$node_name")"
 
-node_handoff_first_master_api_if_needed "$profile" "$context" "$inventory_node_name" "$kubernetes_node_name"
+node_handoff_control_plane_api_if_needed "$profile" "$context" "$inventory_node_name" "$kubernetes_node_name"
 node_assert_api_reachable "$context"
 node_json="$(node_node_json_if_present "$context" "$kubernetes_node_name")"
 [[ -n "$node_json" ]] || node_die "Kubernetes node is absent: ${kubernetes_node_name}"

--- a/hack/bootstrap/tests/bats/offline-ansible.bats
+++ b/hack/bootstrap/tests/bats/offline-ansible.bats
@@ -103,7 +103,8 @@ render_home_ops_inventory() {
     "${ROOT}/hack/bootstrap/ansible/home-ops/control-plane-join.yml" \
     "${ROOT}/hack/bootstrap/ansible/home-ops/control-plane-finalize.yml" \
     "${ROOT}/hack/bootstrap/ansible/home-ops/worker-join.yml" \
-    "${ROOT}/hack/bootstrap/ansible/home-ops/worker-finalize.yml"; do
+    "${ROOT}/hack/bootstrap/ansible/home-ops/worker-finalize.yml" \
+    "${ROOT}/hack/bootstrap/ansible/playbooks/disable-kube-proxy.yml"; do
     run ansible-playbook --syntax-check -i "${home_ops_out}/inventory/live/hosts.yml" "$playbook"
     assert_success
   done
@@ -177,6 +178,12 @@ EOF
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/vars/defaults.yml" 'home_ops_node_taints'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/reset-server-db.yml" 'db-before-rejoin'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/node-control-plane.sh" '--join-ip ADDRESS'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/kube-proxy-disable.yml" 'disable-kube-proxy: true'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/control-plane-join.yml" 'tasks/kube-proxy-disable.yml'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/control-plane-finalize.yml" 'tasks/kube-proxy-disable.yml'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/playbooks/disable-kube-proxy.yml" '../home-ops/tasks/kube-proxy-disable.yml'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/join-servers.yml" 'home_ops_kube_proxy_config.changed'
+  assert_file_contains "$ROOT/hack/bootstrap/nodes/control-plane-join.sh" 'node_assert_kube_proxy_disable_dropin'
 }
 
 @test "render inventory fails on derived value conflicts" {

--- a/hack/bootstrap/tests/bats/offline-nodes.bats
+++ b/hack/bootstrap/tests/bats/offline-nodes.bats
@@ -176,6 +176,69 @@ EOF
   assert_file_not_contains "${tmp}/node-control-plane-finalize.args" '--join-ip'
 }
 
+@test "Lima control-plane API handoff retargets away from any target control-plane" {
+  local calls_file
+  calls_file="${tmp}/handoff.calls"
+
+  run env CALLS_FILE="$calls_file" bash -c "
+    source '${ROOT}/hack/bootstrap/nodes/lib.sh'
+    node_alternate_ready_control_plane_inventory_node() { printf '%s\n' k3s-master-0; }
+    node_start_lima_api_tunnel_to_inventory_node() { printf 'tunnel=%s context=%s\n' \"\$1\" \"\$2\" >>\"\${CALLS_FILE}\"; }
+    node_assert_api_reachable() { :; }
+    node_node_json_if_present() { printf '{\"metadata\":{\"name\":\"%s\",\"labels\":{\"node-role.kubernetes.io/control-plane\":\"true\"}},\"status\":{\"conditions\":[{\"type\":\"Ready\",\"status\":\"True\"}]}}' \"\$2\"; }
+    node_assert_kubernetes_control_plane() { :; }
+    node_assert_ready() { :; }
+    node_handoff_control_plane_api_if_needed lima test k3s-master-1 lima-k3s-master-1
+  "
+  assert_success
+  assert_output_contains 'retargeting Lima API tunnel away from k3s-master-1 to k3s-master-0'
+  assert_file_contains "$calls_file" 'tunnel=k3s-master-0 context=test'
+}
+
+@test "control-plane join validates kube-proxy disable drop-in when replacement is enabled" {
+  local rendered_out rendered_inventory
+  write_fake_ansible
+
+  run env PATH="${tmp}:${PATH}" BOOTSTRAP_ANSIBLE_OUT_DIR="${tmp}/no-render" NODE_LIVE_INVENTORY_DIR="$inventory" \
+    bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_assert_kube_proxy_disable_dropin live k3s-master-0"
+  assert_success
+  assert_output_contains 'validating K3s kube-proxy disable drop-in on k3s-master-0'
+
+  rendered_out="${tmp}/rendered"
+  rendered_inventory="${rendered_out}/inventory/live"
+  mkdir -p "${rendered_inventory}/group_vars"
+  cp "${inventory}/hosts.yml" "${rendered_inventory}/hosts.yml"
+  yq -i 'del(.kube_proxy_replacement)' "${inventory}/group_vars/all.yml"
+  cat > "${rendered_inventory}/group_vars/all.yml" <<'EOF'
+---
+ansible_user: ethan
+ansible_ssh_private_key_file: ~/ansiblekey
+kube_proxy_replacement: true
+EOF
+  run env PATH="${tmp}:${PATH}" BOOTSTRAP_ANSIBLE_OUT_DIR="$rendered_out" NODE_LIVE_INVENTORY_DIR="$inventory" \
+    bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_assert_kube_proxy_disable_dropin live k3s-master-0"
+  assert_success
+  assert_output_contains 'validating K3s kube-proxy disable drop-in on k3s-master-0'
+
+  yq -i '.kube_proxy_replacement = true' "${inventory}/group_vars/all.yml"
+  run env PATH="${tmp}:${PATH}" BOOTSTRAP_ANSIBLE_OUT_DIR="${tmp}/no-render" FAKE_KUBE_PROXY_DROPIN=missing NODE_LIVE_INVENTORY_DIR="$inventory" \
+    bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_assert_kube_proxy_disable_dropin live k3s-master-0"
+  assert_failure
+  assert_output_contains 'K3s kube-proxy disable drop-in is missing or invalid on k3s-master-0'
+
+  yq -i '.kube_proxy_replacement = false' "${inventory}/group_vars/all.yml"
+  run env PATH="${tmp}:${PATH}" BOOTSTRAP_ANSIBLE_OUT_DIR="${tmp}/no-render" NODE_LIVE_INVENTORY_DIR="$inventory" \
+    bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_assert_kube_proxy_disable_dropin live k3s-master-0"
+  assert_success
+  assert_output_contains 'kube_proxy_replacement is false; skipping K3s kube-proxy disable drop-in check'
+
+  yq -i 'del(.kube_proxy_replacement)' "${inventory}/group_vars/all.yml"
+  run env PATH="${tmp}:${PATH}" BOOTSTRAP_ANSIBLE_OUT_DIR="${tmp}/no-render" NODE_LIVE_INVENTORY_DIR="$inventory" \
+    bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_assert_kube_proxy_disable_dropin live k3s-master-0"
+  assert_failure
+  assert_output_contains 'kube_proxy_replacement is missing'
+}
+
 @test "control-plane drain and delete enforce stable API and cleanup semantics" {
   write_control_plane_kubectl
   write_fake_ansible
@@ -366,4 +429,6 @@ EOF
     run "${ROOT}/${script}" --help
     assert_success
   done
+
+  assert_file_contains "$ROOT/hack/bootstrap/nodes/drain.sh" 'node_handoff_control_plane_api_if_needed'
 }

--- a/hack/bootstrap/tests/helpers/nodes.bash
+++ b/hack/bootstrap/tests/helpers/nodes.bash
@@ -32,6 +32,7 @@ EOF
 ---
 ansible_user: ethan
 ansible_ssh_private_key_file: ~/ansiblekey
+kube_proxy_replacement: true
 EOF
 }
 
@@ -331,6 +332,15 @@ printf '%s | CHANGED | rc=0 >>\n' "$target"
 
 if [[ "$joined_args" == *"ansible.builtin.systemd"* ]]; then
   printf '{"changed": true}\n'
+  exit 0
+fi
+
+if [[ "$joined_args" == *"90-home-ops-kube-proxy.yaml"* ]]; then
+  if [[ "${FAKE_KUBE_PROXY_DROPIN:-present}" == missing ]]; then
+    printf 'kube_proxy_disable_dropin=missing\n'
+    exit 2
+  fi
+  printf 'kube_proxy_disable_dropin=present\n'
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- install the K3s kube-proxy disable drop-in before joining control-plane nodes
- verify the drop-in after control-plane join using rendered Ansible inventory when available
- retarget Lima API tunnels away from any control-plane node before lifecycle mutations

## Validation
- just bootstrap-test
- pre-commit run --files <changed files>
- live Lima replacement of home-ops-k3s-test-server-2
- just lima-apps-validate
- review agent approval