### PR TITLE
feat: add additive node convergence

### DIFF
--- a/docs/cluster-operations.md
+++ b/docs/cluster-operations.md
@@ -112,6 +112,19 @@ Ansible and active-context bootstrap:
 | Dry-run bootstrap against the active context | `just bootstrap-dry-run` |
 | Dry-run one bootstrap phase | `just bootstrap-phase argocd` |
 
+Node lifecycle:
+
+| Goal | Recipe |
+| --- | --- |
+| List live nodes | `just node-list` |
+| Plan additive-only live node joins | `just node-converge-plan` |
+| Join missing live inventory nodes after confirmation | `just node-converge` |
+| Join one explicit live node | `just node-join <node>` |
+| Finalize and uncordon one live node | `just node-uncordon <node>` |
+| Plan additive-only Lima node joins | `just node-lima-converge-plan` |
+| Join missing Lima inventory nodes after confirmation | `just node-lima-converge` |
+| Join missing Lima inventory nodes without prompting | `just node-lima-converge-yes` |
+
 ## Validation Ladder
 
 Use the smallest validation that covers the change:
@@ -436,6 +449,7 @@ just node-status k3s-worker-0
 just node-pods k3s-worker-0
 just node-control-plane-status k3s-master-0
 just node-control-plane-delete-preflight k3s-master-0
+just node-converge-plan
 just node-drain k3s-worker-0
 just node-longhorn-evict k3s-worker-0
 just node-delete k3s-worker-0
@@ -452,6 +466,7 @@ just node-lima-status home-ops-k3s-test-agent-1
 just node-lima-pods home-ops-k3s-test-agent-1
 just node-lima-control-plane-status home-ops-k3s-test-server-1
 just node-lima-control-plane-delete-preflight home-ops-k3s-test-server-1
+just node-lima-converge-plan
 just node-lima-drain home-ops-k3s-test-server-2
 just node-lima-longhorn-evict home-ops-k3s-test-server-2
 just node-lima-delete home-ops-k3s-test-server-2
@@ -462,6 +477,14 @@ just node-lima-uncordon home-ops-k3s-test-server-2
 
 For normal maintenance or reboots, use drain and uncordon only.
 `longhorn-evict` is for node replacement.
+
+`node-converge` is additive-only convenience after inventory edits. It joins
+fresh inventory nodes that are absent from Kubernetes, refuses deletes,
+renames, role changes, unhealthy existing nodes, pending cordon/taint
+finalization, K3s version drift, and unsafe control-plane counts. It joins
+workers sequentially, may join at most one control-plane node, delegates to the
+same `node-join` lifecycle path, and leaves all joined nodes cordoned until
+you explicitly run the printed `node-uncordon` commands.
 
 Control-plane delete is gated by read-only preflight, quorum checks, Longhorn
 eviction when installed, fresh K3s etcd snapshot creation, and explicit

--- a/hack/bootstrap/AGENTS.md
+++ b/hack/bootstrap/AGENTS.md
@@ -33,6 +33,8 @@ normal app graph.
   rendering.
 - `nodes/`: existing-cluster node lifecycle commands. Command scripts source
   `nodes/lib.sh`; implementation modules live under `nodes/lib/`.
+  `nodes/converge.sh` is an additive-only planner/orchestrator and must
+  delegate actual joins to `nodes/join.sh`.
 - `tests/bats/`: offline BATS tests for parsing, rendering, Ansible command
   construction, node lifecycle helpers, and bootstrap library helpers.
 - `tests/helpers/`: BATS fixture and assertion helpers.
@@ -88,6 +90,10 @@ Keep this list in sync with `PHASES` in `bootstrap.sh` and the phase list in
 ## Node Lifecycle Flow
 
 - Worker replacement is explicit: status, drain, delete, join, then uncordon.
+- Inventory expansion may use `node-converge`, but it must stay additive-only:
+  refuse deletes, renames, role changes, unhealthy existing nodes, pending
+  finalization, K3s version drift, unsafe control-plane counts, and any state
+  it cannot prove safe.
 - Control-plane replacement adds stricter gates: preflight, Longhorn eviction
   if installed, fresh K3s etcd snapshot, Kubernetes Node deletion, explicit
   embedded-etcd member removal, join with a temporary taint, then finalize and

--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -43,6 +43,7 @@ Do not commit `.out/`.
 | Show Lima status | `just lima-status` |
 | Run larger Lima app-profile bootstrap | `just lima-apps-fresh` |
 | Render live Ansible inventory and vars | `just ansible-plan` |
+| Plan additive-only live node joins | `just node-converge-plan` |
 | Audit active bootstrap/takeover state | `just bootstrap-audit` |
 | Dry-run Kubernetes bootstrap on the active context | `just bootstrap-dry-run` |
 | Run live Ansible plus Kubernetes bootstrap | `just ansible-bootstrap` |
@@ -211,6 +212,8 @@ explicit.
 | Pods bound to node | `just node-pods <node>` | `just node-lima-pods <node>` |
 | Control-plane status | `just node-control-plane-status <node>` | `just node-lima-control-plane-status <node>` |
 | Control-plane delete preflight | `just node-control-plane-delete-preflight <node>` | `just node-lima-control-plane-delete-preflight <node>` |
+| Plan additive-only joins | `just node-converge-plan` | `just node-lima-converge-plan` |
+| Join missing inventory nodes | `just node-converge` | `just node-lima-converge` |
 | Drain | `just node-drain <node>` | `just node-lima-drain <node>` |
 | Evict Longhorn replicas | `just node-longhorn-evict <node>` | `just node-lima-longhorn-evict <node>` |
 | Delete | `just node-delete <node>` | `just node-lima-delete <node>` |
@@ -229,6 +232,10 @@ explicit embedded-etcd member removal from a remaining control-plane.
 Join starts K3s with `node.home-ops.sh/joining=true:NoSchedule`, then cordons
 the node. Uncordon removes the temporary taint, waits for Cilium, checks
 Longhorn scheduling readiness, and restores scheduling.
+
+Converge is additive-only. It joins fresh inventory nodes that are absent from
+Kubernetes, refuses ambiguous drift or pending finalization, delegates mutation
+to `node-join`, and never uncordons automatically.
 
 Control-plane joins also install and verify the K3s kube-proxy disable drop-in
 when `kube_proxy_replacement: true`.

--- a/hack/bootstrap/lima/lib.sh
+++ b/hack/bootstrap/lima/lib.sh
@@ -183,12 +183,19 @@ lima_tunnel_port_open() {
   nc -z 127.0.0.1 "$LIMA_KUBECONFIG_PORT" >/dev/null 2>&1
 }
 
-lima_tunnel_pid_alive() {
-  local pid pid_file
+lima_tunnel_listener_pid() {
+  local port="$1"
+  lsof -nP -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null | head -n 1 || true
+}
+
+lima_tunnel_pid_matches_listener() {
+  local listener_pid pid pid_file
   pid_file="$(lima_tunnel_pid_file)"
   [[ -f "$pid_file" ]] || return 1
   pid="$(<"$pid_file")"
   [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  listener_pid="$(lima_tunnel_listener_pid "$LIMA_KUBECONFIG_PORT")"
+  [[ -n "$listener_pid" && "$pid" == "$listener_pid" ]] || return 1
   kill -0 "$pid" >/dev/null 2>&1
 }
 
@@ -226,8 +233,9 @@ lima_existing_apiserver_tunnel_valid() {
 
 lima_start_apiserver_tunnel() {
   local pid pid_file ssh_config
+  lima_require_tool lsof
   pid_file="$(lima_tunnel_pid_file)"
-  if lima_tunnel_pid_alive && lima_tunnel_port_open; then
+  if lima_tunnel_pid_matches_listener && lima_tunnel_port_open; then
     cat "$pid_file"
     return 0
   fi
@@ -236,7 +244,11 @@ lima_start_apiserver_tunnel() {
   fi
   if lima_tunnel_port_open; then
     if lima_existing_apiserver_tunnel_valid; then
+      pid="$(lima_tunnel_listener_pid "$LIMA_KUBECONFIG_PORT")"
+      [[ -n "$pid" ]] || lima_die "could not identify verified Lima API tunnel PID on 127.0.0.1:${LIMA_KUBECONFIG_PORT}"
+      printf '%s\n' "$pid" > "$pid_file"
       lima_log "using verified existing API tunnel on 127.0.0.1:${LIMA_KUBECONFIG_PORT}"
+      printf '%s\n' "$pid"
       return 0
     fi
     lima_die "port 127.0.0.1:${LIMA_KUBECONFIG_PORT} is already in use and is not a verified Lima API tunnel"
@@ -244,19 +256,23 @@ lima_start_apiserver_tunnel() {
   ssh_config="$(lima_ssh_config_file "$LIMA_SERVER_NAME")"
   [[ -f "$ssh_config" ]] || lima_die "missing Lima SSH config for ${LIMA_SERVER_NAME}: ${ssh_config}"
   mkdir -p "$LIMA_OUT_DIR"
-  ssh -F "$ssh_config" -N \
+  ssh -F "$ssh_config" -S none -fN \
+    -o ControlMaster=no \
+    -o ExitOnForwardFailure=yes \
     -L "127.0.0.1:${LIMA_KUBECONFIG_PORT}:127.0.0.1:6443" \
-    "lima-${LIMA_SERVER_NAME}" &
-  pid="$!"
-  printf '%s\n' "$pid" > "$pid_file"
+    "lima-${LIMA_SERVER_NAME}"
   for _ in $(seq 1 30); do
     if lima_tunnel_port_open; then
+      pid="$(lima_tunnel_listener_pid "$LIMA_KUBECONFIG_PORT")"
+      [[ -n "$pid" ]] || lima_die "could not identify Lima API tunnel PID on 127.0.0.1:${LIMA_KUBECONFIG_PORT}"
+      printf '%s\n' "$pid" > "$pid_file"
       printf '%s\n' "$pid"
       return 0
     fi
     sleep 1
   done
-  kill "$pid" >/dev/null 2>&1 || true
+  pid="$(lima_tunnel_listener_pid "$LIMA_KUBECONFIG_PORT")"
+  [[ -z "$pid" ]] || kill "$pid" >/dev/null 2>&1 || true
   lima_die "timed out waiting for API server tunnel on 127.0.0.1:${LIMA_KUBECONFIG_PORT}"
 }
 

--- a/hack/bootstrap/nodes/converge.sh
+++ b/hack/bootstrap/nodes/converge.sh
@@ -1,0 +1,444 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=hack/bootstrap/nodes/lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+NODE_JOIN_SCRIPT="${NODE_JOIN_SCRIPT:-${NODE_SCRIPT_DIR}/join.sh}"
+
+usage() {
+  cat <<'EOF'
+Usage: hack/bootstrap/nodes/converge.sh [options]
+
+Additive-only node convergence. Joins inventory nodes that are absent from
+Kubernetes, refuses all other drift, and leaves joined nodes cordoned.
+
+Options:
+  --profile NAME    Node lifecycle profile: live or lima. Defaults to live.
+  --context NAME    Kubernetes context. Defaults to the profile context.
+  --plan            Print the plan without mutating.
+  --output FORMAT   Output format: text or json. Defaults to text.
+  --yes             Skip confirmation prompt.
+  -h, --help        Show help.
+EOF
+}
+
+node_converge_json_array() {
+  if [[ "$#" -eq 0 ]]; then
+    printf '[]'
+    return 0
+  fi
+  printf '%s\n' "$@" | "$NODE_JQ_BIN" -R -s 'split("\n")[:-1]'
+}
+
+node_converge_has_value() {
+  local needle="$1"
+  shift
+  local value
+  for value in "$@"; do
+    [[ "$value" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+node_converge_inventory_role_for_kubernetes_node() {
+  local kube_node="$1"
+  local i
+  for ((i = 0; i < ${#inventory_kube_nodes[@]}; i++)); do
+    if [[ "${inventory_kube_nodes[$i]}" == "$kube_node" ]]; then
+      printf '%s\n' "${inventory_roles[$i]}"
+      return 0
+    fi
+  done
+  printf 'absent\n'
+}
+
+node_converge_inventory_name_for_kubernetes_node() {
+  local kube_node="$1"
+  local i
+  for ((i = 0; i < ${#inventory_kube_nodes[@]}; i++)); do
+    if [[ "${inventory_kube_nodes[$i]}" == "$kube_node" ]]; then
+      printf '%s\n' "${inventory_names[$i]}"
+      return 0
+    fi
+  done
+  printf '%s\n' "$kube_node"
+}
+
+node_converge_desired_k3s_version() {
+  local profile="$1"
+  local value
+  if [[ "$profile" == live ]]; then
+    "${BOOTSTRAP_DIR}/ansible/render-inventory.sh" \
+      --profile live \
+      --inventory-source "$NODE_LIVE_INVENTORY_DIR" >/dev/null
+  fi
+  value="$(node_effective_ansible_group_var "$profile" k3s_version 2>/dev/null || true)"
+  [[ -n "$value" && "$value" != "null" ]] ||
+    node_die "k3s_version is missing from effective ${profile} inventory vars; run the Ansible plan/render step first"
+  printf '%s\n' "$value"
+}
+
+node_converge_node_json() {
+  local nodes_json="$1"
+  local node="$2"
+  # shellcheck disable=SC2016
+  "$NODE_JQ_BIN" -c --arg node "$node" '.items[] | select(.metadata.name == $node)' <<<"$nodes_json"
+}
+
+node_converge_longhorn_scheduling_disabled() {
+  local context="$1"
+  local node="$2"
+  local longhorn_node_json allow_scheduling
+
+  longhorn_node_json="$(node_get_json "$context" -n longhorn-system "nodes.longhorn.io/${node}" 2>/dev/null || true)"
+  [[ -n "$longhorn_node_json" ]] || return 1
+  allow_scheduling="$("$NODE_JQ_BIN" -r '
+    if ((.spec // {}) | has("allowScheduling")) then .spec.allowScheduling else true end
+  ' <<<"$longhorn_node_json")"
+  [[ "$allow_scheduling" == false ]]
+}
+
+node_converge_print_list() {
+  local label="$1"
+  shift
+  printf '%s:\n' "$label"
+  if [[ "$#" -eq 0 ]]; then
+    printf '  none\n'
+    return 0
+  fi
+  local value
+  for value in "$@"; do
+    printf '  %s\n' "$value"
+  done
+}
+
+node_converge_print_text_plan() {
+  printf 'profile: %s\n' "$profile"
+  printf 'context: %s\n' "$context"
+  printf 'active_context: %s\n' "$active_context"
+  printf 'desired_k3s_version: %s\n' "$desired_k3s_version"
+  node_converge_print_list "blockers" "${blockers[@]}"
+  node_converge_print_list "missing_workers" "${missing_workers_kube[@]}"
+  node_converge_print_list "missing_control_planes" "${missing_control_planes_kube[@]}"
+  node_converge_print_list "join_order" "${planned_kube_nodes[@]}"
+  node_converge_print_list "follow_up" "${follow_up_commands[@]}"
+}
+
+node_converge_print_json_plan() {
+  local blockers_json missing_workers_json missing_control_planes_json join_order_json follow_up_json
+  blockers_json="$(node_converge_json_array "${blockers[@]}")"
+  missing_workers_json="$(node_converge_json_array "${missing_workers_kube[@]}")"
+  missing_control_planes_json="$(node_converge_json_array "${missing_control_planes_kube[@]}")"
+  join_order_json="$(node_converge_json_array "${planned_kube_nodes[@]}")"
+  follow_up_json="$(node_converge_json_array "${follow_up_commands[@]}")"
+
+  # shellcheck disable=SC2016
+  "$NODE_JQ_BIN" -n \
+    --arg profile "$profile" \
+    --arg context "$context" \
+    --arg active_context "$active_context" \
+    --arg desired_k3s_version "$desired_k3s_version" \
+    --argjson blockers "$blockers_json" \
+    --argjson missing_workers "$missing_workers_json" \
+    --argjson missing_control_planes "$missing_control_planes_json" \
+    --argjson join_order "$join_order_json" \
+    --argjson follow_up "$follow_up_json" \
+    '{
+      profile: $profile,
+      context: $context,
+      active_context: $active_context,
+      desired_k3s_version: $desired_k3s_version,
+      blockers: $blockers,
+      missing_workers: $missing_workers,
+      missing_control_planes: $missing_control_planes,
+      join_order: $join_order,
+      follow_up: $follow_up
+    }'
+}
+
+node_converge_print_plan() {
+  case "$output_format" in
+    text)
+      node_converge_print_text_plan
+      ;;
+    json)
+      node_converge_print_json_plan
+      ;;
+    *)
+      node_die "unknown output format: ${output_format}"
+      ;;
+  esac
+}
+
+profile=live
+context=""
+plan=false
+output_format=text
+yes=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      profile="$2"
+      shift 2
+      ;;
+    --context)
+      context="$2"
+      shift 2
+      ;;
+    --plan)
+      plan=true
+      shift
+      ;;
+    --output)
+      output_format="$2"
+      shift 2
+      ;;
+    --yes)
+      yes=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      node_die "unknown argument: $1"
+      ;;
+  esac
+done
+
+node_validate_profile "$profile"
+context="${context:-$(node_context_for_profile "$profile")}"
+
+case "$output_format" in
+  text|json)
+    ;;
+  *)
+    node_die "--output must be text or json"
+    ;;
+esac
+if [[ "$output_format" == json && "$plan" != true ]]; then
+  node_die "--output json is only supported with --plan"
+fi
+
+node_require_tool "$NODE_KUBECTL_BIN"
+node_require_tool "$NODE_YQ_BIN"
+node_require_tool "$NODE_JQ_BIN"
+node_require_tool ansible
+
+node_inventory_exists "$profile" || node_die "inventory not found for profile ${profile}: $(node_inventory_file "$profile")"
+active_context="$(node_current_context)"
+if ! node_bool "$plan"; then
+  node_assert_current_context "$context"
+fi
+node_assert_api_reachable "$context"
+desired_k3s_version="$(node_converge_desired_k3s_version "$profile")"
+longhorn_state="$(node_assert_longhorn_discovery "$context")"
+kubernetes_nodes_json="$(node_get_json "$context" nodes)"
+
+inventory_names=()
+inventory_roles=()
+inventory_kube_nodes=()
+kubernetes_node_names=()
+blockers=()
+missing_workers_inventory=()
+missing_workers_kube=()
+missing_control_planes_inventory=()
+missing_control_planes_kube=()
+planned_inventory_nodes=()
+planned_kube_nodes=()
+follow_up_commands=()
+current_control_plane_count=0
+desired_control_plane_count="$(node_inventory_group_count "$profile" master)"
+
+while IFS= read -r inventory_node; do
+  [[ -n "$inventory_node" ]] || continue
+  if [[ "$(node_inventory_role "$profile" "$inventory_node")" == conflict ]]; then
+    blockers+=("node appears in both master and node inventory groups: ${inventory_node}")
+  fi
+  inventory_names+=("$inventory_node")
+  inventory_roles+=(master)
+  inventory_kube_nodes+=("$(node_expected_kubernetes_node_name "$profile" "$inventory_node" "$inventory_node")")
+done < <(node_inventory_group_names "$profile" master)
+
+while IFS= read -r inventory_node; do
+  [[ -n "$inventory_node" ]] || continue
+  if [[ "$(node_inventory_role "$profile" "$inventory_node")" == conflict ]]; then
+    blockers+=("node appears in both master and node inventory groups: ${inventory_node}")
+  fi
+  inventory_names+=("$inventory_node")
+  inventory_roles+=(node)
+  inventory_kube_nodes+=("$(node_expected_kubernetes_node_name "$profile" "$inventory_node" "$inventory_node")")
+done < <(node_inventory_group_names "$profile" node)
+
+for ((i = 0; i < ${#inventory_kube_nodes[@]}; i++)); do
+  for ((j = i + 1; j < ${#inventory_kube_nodes[@]}; j++)); do
+    if [[ "${inventory_kube_nodes[$i]}" == "${inventory_kube_nodes[$j]}" ]]; then
+      blockers+=("duplicate expected Kubernetes node name in inventory: ${inventory_kube_nodes[$i]}")
+    fi
+  done
+done
+
+while IFS= read -r kube_node; do
+  [[ -n "$kube_node" ]] || continue
+  kubernetes_node_names+=("$kube_node")
+done < <("$NODE_JQ_BIN" -r '.items[].metadata.name' <<<"$kubernetes_nodes_json")
+
+for kube_node in "${kubernetes_node_names[@]}"; do
+  node_json="$(node_converge_node_json "$kubernetes_nodes_json" "$kube_node")"
+  inventory_role="$(node_converge_inventory_role_for_kubernetes_node "$kube_node")"
+  inventory_node="$(node_converge_inventory_name_for_kubernetes_node "$kube_node")"
+  k8s_role="$(node_k8s_role_from_node_json <<<"$node_json")"
+  ready="$(node_ready_from_node_json <<<"$node_json")"
+  schedulable="$(node_schedulable_from_node_json <<<"$node_json")"
+  joining_taint="$(node_joining_taint_from_node_json <<<"$node_json")"
+  kubelet_version="$("$NODE_JQ_BIN" -r '.status.nodeInfo.kubeletVersion // ""' <<<"$node_json")"
+
+  if [[ "$k8s_role" == control-plane ]]; then
+    current_control_plane_count=$((current_control_plane_count + 1))
+  fi
+  if [[ "$inventory_role" == absent ]]; then
+    blockers+=("Kubernetes node is not present in inventory: ${kube_node}")
+    continue
+  fi
+  expected_role=node
+  if [[ "$inventory_role" == master ]]; then
+    expected_role=control-plane
+  fi
+  if [[ "$k8s_role" != "$expected_role" ]]; then
+    blockers+=("role drift for ${kube_node}: inventory=${inventory_role} kubernetes=${k8s_role}")
+  fi
+  if [[ "$ready" != Ready ]]; then
+    blockers+=("Kubernetes node is not Ready: ${kube_node}")
+  fi
+  if [[ "$schedulable" != schedulable ]]; then
+    blockers+=("Kubernetes node is cordoned or pending finalization: ${kube_node}")
+  fi
+  case "$joining_taint" in
+    absent)
+      ;;
+    present)
+      blockers+=("Kubernetes node still has temporary joining taint: ${kube_node}")
+      ;;
+    invalid)
+      blockers+=("Kubernetes node has invalid temporary joining taint: ${kube_node}")
+      ;;
+    *)
+      blockers+=("Kubernetes node has unexpected joining taint state ${joining_taint}: ${kube_node}")
+      ;;
+  esac
+  if [[ "$kubelet_version" != "$desired_k3s_version" ]]; then
+    blockers+=("K3s version drift for ${kube_node}: desired=${desired_k3s_version} kubelet=${kubelet_version:-missing}")
+  fi
+  if [[ "$longhorn_state" == installed ]] &&
+    node_converge_longhorn_scheduling_disabled "$context" "$kube_node"; then
+    blockers+=("Longhorn scheduling is disabled for existing node: ${kube_node}")
+  fi
+  if [[ "$inventory_node" != "$kube_node" && "$profile" == live ]]; then
+    blockers+=("live inventory node name does not match Kubernetes node name: inventory=${inventory_node} kubernetes=${kube_node}")
+  fi
+done
+
+if ((desired_control_plane_count % 2 == 0)); then
+  blockers+=("desired control-plane count must be odd; desired=${desired_control_plane_count}")
+fi
+if ((current_control_plane_count == 0)); then
+  blockers+=("current Kubernetes control-plane count must be nonzero")
+fi
+
+for ((i = 0; i < ${#inventory_names[@]}; i++)); do
+  inventory_node="${inventory_names[$i]}"
+  inventory_role="${inventory_roles[$i]}"
+  kube_node="${inventory_kube_nodes[$i]}"
+  if node_converge_has_value "$kube_node" "${kubernetes_node_names[@]}"; then
+    continue
+  fi
+  case "$inventory_role" in
+    node)
+      missing_workers_inventory+=("$inventory_node")
+      missing_workers_kube+=("$kube_node")
+      ;;
+    master)
+      missing_control_planes_inventory+=("$inventory_node")
+      missing_control_planes_kube+=("$kube_node")
+      ;;
+  esac
+done
+
+allow_even_control_plane_repair=false
+if ((current_control_plane_count > 0 && current_control_plane_count % 2 == 0)); then
+  if [[ "${#missing_control_planes_inventory[@]}" -eq 1 &&
+    "${#missing_workers_inventory[@]}" -eq 0 &&
+    $(((current_control_plane_count + 1) % 2)) -eq 1 &&
+    $((desired_control_plane_count % 2)) -eq 1 ]]; then
+    allow_even_control_plane_repair=true
+  else
+    blockers+=("current Kubernetes control-plane count must be odd; current=${current_control_plane_count}")
+  fi
+fi
+
+for ((i = 0; i < ${#missing_workers_inventory[@]}; i++)); do
+  planned_inventory_nodes+=("${missing_workers_inventory[$i]}")
+  planned_kube_nodes+=("${missing_workers_kube[$i]}")
+done
+
+if [[ "${#missing_control_planes_inventory[@]}" -gt 0 ]]; then
+  if [[ "${#missing_control_planes_inventory[@]}" -ne 1 ]]; then
+    blockers+=("control-plane converge supports exactly one missing control-plane; missing=${#missing_control_planes_inventory[@]}")
+  elif ((desired_control_plane_count % 2 == 0)); then
+    blockers+=("desired control-plane count must be odd; desired=${desired_control_plane_count}")
+  elif ((current_control_plane_count % 2 == 0)) && [[ "$allow_even_control_plane_repair" != true ]]; then
+    blockers+=("cannot join control-plane while current control-plane count is even; current=${current_control_plane_count}")
+  elif (((current_control_plane_count + 1) % 2 == 0)); then
+    blockers+=("post-converge control-plane count must be odd; post=$((current_control_plane_count + 1))")
+  else
+    planned_inventory_nodes+=("${missing_control_planes_inventory[0]}")
+    planned_kube_nodes+=("${missing_control_planes_kube[0]}")
+  fi
+fi
+
+for inventory_node in "${planned_inventory_nodes[@]}"; do
+  if ! ping_output="$(node_ansible_ping "$profile" "$inventory_node" 2>&1 >/dev/null)"; then
+    blockers+=("Ansible could not reach planned node ${inventory_node}: ${ping_output}")
+  fi
+done
+
+for kube_node in "${planned_kube_nodes[@]}"; do
+  case "$profile" in
+    live)
+      follow_up_commands+=("just node-uncordon ${kube_node}")
+      ;;
+    lima)
+      follow_up_commands+=("just node-lima-uncordon ${kube_node}")
+      ;;
+  esac
+done
+
+if [[ "${#blockers[@]}" -gt 0 ]]; then
+  node_converge_print_plan
+  exit 1
+fi
+
+node_converge_print_plan
+if node_bool "$plan"; then
+  exit 0
+fi
+
+if [[ "${#planned_kube_nodes[@]}" -eq 0 ]]; then
+  node_log "no missing inventory nodes to join"
+  exit 0
+fi
+
+node_confirm "$yes" "converge missing nodes in ${context}"
+
+for kube_node in "${planned_kube_nodes[@]}"; do
+  node_log "joining missing node ${kube_node}"
+  "$NODE_JOIN_SCRIPT" --profile "$profile" --context "$context" --yes "$kube_node"
+done
+
+node_log "converge complete; inspect joined nodes and run follow-up uncordon commands when ready"
+for command in "${follow_up_commands[@]}"; do
+  printf '  %s\n' "$command"
+done

--- a/hack/bootstrap/nodes/lib/k8s.sh
+++ b/hack/bootstrap/nodes/lib/k8s.sh
@@ -24,6 +24,18 @@ node_assert_api_reachable() {
     node_die "Kubernetes context is not reachable: ${context}"
 }
 
+node_current_context() {
+  "$NODE_KUBECTL_BIN" config current-context
+}
+
+node_assert_current_context() {
+  local context="$1"
+  local current_context
+  current_context="$(node_current_context)"
+  [[ "$current_context" == "$context" ]] ||
+    node_die "active kube context must be ${context}; current context is ${current_context}"
+}
+
 node_wait_for_api_reachable() {
   local context="$1"
   local timeout="${2:-180}"

--- a/hack/bootstrap/nodes/lib/lima.sh
+++ b/hack/bootstrap/nodes/lib/lima.sh
@@ -14,6 +14,11 @@ node_lima_tunnel_port_open() {
   nc -z 127.0.0.1 "$port" >/dev/null 2>&1
 }
 
+node_lima_tunnel_listener_pid() {
+  local port="$1"
+  lsof -nP -tiTCP:"$port" -sTCP:LISTEN 2>/dev/null | head -n 1 || true
+}
+
 node_stop_lima_api_tunnel() {
   local pid_file pid
   pid_file="$(node_lima_tunnel_pid_file)"
@@ -32,6 +37,7 @@ node_start_lima_api_tunnel_to_inventory_node() {
 
   node_require_tool ssh
   node_require_tool nc
+  node_require_tool lsof
   node_require_tool "$NODE_KUBECTL_BIN"
   node_require_tool "$NODE_JQ_BIN"
   ssh_config="${HOME}/.lima/${inventory_node}/ssh.config"
@@ -49,13 +55,16 @@ node_start_lima_api_tunnel_to_inventory_node() {
   [[ -n "$port" ]] || node_die "could not find an available local port for Lima API handoff"
 
   mkdir -p "$(node_lima_out_dir)"
-  ssh -F "$ssh_config" -N \
+  ssh -F "$ssh_config" -S none -fN \
+    -o ControlMaster=no \
+    -o ExitOnForwardFailure=yes \
     -L "127.0.0.1:${port}:127.0.0.1:6443" \
-    "lima-${inventory_node}" &
-  pid="$!"
-  printf '%s\n' "$pid" > "$pid_file"
+    "lima-${inventory_node}"
   for _ in $(seq 1 30); do
     if node_lima_tunnel_port_open "$port"; then
+      pid="$(node_lima_tunnel_listener_pid "$port")"
+      [[ -n "$pid" ]] || node_die "could not identify Lima API tunnel PID on 127.0.0.1:${port}"
+      printf '%s\n' "$pid" > "$pid_file"
       # shellcheck disable=SC2016
       cluster_name="$("$NODE_KUBECTL_BIN" config view -o json |
         "$NODE_JQ_BIN" -r --arg context "$context" '
@@ -70,7 +79,8 @@ node_start_lima_api_tunnel_to_inventory_node() {
     fi
     sleep 1
   done
-  kill "$pid" >/dev/null 2>&1 || true
+  pid="$(node_lima_tunnel_listener_pid "$port")"
+  [[ -z "$pid" ]] || kill "$pid" >/dev/null 2>&1 || true
   rm -f "$pid_file"
   node_die "timed out waiting for Lima API tunnel through ${inventory_node}"
 }

--- a/hack/bootstrap/tests/bats/offline-nodes.bats
+++ b/hack/bootstrap/tests/bats/offline-nodes.bats
@@ -11,6 +11,7 @@ setup_file() {
 
 setup() {
   tmp="$BATS_TEST_TMPDIR"
+  export BOOTSTRAP_ANSIBLE_OUT_DIR="${tmp}/ansible-out"
   create_node_inventory
 }
 
@@ -195,6 +196,56 @@ EOF
   assert_file_contains "$calls_file" 'tunnel=k3s-master-0 context=test'
 }
 
+@test "Lima API tunnels disable SSH multiplexing" {
+  assert_file_contains "$ROOT/hack/bootstrap/lima/lib.sh" '-S none'
+  assert_file_contains "$ROOT/hack/bootstrap/lima/lib.sh" '-fN'
+  assert_file_contains "$ROOT/hack/bootstrap/lima/lib.sh" '-o ControlMaster=no'
+  assert_file_contains "$ROOT/hack/bootstrap/lima/lib.sh" '-o ExitOnForwardFailure=yes'
+  assert_file_contains "$ROOT/hack/bootstrap/nodes/lib/lima.sh" '-S none'
+  assert_file_contains "$ROOT/hack/bootstrap/nodes/lib/lima.sh" '-fN'
+  assert_file_contains "$ROOT/hack/bootstrap/nodes/lib/lima.sh" '-o ControlMaster=no'
+  assert_file_contains "$ROOT/hack/bootstrap/nodes/lib/lima.sh" '-o ExitOnForwardFailure=yes'
+}
+
+@test "Lima API tunnel pidfile must match listener PID" {
+  run env LIMA_OUT_DIR="${tmp}/lima-out" LIMA_KUBECONFIG_PORT=16443 bash -c "
+    source '${ROOT}/hack/bootstrap/lima/lib.sh'
+    mkdir -p \"\${LIMA_OUT_DIR}\"
+    printf '%s\n' \"\$\$\" >\"\$(lima_tunnel_pid_file)\"
+    lima_tunnel_listener_pid() { printf '%s\n' \"\$\$\"; }
+    lima_tunnel_pid_matches_listener
+  "
+  assert_success
+
+  run env LIMA_OUT_DIR="${tmp}/lima-out" LIMA_KUBECONFIG_PORT=16443 bash -c "
+    source '${ROOT}/hack/bootstrap/lima/lib.sh'
+    mkdir -p \"\${LIMA_OUT_DIR}\"
+    printf '%s\n' \"\$\$\" >\"\$(lima_tunnel_pid_file)\"
+    lima_tunnel_listener_pid() { printf '%s\n' 999999; }
+    lima_tunnel_pid_matches_listener
+  "
+  assert_failure
+}
+
+@test "verified existing Lima API tunnel refreshes stale pidfile" {
+  run env LIMA_OUT_DIR="${tmp}/lima-out" LIMA_KUBECONFIG_PORT=16443 bash -c "
+    source '${ROOT}/hack/bootstrap/lima/lib.sh'
+    mkdir -p \"\${LIMA_OUT_DIR}\"
+    printf '%s\n' 111 >\"\$(lima_tunnel_pid_file)\"
+    lima_require_tool() { :; }
+    lima_tunnel_pid_matches_listener() { return 1; }
+    lima_tunnel_port_open() { return 0; }
+    lima_existing_apiserver_tunnel_valid() { return 0; }
+    lima_tunnel_listener_pid() { printf '%s\n' 4242; }
+    lima_start_apiserver_tunnel
+    printf 'pidfile=%s\n' \"\$(cat \"\$(lima_tunnel_pid_file)\")\"
+  "
+  assert_success
+  assert_output_contains 'using verified existing API tunnel on 127.0.0.1:16443'
+  assert_output_contains '4242'
+  assert_output_contains 'pidfile=4242'
+}
+
 @test "control-plane join validates kube-proxy disable drop-in when replacement is enabled" {
   local rendered_out rendered_inventory
   write_fake_ansible
@@ -315,6 +366,216 @@ EOF
   assert_output_contains 'etcd still has 1 member(s) for k3s-master-1'
 }
 
+@test "node converge plans no-op inventory and emits JSON shape" {
+  local nodes_json
+  nodes_json="${tmp}/nodes.json"
+  write_default_converge_nodes_json "$nodes_json"
+  write_converge_kubectl
+  write_fake_ansible
+
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --plan --output json
+  assert_success
+  printf '%s\n' "$output" > "${tmp}/converge-plan.json"
+
+  run jq -r '.profile' "${tmp}/converge-plan.json"
+  assert_success
+  [[ "$output" == "live" ]]
+
+  run jq -r '.join_order | length' "${tmp}/converge-plan.json"
+  assert_success
+  [[ "$output" == "0" ]]
+
+  run jq -r '.blockers | length' "${tmp}/converge-plan.json"
+  assert_success
+  [[ "$output" == "0" ]]
+}
+
+@test "node converge joins missing workers sequentially through existing join script" {
+  local nodes_json calls_file
+  nodes_json="${tmp}/nodes.json"
+  calls_file="${tmp}/join.calls"
+  add_inventory_worker k3s-worker-1 192.168.99.21
+  add_inventory_worker k3s-worker-2 192.168.99.22
+  write_default_converge_nodes_json "$nodes_json"
+  write_converge_kubectl
+  write_fake_ansible
+  write_fake_join_script
+
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" NODE_JOIN_SCRIPT="$fake_join_script" FAKE_CONVERGE_NODES_JSON="$nodes_json" FAKE_JOIN_CALLS="$calls_file" \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --yes
+  assert_success
+  assert_output_contains 'join_order:'
+  assert_output_contains 'k3s-worker-1'
+  assert_output_contains 'k3s-worker-2'
+  assert_output_contains 'just node-uncordon k3s-worker-1'
+  assert_file_contains "$calls_file" '--profile live --context test --yes k3s-worker-1'
+  assert_file_contains "$calls_file" '--profile live --context test --yes k3s-worker-2'
+}
+
+@test "node converge plans one control-plane repair from even to odd count" {
+  local nodes_json
+  nodes_json="${tmp}/nodes.json"
+  add_inventory_master k3s-master-3 192.168.99.13
+  add_inventory_master k3s-master-4 192.168.99.14
+  write_converge_nodes_json "$nodes_json" \
+    "k3s-master-0:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-1:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-2:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-3:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-worker-0:node:True:schedulable:absent:v1.35.4+k3s1"
+  write_converge_kubectl
+  write_fake_ansible
+
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --plan --output json
+  assert_success
+  printf '%s\n' "$output" > "${tmp}/converge-cp-plan.json"
+
+  run jq -r '.join_order | join(",")' "${tmp}/converge-cp-plan.json"
+  assert_success
+  [[ "$output" == "k3s-master-4" ]]
+}
+
+@test "node converge refuses unsafe control-plane additions" {
+  local nodes_json
+  nodes_json="${tmp}/nodes.json"
+  add_inventory_master k3s-master-3 192.168.99.13
+  add_inventory_master k3s-master-4 192.168.99.14
+  write_default_converge_nodes_json "$nodes_json"
+  write_converge_kubectl
+  write_fake_ansible
+
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --plan
+  assert_failure
+  assert_output_contains 'control-plane converge supports exactly one missing control-plane'
+
+  create_node_inventory
+  add_inventory_master k3s-master-3 192.168.99.13
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --plan
+  assert_failure
+  assert_output_contains 'desired control-plane count must be odd'
+}
+
+@test "node converge refuses unsafe control-plane counts even for worker-only plans" {
+  local nodes_json
+  nodes_json="${tmp}/nodes.json"
+  add_inventory_worker k3s-worker-1 192.168.99.21
+  write_converge_nodes_json "$nodes_json" \
+    "k3s-master-0:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-1:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-worker-0:node:True:schedulable:absent:v1.35.4+k3s1"
+  write_converge_kubectl
+  write_fake_ansible
+
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --plan
+  assert_failure
+  assert_output_contains 'current Kubernetes control-plane count must be odd; current=2'
+
+  add_inventory_master k3s-master-3 192.168.99.13
+  write_default_converge_nodes_json "$nodes_json"
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --plan
+  assert_failure
+  assert_output_contains 'desired control-plane count must be odd; desired=4'
+}
+
+@test "node converge refuses duplicate inventory roles" {
+  local nodes_json
+  nodes_json="${tmp}/nodes.json"
+  add_inventory_worker k3s-master-1 192.168.99.11
+  write_default_converge_nodes_json "$nodes_json"
+  write_converge_kubectl
+  write_fake_ansible
+
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --plan
+  assert_failure
+  assert_output_contains 'node appears in both master and node inventory groups: k3s-master-1'
+  assert_output_contains 'duplicate expected Kubernetes node name in inventory: k3s-master-1'
+}
+
+@test "node converge strict preflight blocks drift and pending finalization" {
+  local nodes_json
+  nodes_json="${tmp}/nodes.json"
+  write_converge_kubectl
+  write_fake_ansible
+
+  write_converge_nodes_json "$nodes_json" \
+    "k3s-master-0:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-1:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-2:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-worker-0:master:True:schedulable:absent:v1.35.4+k3s1"
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --plan
+  assert_failure
+  assert_output_contains 'role drift for k3s-worker-0'
+
+  write_converge_nodes_json "$nodes_json" \
+    "k3s-master-0:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-1:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-2:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-worker-0:node:False:schedulable:absent:v1.35.4+k3s1"
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --plan
+  assert_failure
+  assert_output_contains 'Kubernetes node is not Ready: k3s-worker-0'
+
+  write_converge_nodes_json "$nodes_json" \
+    "k3s-master-0:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-1:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-2:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-worker-0:node:True:cordoned:present:v1.35.4+k3s1"
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --plan
+  assert_failure
+  assert_output_contains 'Kubernetes node is cordoned or pending finalization: k3s-worker-0'
+  assert_output_contains 'Kubernetes node still has temporary joining taint: k3s-worker-0'
+
+  write_converge_nodes_json "$nodes_json" \
+    "k3s-master-0:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-1:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-2:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-worker-0:node:True:schedulable:absent:v1.35.3+k3s1"
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --plan
+  assert_failure
+  assert_output_contains 'K3s version drift for k3s-worker-0'
+
+  write_default_converge_nodes_json "$nodes_json"
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" FAKE_LONGHORN_INSTALLED=true FAKE_LONGHORN_DISABLED_NODE=k3s-worker-0 \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --plan
+  assert_failure
+  assert_output_contains 'Longhorn scheduling is disabled for existing node: k3s-worker-0'
+}
+
+@test "node converge blocks unknown Kubernetes nodes and active context mismatch" {
+  local nodes_json
+  nodes_json="${tmp}/nodes.json"
+  write_converge_nodes_json "$nodes_json" \
+    "k3s-master-0:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-1:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-2:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-worker-0:node:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-stray-0:node:True:schedulable:absent:v1.35.4+k3s1"
+  write_converge_kubectl
+  write_fake_ansible
+
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --plan
+  assert_failure
+  assert_output_contains 'Kubernetes node is not present in inventory: k3s-stray-0'
+
+  write_default_converge_nodes_json "$nodes_json"
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_converge_kubectl" FAKE_CONVERGE_NODES_JSON="$nodes_json" FAKE_CURRENT_CONTEXT=other \
+    "${ROOT}/hack/bootstrap/nodes/converge.sh" --profile live --context test --yes
+  assert_failure
+  assert_output_contains 'active kube context must be test'
+}
+
 @test "Longhorn deleted-node cleanup deletes only safe stale state and reports blockers" {
   write_deleted_node_longhorn_kubectl
   mkdir -p "${tmp}/longhorn-state"
@@ -424,6 +685,7 @@ EOF
     hack/bootstrap/nodes/longhorn-evict.sh \
     hack/bootstrap/nodes/join.sh \
     hack/bootstrap/nodes/uncordon.sh \
+    hack/bootstrap/nodes/converge.sh \
     hack/bootstrap/nodes/refresh-ssh-host-key.sh \
     hack/bootstrap/ansible/node-control-plane.sh; do
     run "${ROOT}/${script}" --help
@@ -431,4 +693,8 @@ EOF
   done
 
   assert_file_contains "$ROOT/hack/bootstrap/nodes/drain.sh" 'node_handoff_control_plane_api_if_needed'
+  assert_file_contains "$ROOT/justfile" "[group('node-mutate')]"
+  assert_file_contains "$ROOT/justfile" "node-converge:"
+  assert_file_not_contains "$ROOT/justfile" "node-converge-yes:"
+  assert_file_contains "$ROOT/justfile" "node-lima-converge-yes:"
 }

--- a/hack/bootstrap/tests/helpers/nodes.bash
+++ b/hack/bootstrap/tests/helpers/nodes.bash
@@ -33,7 +33,157 @@ EOF
 ansible_user: ethan
 ansible_ssh_private_key_file: ~/ansiblekey
 kube_proxy_replacement: true
+k3s_version: v1.35.4+k3s1
 EOF
+}
+
+add_inventory_worker() {
+  local name="$1"
+  local address="$2"
+  NODE_NAME="$name" NODE_ADDRESS="$address" yq -i '
+    .all.children.k3s_cluster.children.node.hosts[strenv(NODE_NAME)] = {
+      "ansible_host": strenv(NODE_ADDRESS),
+      "k3s_role": "agent"
+    }
+  ' "${inventory}/hosts.yml"
+}
+
+add_inventory_master() {
+  local name="$1"
+  local address="$2"
+  NODE_NAME="$name" NODE_ADDRESS="$address" yq -i '
+    .all.children.k3s_cluster.children.master.hosts[strenv(NODE_NAME)] = {
+      "ansible_host": strenv(NODE_ADDRESS),
+      "k3s_role": "server"
+    }
+  ' "${inventory}/hosts.yml"
+}
+
+write_converge_nodes_json() {
+  local file="$1"
+  shift
+  printf '{"items":[' > "$file"
+  local first=true
+  local node name role ready schedulable taint version role_labels spec_fields
+  for spec in "$@"; do
+    IFS=: read -r name role ready schedulable taint version <<<"$spec"
+    if [[ "$first" == true ]]; then
+      first=false
+    else
+      printf ',' >> "$file"
+    fi
+    if [[ "$role" == master ]]; then
+      role_labels='"node-role.kubernetes.io/control-plane":"true"'
+    else
+      role_labels=''
+    fi
+    spec_fields=''
+    if [[ "$schedulable" == cordoned ]]; then
+      spec_fields='"unschedulable":true'
+    fi
+    case "$taint" in
+      present)
+        taints='"taints":[{"key":"node.home-ops.sh/joining","value":"true","effect":"NoSchedule"}]'
+        ;;
+      invalid)
+        taints='"taints":[{"key":"node.home-ops.sh/joining","value":"true","effect":"PreferNoSchedule"}]'
+        ;;
+      *)
+        taints=''
+        ;;
+    esac
+    if [[ -n "$taints" ]]; then
+      if [[ -n "$spec_fields" ]]; then
+        spec_fields="${spec_fields},${taints}"
+      else
+        spec_fields="$taints"
+      fi
+    fi
+    node="$(cat <<JSON
+{
+  "metadata": {
+    "name": "${name}",
+    "labels": {${role_labels}}
+  },
+  "spec": {${spec_fields}},
+  "status": {
+    "conditions": [{"type": "Ready", "status": "${ready}"}],
+    "nodeInfo": {"kubeletVersion": "${version:-v1.35.4+k3s1}"}
+  }
+}
+JSON
+)"
+    printf '%s' "$node" >> "$file"
+  done
+  printf ']}\n' >> "$file"
+}
+
+write_default_converge_nodes_json() {
+  write_converge_nodes_json "$1" \
+    "k3s-master-0:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-1:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-master-2:master:True:schedulable:absent:v1.35.4+k3s1" \
+    "k3s-worker-0:node:True:schedulable:absent:v1.35.4+k3s1"
+}
+
+write_converge_kubectl() {
+  fake_converge_kubectl="${tmp}/kubectl-converge"
+  cat > "$fake_converge_kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--context" ]]; then
+  shift 2
+fi
+
+if [[ "${1:-}" == "config" && "${2:-}" == "current-context" ]]; then
+  printf '%s\n' "${FAKE_CURRENT_CONTEXT:-test}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "--raw=/readyz" ]]; then
+  printf 'ok\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "nodes" ]]; then
+  cat "${FAKE_CONVERGE_NODES_JSON:?}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "crd" && "${3:-}" == "volumes.longhorn.io" ]]; then
+  if [[ "${FAKE_LONGHORN_INSTALLED:-false}" == true ]]; then
+    printf '{"metadata":{"name":"volumes.longhorn.io"}}\n'
+    exit 0
+  fi
+  printf 'Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "volumes.longhorn.io" not found\n' >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "-n" && "${3:-}" == "longhorn-system" && "${4:-}" == nodes.longhorn.io/* ]]; then
+  node="${4#nodes.longhorn.io/}"
+  allow=true
+  if [[ "${FAKE_LONGHORN_DISABLED_NODE:-}" == "$node" ]]; then
+    allow=false
+  fi
+  printf '{"metadata":{"name":"%s"},"spec":{"allowScheduling":%s},"status":{"conditions":[{"type":"Ready","status":"True"},{"type":"Schedulable","status":"True"}]}}\n' "$node" "$allow"
+  exit 0
+fi
+
+printf 'unexpected fake converge kubectl args: %s\n' "$*" >&2
+exit 1
+EOF
+  chmod +x "$fake_converge_kubectl"
+}
+
+write_fake_join_script() {
+  fake_join_script="${tmp}/join.sh"
+  cat > "$fake_join_script" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${FAKE_JOIN_CALLS:?}"
+EOF
+  chmod +x "$fake_join_script"
 }
 
 write_worker_status_kubectl() {

--- a/justfile
+++ b/justfile
@@ -287,35 +287,45 @@ node-control-plane-status node:
 node-control-plane-delete-preflight node:
     ./hack/bootstrap/nodes/control-plane-delete-preflight.sh --profile live --context default '{{ node }}'
 
-# Drain a live worker or control-plane node before deletion or maintenance.
+# Plan additive-only live node convergence from inventory.
 [group('node')]
+node-converge-plan:
+    ./hack/bootstrap/nodes/converge.sh --profile live --context default --plan
+
+# Drain a live worker or control-plane node before deletion or maintenance.
+[group('node-mutate')]
 node-drain node:
     ./hack/bootstrap/nodes/drain.sh --profile live --context default '{{ node }}'
 
 # Delete a drained live worker or control-plane node after Longhorn state has been evacuated.
-[group('node')]
+[group('node-mutate')]
 node-delete node:
     ./hack/bootstrap/nodes/delete.sh --profile live --context default '{{ node }}'
 
 # Evict Longhorn replicas from a drained live node before replacement.
-[group('node')]
+[group('node-mutate')]
 node-longhorn-evict node:
     ./hack/bootstrap/nodes/longhorn-evict.sh --profile live --context default '{{ node }}'
 
 # Refresh a rebuilt live worker's SSH host key in known_hosts.
-[group('node')]
+[group('node-mutate')]
 node-refresh-ssh-host-key node:
     ./hack/bootstrap/nodes/refresh-ssh-host-key.sh --profile live '{{ node }}'
 
 # Join a live worker or control-plane node from inventory with a temporary scheduling taint.
-[group('node')]
+[group('node-mutate')]
 node-join node:
     ./hack/bootstrap/nodes/join.sh --profile live --context default '{{ node }}'
 
 # Remove the temporary live node taint and restore scheduling.
-[group('node')]
+[group('node-mutate')]
 node-uncordon node:
     ./hack/bootstrap/nodes/uncordon.sh --profile live --context default '{{ node }}'
+
+# Run prompted additive-only live node convergence from inventory.
+[group('node-mutate')]
+node-converge:
+    ./hack/bootstrap/nodes/converge.sh --profile live --context default
 
 # Delete the configured kind cluster.
 [group('kind')]
@@ -444,35 +454,50 @@ node-lima-control-plane-status node:
 node-lima-control-plane-delete-preflight node:
     ./hack/bootstrap/nodes/control-plane-delete-preflight.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
 
-# Drain a Lima worker or control-plane node before deletion or maintenance.
+# Plan additive-only Lima node convergence from inventory.
 [group('node-lima')]
+node-lima-converge-plan:
+    ./hack/bootstrap/nodes/converge.sh --profile lima --context '{{ lima_context }}' --plan
+
+# Drain a Lima worker or control-plane node before deletion or maintenance.
+[group('node-lima-mutate')]
 node-lima-drain node:
     ./hack/bootstrap/nodes/drain.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
 
 # Delete a drained Lima worker or control-plane node after Longhorn state has been evacuated.
-[group('node-lima')]
+[group('node-lima-mutate')]
 node-lima-delete node:
     ./hack/bootstrap/nodes/delete.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
 
 # Evict Longhorn replicas from a drained Lima node before replacement.
-[group('node-lima')]
+[group('node-lima-mutate')]
 node-lima-longhorn-evict node:
     ./hack/bootstrap/nodes/longhorn-evict.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
 
 # Refresh a rebuilt Lima worker's SSH host key in known_hosts.
-[group('node-lima')]
+[group('node-lima-mutate')]
 node-lima-refresh-ssh-host-key node:
     ./hack/bootstrap/nodes/refresh-ssh-host-key.sh --profile lima '{{ node }}'
 
 # Join a Lima worker or control-plane node from inventory with a temporary scheduling taint.
-[group('node-lima')]
+[group('node-lima-mutate')]
 node-lima-join node:
     ./hack/bootstrap/nodes/join.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
 
 # Remove the temporary Lima node taint and restore scheduling.
-[group('node-lima')]
+[group('node-lima-mutate')]
 node-lima-uncordon node:
     ./hack/bootstrap/nodes/uncordon.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
+
+# Run prompted additive-only Lima node convergence from inventory.
+[group('node-lima-mutate')]
+node-lima-converge:
+    ./hack/bootstrap/nodes/converge.sh --profile lima --context '{{ lima_context }}'
+
+# Run non-interactive additive-only Lima node convergence from inventory.
+[group('node-lima-mutate')]
+node-lima-converge-yes:
+    ./hack/bootstrap/nodes/converge.sh --profile lima --context '{{ lima_context }}' --yes
 
 # Recreate larger Lima VMs, run Ansible, bootstrap app profile, and validate app safety.
 [group('lima-apps')]


### PR DESCRIPTION
## Summary
- add additive-only node convergence for inventory nodes that are absent from Kubernetes
- split read-only and mutating node lifecycle just groups, including Lima converge helpers
- harden Lima API tunnel management to avoid SSH ControlMaster port-forward leaks
- document converge behavior in bootstrap and cluster operations docs

## Validation
- just bootstrap-test
- pre-commit run --files docs/cluster-operations.md hack/bootstrap/AGENTS.md hack/bootstrap/README.md hack/bootstrap/lima/lib.sh hack/bootstrap/nodes/converge.sh hack/bootstrap/nodes/lib/k8s.sh hack/bootstrap/nodes/lib/lima.sh hack/bootstrap/tests/bats/offline-nodes.bats hack/bootstrap/tests/helpers/nodes.bash justfile
- live Lima app cluster: worker drain/evict/delete/converge/uncordon passed
- live Lima app cluster: non-first control-plane preflight/drain/evict/delete/converge/uncordon passed
- final node-lima-converge-plan clean with all five Lima nodes Ready

Review agent approved after blocker fixes.