### PR TITLE
feat: manage host services with ansible

### DIFF
--- a/hack/bootstrap/ansible/home-ops/control-plane-join.yml
+++ b/hack/bootstrap/ansible/home-ops/control-plane-join.yml
@@ -33,3 +33,9 @@
 
     - name: Join K3s server with temporary taint
       ansible.builtin.import_tasks: tasks/join-servers.yml
+
+    - name: Apply RPi reporter host service
+      ansible.builtin.import_tasks: tasks/rpi-reporter.yml
+
+    - name: Apply NUT client host service
+      ansible.builtin.import_tasks: tasks/nut-client.yml

--- a/hack/bootstrap/ansible/home-ops/host-services.yml
+++ b/hack/bootstrap/ansible/home-ops/host-services.yml
@@ -1,0 +1,16 @@
+---
+- name: Converge RPi reporter host service
+  hosts: k3s_cluster
+  gather_facts: true
+  become: true
+  tasks:
+    - name: Apply RPi reporter host service
+      ansible.builtin.import_tasks: tasks/rpi-reporter.yml
+
+- name: Converge NUT client host service
+  hosts: master
+  gather_facts: true
+  become: true
+  tasks:
+    - name: Apply NUT client host service
+      ansible.builtin.import_tasks: tasks/nut-client.yml

--- a/hack/bootstrap/ansible/home-ops/site.yml
+++ b/hack/bootstrap/ansible/home-ops/site.yml
@@ -71,3 +71,19 @@
   tasks:
     - name: Prepare and fetch kubeconfig
       ansible.builtin.import_tasks: tasks/kubeconfig.yml
+
+- name: Converge RPi reporter host service
+  hosts: k3s_cluster
+  gather_facts: true
+  become: true
+  tasks:
+    - name: Apply RPi reporter host service
+      ansible.builtin.import_tasks: tasks/rpi-reporter.yml
+
+- name: Converge NUT client host service
+  hosts: master
+  gather_facts: true
+  become: true
+  tasks:
+    - name: Apply NUT client host service
+      ansible.builtin.import_tasks: tasks/nut-client.yml

--- a/hack/bootstrap/ansible/home-ops/tasks/nut-client.yml
+++ b/hack/bootstrap/ansible/home-ops/tasks/nut-client.yml
@@ -1,0 +1,93 @@
+---
+- name: Install NUT client package
+  ansible.builtin.package:
+    name: nut-client
+    state: present
+  register: home_ops_nut_client_package
+  when: home_ops_nut_client_enabled | bool
+
+- name: Check NUT client configuration
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop:
+    - /etc/nut/nut.conf
+    - /etc/nut/upsmon.conf
+  register: home_ops_nut_config_stats
+  when: home_ops_nut_client_enabled | bool
+
+- name: Decide whether to render NUT client configuration
+  ansible.builtin.set_fact:
+    home_ops_nut_client_render_config: >-
+      {{ home_ops_nut_client_manage_config | bool
+      or not (home_ops_nut_config_stats.results
+      | map(attribute='stat.exists') | min) }}
+  when: home_ops_nut_client_enabled | bool
+
+- name: Validate NUT client secret inputs
+  ansible.builtin.assert:
+    that:
+      - home_ops_nut_monitor_system | length > 0
+      - home_ops_nut_monitor_user | length > 0
+      - home_ops_nut_monitor_password | length > 0
+    fail_msg: >-
+      Missing NUT monitor settings. Preserve existing /etc/nut config or
+      provide HOME_OPS_NUT_MONITOR_SYSTEM, HOME_OPS_NUT_MONITOR_USER, and
+      HOME_OPS_NUT_MONITOR_PASSWORD.
+  when:
+    - home_ops_nut_client_enabled | bool
+    - home_ops_nut_client_render_config | bool
+
+- name: Ensure NUT config directory permissions
+  ansible.builtin.file:
+    path: /etc/nut
+    state: directory
+    owner: root
+    group: nut
+    mode: "0755"
+  when:
+    - home_ops_nut_client_enabled | bool
+    - home_ops_nut_client_render_config | bool
+
+- name: Render NUT client mode
+  ansible.builtin.template:
+    src: nut.conf.j2
+    dest: /etc/nut/nut.conf
+    owner: root
+    group: nut
+    mode: "0640"
+  register: home_ops_nut_conf
+  when:
+    - home_ops_nut_client_enabled | bool
+    - home_ops_nut_client_render_config | bool
+
+- name: Render NUT monitor configuration
+  ansible.builtin.template:
+    src: upsmon.conf.j2
+    dest: /etc/nut/upsmon.conf
+    owner: root
+    group: nut
+    mode: "0640"
+  register: home_ops_upsmon_conf
+  no_log: true
+  when:
+    - home_ops_nut_client_enabled | bool
+    - home_ops_nut_client_render_config | bool
+
+- name: Decide whether to restart NUT client
+  ansible.builtin.set_fact:
+    home_ops_nut_client_restart_needed: >-
+      {{ home_ops_nut_client_package.changed | default(false)
+      or home_ops_nut_conf.changed | default(false)
+      or home_ops_upsmon_conf.changed | default(false) }}
+  when: home_ops_nut_client_enabled | bool
+
+- name: Enable and start NUT monitor
+  ansible.builtin.systemd:
+    name: "{{ home_ops_nut_client_service_name }}.service"
+    enabled: true
+    state: >-
+      {{ 'restarted'
+      if (home_ops_nut_client_restart_needed | bool
+      and home_ops_nut_client_restart_on_change | bool)
+      else 'started' }}
+  when: home_ops_nut_client_enabled | bool

--- a/hack/bootstrap/ansible/home-ops/tasks/rpi-reporter.yml
+++ b/hack/bootstrap/ansible/home-ops/tasks/rpi-reporter.yml
@@ -1,0 +1,154 @@
+---
+- name: Install RPi reporter prerequisites
+  ansible.builtin.package:
+    name:
+      - git
+      - python3-pip
+      - python3-venv
+    state: present
+  when: home_ops_rpi_reporter_enabled | bool
+
+- name: Check RPi reporter checkout
+  ansible.builtin.stat:
+    path: "{{ home_ops_rpi_reporter_path }}"
+  register: home_ops_rpi_reporter_path_stat
+  when: home_ops_rpi_reporter_enabled | bool
+
+- name: Check RPi reporter git metadata
+  ansible.builtin.stat:
+    path: "{{ home_ops_rpi_reporter_path }}/.git"
+  register: home_ops_rpi_reporter_git_stat
+  when:
+    - home_ops_rpi_reporter_enabled | bool
+    - home_ops_rpi_reporter_path_stat.stat.exists
+
+- name: Refuse to manage a non-git RPi reporter path
+  ansible.builtin.fail:
+    msg: >-
+      {{ home_ops_rpi_reporter_path }} exists but is not a git checkout;
+      refusing to overwrite it.
+  when:
+    - home_ops_rpi_reporter_enabled | bool
+    - home_ops_rpi_reporter_path_stat.stat.exists
+    - not home_ops_rpi_reporter_git_stat.stat.exists
+
+- name: Clone RPi reporter when missing
+  ansible.builtin.git:
+    repo: "{{ home_ops_rpi_reporter_repo }}"
+    dest: "{{ home_ops_rpi_reporter_path }}"
+    version: "{{ home_ops_rpi_reporter_version }}"
+    update: false
+  register: home_ops_rpi_reporter_clone
+  when:
+    - home_ops_rpi_reporter_enabled | bool
+    - not home_ops_rpi_reporter_path_stat.stat.exists
+
+- name: Refuse to update an existing RPi reporter checkout
+  ansible.builtin.fail:
+    msg: >-
+      Existing RPi reporter checkout updates are intentionally disabled.
+      Preserve the live checkout or rebuild the node so this role performs a
+      fresh pinned clone.
+  when:
+    - home_ops_rpi_reporter_enabled | bool
+    - home_ops_rpi_reporter_path_stat.stat.exists
+    - home_ops_rpi_reporter_update_existing | bool
+
+- name: Preserve retained MQTT discovery payloads
+  ansible.builtin.replace:
+    path: "{{ home_ops_rpi_reporter_path }}/ISP-RPi-mqtt-daemon.py"
+    regexp: "retain=False"
+    replace: "retain=True"
+  register: home_ops_rpi_reporter_retain_patch
+  when:
+    - home_ops_rpi_reporter_enabled | bool
+    - home_ops_rpi_reporter_apply_retain_patch | bool
+
+- name: Create RPi reporter virtual environment
+  ansible.builtin.command:
+    cmd: python3 -m venv "{{ home_ops_rpi_reporter_path }}/venv"
+    creates: "{{ home_ops_rpi_reporter_path }}/venv/bin/python3"
+  register: home_ops_rpi_reporter_venv
+  when: home_ops_rpi_reporter_enabled | bool
+
+- name: Install RPi reporter Python requirements
+  ansible.builtin.pip:
+    requirements: "{{ home_ops_rpi_reporter_path }}/requirements.txt"
+    virtualenv: "{{ home_ops_rpi_reporter_path }}/venv"
+    virtualenv_command: python3 -m venv
+  register: home_ops_rpi_reporter_pip
+  when: home_ops_rpi_reporter_enabled | bool
+
+- name: Check RPi reporter config
+  ansible.builtin.stat:
+    path: "{{ home_ops_rpi_reporter_path }}/config.ini"
+  register: home_ops_rpi_reporter_config_stat
+  when: home_ops_rpi_reporter_enabled | bool
+
+- name: Decide whether to render RPi reporter config
+  ansible.builtin.set_fact:
+    home_ops_rpi_reporter_render_config: >-
+      {{ home_ops_rpi_reporter_manage_config | bool
+      or not home_ops_rpi_reporter_config_stat.stat.exists }}
+  when: home_ops_rpi_reporter_enabled | bool
+
+- name: Validate RPi reporter MQTT secret inputs
+  ansible.builtin.assert:
+    that:
+      - home_ops_rpi_reporter_mqtt_hostname | length > 0
+      - home_ops_rpi_reporter_mqtt_username | length > 0
+      - home_ops_rpi_reporter_mqtt_password | length > 0
+    fail_msg: >-
+      Missing RPi reporter MQTT settings. Preserve an existing config.ini or
+      provide HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME,
+      HOME_OPS_RPI_REPORTER_MQTT_USERNAME, and
+      HOME_OPS_RPI_REPORTER_MQTT_PASSWORD.
+  when:
+    - home_ops_rpi_reporter_enabled | bool
+    - home_ops_rpi_reporter_render_config | bool
+
+- name: Render RPi reporter config when missing or managed
+  ansible.builtin.template:
+    src: rpi-reporter-config.ini.j2
+    dest: "{{ home_ops_rpi_reporter_path }}/config.ini"
+    owner: root
+    group: "{{ home_ops_rpi_reporter_daemon_group }}"
+    mode: "0640"
+  register: home_ops_rpi_reporter_config
+  no_log: true
+  when:
+    - home_ops_rpi_reporter_enabled | bool
+    - home_ops_rpi_reporter_render_config | bool
+
+- name: Install RPi reporter systemd unit
+  ansible.builtin.template:
+    src: isp-rpi-reporter.service.j2
+    dest: "{{ systemd_dir }}/{{ home_ops_rpi_reporter_service_name }}.service"
+    owner: root
+    group: root
+    mode: "0644"
+  register: home_ops_rpi_reporter_unit
+  when: home_ops_rpi_reporter_enabled | bool
+
+- name: Decide whether to restart RPi reporter
+  ansible.builtin.set_fact:
+    home_ops_rpi_reporter_restart_needed: >-
+      {{ home_ops_rpi_reporter_clone.changed | default(false)
+      or home_ops_rpi_reporter_retain_patch.changed | default(false)
+      or home_ops_rpi_reporter_venv.changed | default(false)
+      or home_ops_rpi_reporter_pip.changed | default(false)
+      or home_ops_rpi_reporter_config.changed | default(false)
+      or home_ops_rpi_reporter_unit.changed | default(false) }}
+  when: home_ops_rpi_reporter_enabled | bool
+
+- name: Enable and start RPi reporter
+  ansible.builtin.systemd:
+    name: "{{ home_ops_rpi_reporter_service_name }}.service"
+    enabled: true
+    daemon_reload: "{{ home_ops_rpi_reporter_unit.changed | default(false) }}"
+    state: >-
+      {{ 'restarted'
+      if (home_ops_rpi_reporter_restart_needed | bool
+      and home_ops_rpi_reporter_restart_on_change | bool)
+      else 'started' }}
+  when: home_ops_rpi_reporter_enabled | bool

--- a/hack/bootstrap/ansible/home-ops/templates/isp-rpi-reporter.service.j2
+++ b/hack/bootstrap/ansible/home-ops/templates/isp-rpi-reporter.service.j2
@@ -1,0 +1,20 @@
+[Unit]
+Description=RPi Reporter MQTT Client/Daemon
+After=network.target mosquitto.service network-online.target
+Wants=network-online.target
+Requires=network.target
+
+[Service]
+Type=notify
+User={{ home_ops_rpi_reporter_daemon_user }}
+Group={{ home_ops_rpi_reporter_daemon_group }}
+WorkingDirectory={{ home_ops_rpi_reporter_path }}/
+ExecStart={{ home_ops_rpi_reporter_path }}/venv/bin/python3 -u {{ home_ops_rpi_reporter_path }}/ISP-RPi-mqtt-daemon.py
+StandardOutput=null
+StandardError=journal
+Environment=PYTHONUNBUFFERED=1
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/hack/bootstrap/ansible/home-ops/templates/nut.conf.j2
+++ b/hack/bootstrap/ansible/home-ops/templates/nut.conf.j2
@@ -1,0 +1,1 @@
+MODE={{ home_ops_nut_mode }}

--- a/hack/bootstrap/ansible/home-ops/templates/rpi-reporter-config.ini.j2
+++ b/hack/bootstrap/ansible/home-ops/templates/rpi-reporter-config.ini.j2
@@ -1,0 +1,22 @@
+[Daemon]
+enabled = {{ home_ops_rpi_reporter_daemon_enabled | bool | lower }}
+fallback_domain = {{ home_ops_rpi_reporter_fallback_domain }}
+interval_in_minutes = {{ home_ops_rpi_reporter_interval_in_minutes }}
+
+[MQTT]
+base_topic = {{ home_ops_rpi_reporter_mqtt_base_topic }}
+discovery_prefix = {{ home_ops_rpi_reporter_mqtt_discovery_prefix }}
+hostname = {{ home_ops_rpi_reporter_mqtt_hostname }}
+keepalive = {{ home_ops_rpi_reporter_mqtt_keepalive }}
+password = {{ home_ops_rpi_reporter_mqtt_password }}
+port = {{ home_ops_rpi_reporter_mqtt_port }}
+sensor_name = {{ home_ops_rpi_reporter_mqtt_sensor_name }}
+tls = {{ home_ops_rpi_reporter_mqtt_tls | bool | lower }}
+username = {{ home_ops_rpi_reporter_mqtt_username }}
+{% if home_ops_rpi_reporter_commands | length > 0 %}
+
+[Commands]
+{% for key, value in home_ops_rpi_reporter_commands.items() %}
+{{ key }} = {{ value }}
+{% endfor %}
+{% endif %}

--- a/hack/bootstrap/ansible/home-ops/templates/upsmon.conf.j2
+++ b/hack/bootstrap/ansible/home-ops/templates/upsmon.conf.j2
@@ -1,0 +1,11 @@
+MONITOR {{ home_ops_nut_monitor_system }} {{ home_ops_nut_monitor_power_value }} {{ home_ops_nut_monitor_user }} {{ home_ops_nut_monitor_password }} {{ home_ops_nut_monitor_type }}
+MINSUPPLIES {{ home_ops_nut_minsupplies }}
+SHUTDOWNCMD "{{ home_ops_nut_shutdowncmd }}"
+POLLFREQ {{ home_ops_nut_pollfreq }}
+POLLFREQALERT {{ home_ops_nut_pollfreqalert }}
+HOSTSYNC {{ home_ops_nut_hostsync }}
+DEADTIME {{ home_ops_nut_deadtime }}
+POWERDOWNFLAG {{ home_ops_nut_powerdownflag }}
+RBWARNTIME {{ home_ops_nut_rbwarntime }}
+NOCOMMWARNTIME {{ home_ops_nut_nocommwarntime }}
+FINALDELAY {{ home_ops_nut_finaldelay }}

--- a/hack/bootstrap/ansible/home-ops/vars/defaults.yml
+++ b/hack/bootstrap/ansible/home-ops/vars/defaults.yml
@@ -68,3 +68,49 @@ home_ops_node_taints: []
 cilium_iface: auto
 cilium_export_pod_cidr: "false"
 cilium_extra_values_files: []
+
+home_ops_rpi_reporter_enabled: false
+home_ops_rpi_reporter_repo: https://github.com/ironsheep/RPi-Reporter-MQTT2HA-Daemon.git
+home_ops_rpi_reporter_version: 4951bc918c4d889467c3386794d9e0730add4ed6
+home_ops_rpi_reporter_path: /opt/RPi-Reporter-MQTT2HA-Daemon
+home_ops_rpi_reporter_service_name: isp-rpi-reporter
+home_ops_rpi_reporter_daemon_user: daemon
+home_ops_rpi_reporter_daemon_group: daemon
+home_ops_rpi_reporter_update_existing: false
+home_ops_rpi_reporter_apply_retain_patch: true
+home_ops_rpi_reporter_manage_config: false
+home_ops_rpi_reporter_restart_on_change: false
+home_ops_rpi_reporter_daemon_enabled: true
+home_ops_rpi_reporter_interval_in_minutes: 5
+home_ops_rpi_reporter_fallback_domain: local
+home_ops_rpi_reporter_mqtt_base_topic: homeassistant
+home_ops_rpi_reporter_mqtt_discovery_prefix: homeassistant
+home_ops_rpi_reporter_mqtt_hostname: "{{ lookup('ansible.builtin.env', 'HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME') }}"
+home_ops_rpi_reporter_mqtt_keepalive: 60
+home_ops_rpi_reporter_mqtt_password: "{{ lookup('ansible.builtin.env', 'HOME_OPS_RPI_REPORTER_MQTT_PASSWORD') }}"
+home_ops_rpi_reporter_mqtt_port: 1883
+home_ops_rpi_reporter_mqtt_sensor_name: "{{ inventory_hostname }}"
+home_ops_rpi_reporter_mqtt_tls: false
+home_ops_rpi_reporter_mqtt_username: "{{ lookup('ansible.builtin.env', 'HOME_OPS_RPI_REPORTER_MQTT_USERNAME') }}"
+home_ops_rpi_reporter_commands: {}
+
+home_ops_nut_client_enabled: false
+home_ops_nut_client_manage_config: false
+home_ops_nut_client_restart_on_change: false
+home_ops_nut_client_service_name: nut-monitor
+home_ops_nut_mode: netclient
+home_ops_nut_monitor_system: "{{ lookup('ansible.builtin.env', 'HOME_OPS_NUT_MONITOR_SYSTEM') }}"
+home_ops_nut_monitor_user: "{{ lookup('ansible.builtin.env', 'HOME_OPS_NUT_MONITOR_USER') }}"
+home_ops_nut_monitor_password: "{{ lookup('ansible.builtin.env', 'HOME_OPS_NUT_MONITOR_PASSWORD') }}"
+home_ops_nut_monitor_power_value: 1
+home_ops_nut_monitor_type: slave
+home_ops_nut_deadtime: 15
+home_ops_nut_finaldelay: 5
+home_ops_nut_hostsync: 15
+home_ops_nut_minsupplies: 1
+home_ops_nut_nocommwarntime: 300
+home_ops_nut_pollfreq: 5
+home_ops_nut_pollfreqalert: 5
+home_ops_nut_powerdownflag: /etc/killpower
+home_ops_nut_rbwarntime: 43200
+home_ops_nut_shutdowncmd: /sbin/shutdown -h +0

--- a/hack/bootstrap/ansible/home-ops/worker-join.yml
+++ b/hack/bootstrap/ansible/home-ops/worker-join.yml
@@ -24,3 +24,6 @@
 
     - name: Join K3s agent with temporary taint
       ansible.builtin.import_tasks: tasks/join-agents.yml
+
+    - name: Apply RPi reporter host service
+      ansible.builtin.import_tasks: tasks/rpi-reporter.yml

--- a/hack/bootstrap/ansible/host-services.sh
+++ b/hack/bootstrap/ansible/host-services.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=hack/bootstrap/ansible/lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: hack/bootstrap/ansible/host-services.sh [options] NODE
+
+Converge only home-ops host services on one live inventory node. This path does
+not join, drain, reboot, or run Kubernetes bootstrap phases.
+
+Options:
+  --inventory-source DIR  Source inventory directory.
+  --inventory-dir DIR     Existing/generated inventory directory.
+  --skip-render           Use --inventory-dir as-is.
+  --yes                   Skip confirmation prompt.
+  -h, --help              Show help.
+EOF
+}
+
+source_dir="$BOOTSTRAP_ANSIBLE_LIVE_INVENTORY_DIR"
+inventory_dir=""
+skip_render=false
+yes=false
+node_name=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --inventory-source)
+      source_dir="$2"
+      shift 2
+      ;;
+    --inventory-dir)
+      inventory_dir="$2"
+      shift 2
+      ;;
+    --skip-render)
+      skip_render=true
+      shift
+      ;;
+    --yes)
+      yes=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      ansible_die "unknown argument: $1"
+      ;;
+    *)
+      if [[ -n "$node_name" ]]; then
+        ansible_die "unexpected extra argument: $1"
+      fi
+      node_name="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$node_name" ]] || ansible_die "NODE is required"
+
+BOOTSTRAP_ANSIBLE_BACKEND=home-ops
+export BOOTSTRAP_ANSIBLE_BACKEND
+ansible_set_profile live
+
+inventory_dir="${inventory_dir:-$(ansible_inventory_dir live)}"
+inventory_file="${inventory_dir}/hosts.yml"
+
+ansible_require_tool yq
+ansible_require_tool jq
+ansible_require_tool ansible-playbook
+
+if ! ansible_bool "$skip_render"; then
+  ansible_render_inventory live "$source_dir" "$inventory_dir"
+fi
+
+in_master="$(
+  NODE_NAME="$node_name" yq -r \
+    '.all.children.k3s_cluster.children.master.hosts | has(strenv(NODE_NAME))' \
+    "$inventory_file"
+)"
+in_node="$(
+  NODE_NAME="$node_name" yq -r \
+    '.all.children.k3s_cluster.children.node.hosts | has(strenv(NODE_NAME))' \
+    "$inventory_file"
+)"
+
+case "${in_master}:${in_node}" in
+  true:false)
+    node_role=master
+    ;;
+  false:true)
+    node_role=node
+    ;;
+  false:false)
+    node_role=absent
+    ;;
+  true:true)
+    node_role=conflict
+    ;;
+  *)
+    node_role=unknown
+    ;;
+esac
+
+case "$node_role" in
+  master|node)
+    ;;
+  absent)
+    ansible_die "node is not present in live inventory: ${node_name}"
+    ;;
+  conflict)
+    ansible_die "node is present in multiple live inventory groups: ${node_name}"
+    ;;
+  *)
+    ansible_die "could not resolve inventory role for node: ${node_name}"
+    ;;
+esac
+
+ansible_require_host_service_env "$node_role"
+
+if ! ansible_bool "$yes"; then
+  ansible_log "host-services target: ${node_name} (${node_role})"
+  printf 'Type "converge host services on %s" to continue: ' "$node_name" >&2
+  read -r answer
+  [[ "$answer" == "converge host services on ${node_name}" ]] ||
+    ansible_die "confirmation failed"
+fi
+
+ansible_log "converging host services on ${node_name}"
+ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook \
+  -i "$inventory_file" \
+  "${ANSIBLE_BOOTSTRAP_DIR}/home-ops/host-services.yml" \
+  --limit "$node_name"

--- a/hack/bootstrap/ansible/inventory/live/group_vars/all.yml
+++ b/hack/bootstrap/ansible/inventory/live/group_vars/all.yml
@@ -14,6 +14,9 @@ kube_vip_arp: true
 kube_vip_bgp: false
 k3s_master_taint: false
 
+home_ops_rpi_reporter_enabled: true
+home_ops_nut_client_enabled: true
+
 k3s_node_ip: "{{ ansible_facts[cilium_iface]['ipv4']['address'] }}"
 extra_args: >-
   --node-ip={{ k3s_node_ip }}

--- a/hack/bootstrap/ansible/lib.sh
+++ b/hack/bootstrap/ansible/lib.sh
@@ -17,6 +17,9 @@ BOOTSTRAP_ANSIBLE_LIVE_INVENTORY_DIR="${BOOTSTRAP_ANSIBLE_LIVE_INVENTORY_DIR:-${
 BOOTSTRAP_ANSIBLE_OP_VAULT="${BOOTSTRAP_ANSIBLE_OP_VAULT:-Kubernetes}"
 BOOTSTRAP_ANSIBLE_OP_ITEM="${BOOTSTRAP_ANSIBLE_OP_ITEM:-k3s-bootstrap}"
 BOOTSTRAP_ANSIBLE_OP_FIELD="${BOOTSTRAP_ANSIBLE_OP_FIELD:-k3s_token}"
+BOOTSTRAP_ANSIBLE_OP_ACCOUNT="${BOOTSTRAP_ANSIBLE_OP_ACCOUNT:-${BOOTSTRAP_OP_ACCOUNT:-}}"
+BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_VAULT="${BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_VAULT:-Kubernetes}"
+BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_ITEM="${BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_ITEM:-host-services}"
 BOOTSTRAP_ANSIBLE_KUBECONTEXT="${BOOTSTRAP_ANSIBLE_KUBECONTEXT:-default}"
 BOOTSTRAP_ANSIBLE_USER_KUBECONFIG="${BOOTSTRAP_ANSIBLE_USER_KUBECONFIG:-${HOME}/.kube/config}"
 
@@ -26,8 +29,12 @@ source "${ANSIBLE_BOOTSTRAP_DIR}/lib/common.sh"
 source "${ANSIBLE_BOOTSTRAP_DIR}/lib/paths.sh"
 # shellcheck source=hack/bootstrap/ansible/lib/inventory.sh
 source "${ANSIBLE_BOOTSTRAP_DIR}/lib/inventory.sh"
+# shellcheck source=hack/bootstrap/ansible/lib/op.sh
+source "${ANSIBLE_BOOTSTRAP_DIR}/lib/op.sh"
 # shellcheck source=hack/bootstrap/ansible/lib/token.sh
 source "${ANSIBLE_BOOTSTRAP_DIR}/lib/token.sh"
+# shellcheck source=hack/bootstrap/ansible/lib/host-services.sh
+source "${ANSIBLE_BOOTSTRAP_DIR}/lib/host-services.sh"
 # shellcheck source=hack/bootstrap/ansible/lib/kubeconfig.sh
 source "${ANSIBLE_BOOTSTRAP_DIR}/lib/kubeconfig.sh"
 # shellcheck source=hack/bootstrap/ansible/lib/playbooks.sh

--- a/hack/bootstrap/ansible/lib/host-services.sh
+++ b/hack/bootstrap/ansible/lib/host-services.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+ansible_host_service_secret_ref() {
+  local field="$1"
+  printf 'op://%s/%s/%s\n' \
+    "$BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_VAULT" \
+    "$BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_ITEM" \
+    "$field"
+}
+
+ansible_host_service_secret_vars() {
+  local role="$1"
+  case "$role" in
+    node)
+      cat <<'EOF'
+HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME
+HOME_OPS_RPI_REPORTER_MQTT_USERNAME
+HOME_OPS_RPI_REPORTER_MQTT_PASSWORD
+EOF
+      ;;
+    master|all)
+      cat <<'EOF'
+HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME
+HOME_OPS_RPI_REPORTER_MQTT_USERNAME
+HOME_OPS_RPI_REPORTER_MQTT_PASSWORD
+HOME_OPS_NUT_MONITOR_SYSTEM
+HOME_OPS_NUT_MONITOR_USER
+HOME_OPS_NUT_MONITOR_PASSWORD
+EOF
+      ;;
+    *)
+      ansible_die "unknown host service secret role: ${role}"
+      ;;
+  esac
+}
+
+ansible_load_host_service_secrets_from_op() {
+  local var value ref needs_op=false
+
+  while IFS= read -r var; do
+    [[ -n "$var" ]] || continue
+    if [[ -z "${!var:-}" ]]; then
+      needs_op=true
+      break
+    fi
+  done < <(ansible_host_service_secret_vars all)
+
+  ansible_bool "$needs_op" || return
+
+  command -v op >/dev/null 2>&1 || return 0
+  ansible_op_signin_if_needed
+
+  while IFS= read -r var; do
+    [[ -n "$var" ]] || continue
+    [[ -z "${!var:-}" ]] || continue
+
+    ref="$(ansible_host_service_secret_ref "$var")"
+    value="$(ansible_op_read_optional "$ref" || true)"
+    [[ -n "$value" ]] || continue
+    export "${var}=${value}"
+  done < <(ansible_host_service_secret_vars all)
+}
+
+ansible_require_host_service_env() {
+  local role="$1"
+  local var missing=()
+
+  ansible_load_host_service_secrets_from_op
+
+  while IFS= read -r var; do
+    [[ -n "$var" ]] || continue
+    if [[ -z "${!var:-}" ]]; then
+      missing+=("$var")
+    fi
+  done < <(ansible_host_service_secret_vars "$role")
+
+  if ((${#missing[@]} > 0)); then
+    {
+      printf 'ERROR: missing host service secret environment values for %s:\n' "$role"
+      printf '  - %s\n' "${missing[@]}"
+      printf 'Create fields with these exact names in %s, or export them before running Ansible.\n' \
+        "op://${BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_VAULT}/${BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_ITEM}"
+    } >&2
+    exit 1
+  fi
+}

--- a/hack/bootstrap/ansible/lib/op.sh
+++ b/hack/bootstrap/ansible/lib/op.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+ansible_op_signin_if_needed() {
+  local op_args=()
+  if [[ -n "$BOOTSTRAP_ANSIBLE_OP_ACCOUNT" ]]; then
+    op_args=(--account "$BOOTSTRAP_ANSIBLE_OP_ACCOUNT")
+  fi
+
+  op whoami "${op_args[@]}" >/dev/null 2>&1 && return
+
+  local signin_tty="${BOOTSTRAP_ANSIBLE_OP_SIGNIN_TTY:-/dev/tty}"
+  [[ -r "$signin_tty" && -w "$signin_tty" ]] ||
+    ansible_die "1Password CLI is not signed in and no controlling terminal is available; run 'eval \"\$(op signin)\"' first"
+
+  ansible_log "1Password CLI is not signed in; starting interactive op signin" >&2
+  local signin
+  signin="$(op signin --force "${op_args[@]}" <"$signin_tty")" || ansible_die "op signin failed"
+  # op signin writes shell exports to stdout. Evaluate them without logging.
+  eval "$signin"
+}
+
+ansible_op_read_optional() {
+  local ref="$1"
+  local op_args=()
+  if [[ -n "$BOOTSTRAP_ANSIBLE_OP_ACCOUNT" ]]; then
+    op_args=(--account "$BOOTSTRAP_ANSIBLE_OP_ACCOUNT")
+  fi
+
+  command -v op >/dev/null 2>&1 || return 1
+  ansible_op_signin_if_needed
+  op read -n "${op_args[@]}" "$ref" 2>/dev/null
+}
+
+ansible_op_read_required() {
+  local ref="$1"
+  local op_args=()
+  if [[ -n "$BOOTSTRAP_ANSIBLE_OP_ACCOUNT" ]]; then
+    op_args=(--account "$BOOTSTRAP_ANSIBLE_OP_ACCOUNT")
+  fi
+
+  command -v op >/dev/null 2>&1 || ansible_die "required tool not found: op"
+  ansible_op_signin_if_needed
+  op read -n "${op_args[@]}" "$ref"
+}

--- a/hack/bootstrap/ansible/lib/token.sh
+++ b/hack/bootstrap/ansible/lib/token.sh
@@ -54,7 +54,7 @@ ansible_read_remote_token_if_exists() {
 }
 
 ansible_read_token_from_op() {
-  op read -n "$(ansible_token_ref)" 2>/dev/null
+  ansible_op_read_optional "$(ansible_token_ref)"
 }
 
 ansible_new_token_item_json() {

--- a/hack/bootstrap/ansible/node-control-plane.sh
+++ b/hack/bootstrap/ansible/node-control-plane.sh
@@ -109,6 +109,9 @@ case "$profile" in
     ansible_require_tool ssh
     K3S_TOKEN="$(ansible_prepare_live_token "$inventory_dir")"
     export K3S_TOKEN
+    if [[ "$action" == join ]]; then
+      ansible_require_host_service_env master
+    fi
     ;;
   lima)
     inventory_dir="${inventory_dir:-${BOOTSTRAP_DIR}/.out/lima-${LIMA_CLUSTER_NAME:-home-ops-k3s-test}/inventory}"

--- a/hack/bootstrap/ansible/node-worker.sh
+++ b/hack/bootstrap/ansible/node-worker.sh
@@ -103,6 +103,9 @@ case "$profile" in
     ansible_require_tool ssh
     K3S_TOKEN="$(ansible_prepare_live_token "$inventory_dir")"
     export K3S_TOKEN
+    if [[ "$action" == join ]]; then
+      ansible_require_host_service_env node
+    fi
     ;;
   lima)
     inventory_dir="${inventory_dir:-${BOOTSTRAP_DIR}/.out/lima-${LIMA_CLUSTER_NAME:-home-ops-k3s-test}/inventory}"

--- a/hack/bootstrap/ansible/run.sh
+++ b/hack/bootstrap/ansible/run.sh
@@ -141,6 +141,9 @@ if [[ "$profile" == live ]]; then
   ansible_require_tool op
   ansible_require_tool openssl
   ansible_require_tool ssh
+  if ! ansible_bool "$skip_site" && [[ "$BOOTSTRAP_ANSIBLE_BACKEND" == home-ops ]]; then
+    ansible_require_host_service_env all
+  fi
   ansible_confirm_live_run "$yes" "$inventory_dir" "$kube_bootstrap"
   K3S_TOKEN="$(ansible_prepare_live_token "$inventory_dir")"
   export K3S_TOKEN

--- a/hack/bootstrap/nodes/cmd.sh
+++ b/hack/bootstrap/nodes/cmd.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=hack/bootstrap/nodes/lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: hack/bootstrap/nodes/cmd.sh [options] NODE -- COMMAND [ARG...]
+
+Run one SSH command against a node from inventory. The helper does not add sudo
+or mutate Kubernetes state by itself.
+
+Options:
+  --profile NAME  Inventory profile: live or lima. Defaults to live.
+  -h, --help      Show help.
+EOF
+}
+
+profile="live"
+input_node=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      profile="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    --*)
+      node_die "unknown argument: $1"
+      ;;
+    *)
+      if [[ -n "$input_node" ]]; then
+        node_die "use -- before the remote command"
+      fi
+      input_node="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$input_node" ]] || node_die "NODE is required"
+[[ $# -gt 0 ]] || node_die "remote command is required after --"
+
+node_validate_profile "$profile"
+node_require_tool "$NODE_YQ_BIN"
+node_require_tool ssh
+node_inventory_exists "$profile" || node_die "missing inventory: $(node_inventory_file "$profile")"
+
+IFS=$'\t' read -r inventory_node inventory_role < <(
+  node_resolve_inventory_node "$profile" "$input_node"
+)
+
+case "$inventory_role" in
+  master|node)
+    ;;
+  absent)
+    node_die "node is not present in ${profile} inventory: ${input_node}"
+    ;;
+  conflict)
+    node_die "node is present in multiple ${profile} inventory groups: ${input_node}"
+    ;;
+  *)
+    node_die "could not resolve inventory role for node: ${input_node}"
+    ;;
+esac
+
+if [[ "$profile" == lima ]]; then
+  lima_ssh_config="${HOME}/.lima/${inventory_node}/ssh.config"
+  [[ -f "$lima_ssh_config" ]] ||
+    node_die "missing Lima ssh config for ${inventory_node}: ${lima_ssh_config}"
+  exec ssh -F "$lima_ssh_config" "lima-${inventory_node}" "$@"
+fi
+
+target="$(node_inventory_value "$profile" "$inventory_node" ansible_host 2>/dev/null || true)"
+if [[ -z "$target" || "$target" == "null" ]]; then
+  target="$inventory_node"
+fi
+
+user="$(node_effective_ansible_user "$profile" "$inventory_node")"
+[[ -n "$user" ]] || node_die "could not resolve ansible_user for ${inventory_node}"
+
+ssh_key="$(node_effective_ssh_key "$profile" "$inventory_node")"
+ssh_args=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+if [[ -n "$ssh_key" ]]; then
+  ssh_args+=(-i "$ssh_key")
+fi
+
+exec ssh "${ssh_args[@]}" "${user}@${target}" "$@"

--- a/hack/bootstrap/tests/bats/offline-ansible.bats
+++ b/hack/bootstrap/tests/bats/offline-ansible.bats
@@ -73,6 +73,11 @@ render_home_ops_inventory() {
   [[ "$(yq -r '.cluster_cidr' "$home_ops_vars")" == "10.52.0.0/16" ]]
   [[ "$(yq -r '.k3s_token' "$home_ops_vars")" == "{{ lookup('ansible.builtin.env', 'K3S_TOKEN') }}" ]]
   [[ "$(yq -r '.home_ops_etcdctl_version_override' "$home_ops_vars")" == "" ]]
+  [[ "$(yq -r '.home_ops_rpi_reporter_enabled' "$home_ops_vars")" == "true" ]]
+  [[ "$(yq -r '.home_ops_nut_client_enabled' "$home_ops_vars")" == "true" ]]
+  [[ "$(yq -r '.home_ops_rpi_reporter_update_existing' "$home_ops_vars")" == "false" ]]
+  [[ "$(yq -r '.home_ops_rpi_reporter_restart_on_change' "$home_ops_vars")" == "false" ]]
+  [[ "$(yq -r '.home_ops_nut_client_restart_on_change' "$home_ops_vars")" == "false" ]]
   assert_file_not_contains "$home_ops_vars" 'sample-token'
 
   local raw_kubeconfig default_lima_inventory default_backend
@@ -100,6 +105,7 @@ render_home_ops_inventory() {
   local playbook
   for playbook in \
     "${ROOT}/hack/bootstrap/ansible/home-ops/site.yml" \
+    "${ROOT}/hack/bootstrap/ansible/home-ops/host-services.yml" \
     "${ROOT}/hack/bootstrap/ansible/home-ops/control-plane-join.yml" \
     "${ROOT}/hack/bootstrap/ansible/home-ops/control-plane-finalize.yml" \
     "${ROOT}/hack/bootstrap/ansible/home-ops/worker-join.yml" \
@@ -167,9 +173,18 @@ EOF
 
 @test "static Ansible lifecycle invariants are present" {
   assert_file_contains "$ROOT/hack/bootstrap/ansible/lib.sh" "source \"\${ANSIBLE_BOOTSTRAP_DIR}/lib/inventory.sh\""
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib.sh" "source \"\${ANSIBLE_BOOTSTRAP_DIR}/lib/op.sh\""
   assert_file_contains "$ROOT/hack/bootstrap/ansible/lib.sh" "source \"\${ANSIBLE_BOOTSTRAP_DIR}/lib/token.sh\""
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib.sh" "source \"\${ANSIBLE_BOOTSTRAP_DIR}/lib/host-services.sh\""
   assert_file_contains "$ROOT/hack/bootstrap/ansible/lib.sh" "source \"\${ANSIBLE_BOOTSTRAP_DIR}/lib/playbooks.sh\""
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib/op.sh" 'op signin --force'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib/op.sh" 'BOOTSTRAP_ANSIBLE_OP_SIGNIN_TTY:-/dev/tty'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib/token.sh" 'ansible_op_read_optional'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/run.sh" 'ansible_disable_kube_proxy_after_cilium'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/run.sh" 'ansible_require_host_service_env all'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/node-worker.sh" 'ansible_require_host_service_env node'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/node-control-plane.sh" 'ansible_require_host_service_env master'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/host-services.sh" "ansible_require_host_service_env \"\$node_role\""
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/etcdctl.yml" 'api.github.com/repos/k3s-io/k3s/releases/tags'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/etcdctl.yml" 'home_ops_embedded_etcd_version'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/etcdctl.yml" 'home_ops_etcdctl_version_effective'
@@ -184,6 +199,123 @@ EOF
   assert_file_contains "$ROOT/hack/bootstrap/ansible/playbooks/disable-kube-proxy.yml" '../home-ops/tasks/kube-proxy-disable.yml'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/join-servers.yml" 'home_ops_kube_proxy_config.changed'
   assert_file_contains "$ROOT/hack/bootstrap/nodes/control-plane-join.sh" 'node_assert_kube_proxy_disable_dropin'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/host-services.sh" 'home-ops/host-services.yml'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/rpi-reporter.yml" 'home_ops_rpi_reporter_update_existing'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/rpi-reporter.yml" 'fresh pinned clone'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/rpi-reporter.yml" 'no_log: true'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/nut-client.yml" 'nut-client'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/nut-client.yml" 'no_log: true'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/control-plane-join.yml" 'tasks/nut-client.yml'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/worker-join.yml" 'tasks/rpi-reporter.yml'
+}
+
+@test "host service secret helper loads missing values from 1Password fields" {
+  local fake_op
+  fake_op="${tmp}/op"
+  cat > "$fake_op" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == whoami ]]; then
+  exit 0
+fi
+[[ "$1" == read && "$2" == -n ]] || exit 2
+case "$3" in
+  op://Kubernetes/host-services/HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME)
+    printf 'mqtt.example.invalid'
+    ;;
+  op://Kubernetes/host-services/HOME_OPS_RPI_REPORTER_MQTT_USERNAME)
+    printf 'reporter-user'
+    ;;
+  op://Kubernetes/host-services/HOME_OPS_RPI_REPORTER_MQTT_PASSWORD)
+    printf 'reporter-secret'
+    ;;
+  op://Kubernetes/host-services/HOME_OPS_NUT_MONITOR_SYSTEM)
+    printf 'ups@example.invalid'
+    ;;
+  op://Kubernetes/host-services/HOME_OPS_NUT_MONITOR_USER)
+    printf 'nut-user'
+    ;;
+  op://Kubernetes/host-services/HOME_OPS_NUT_MONITOR_PASSWORD)
+    printf 'nut-secret'
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+  chmod +x "$fake_op"
+
+  run env PATH="${tmp}:/usr/bin:/bin" \
+    bash -c "source '${ROOT}/hack/bootstrap/ansible/lib.sh'; ansible_require_host_service_env master; printf '%s:%s\n' \"\$HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME\" \"\$HOME_OPS_NUT_MONITOR_SYSTEM\""
+  assert_success
+  [[ "$output" == "mqtt.example.invalid:ups@example.invalid" ]]
+  assert_output_not_contains 'reporter-secret'
+  assert_output_not_contains 'nut-secret'
+}
+
+@test "host service secret helper signs in once in the parent shell before reading fields" {
+  local fake_op calls
+  fake_op="${tmp}/op"
+  calls="${tmp}/op-calls"
+  cat > "$fake_op" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$1" >>"$OP_CALLS"
+case "$1" in
+  whoami)
+    [[ "${OP_SESSION_FAKE:-}" == "1" ]]
+    ;;
+  signin)
+    printf 'export OP_SESSION_FAKE=1\n'
+    ;;
+  read)
+    [[ "${OP_SESSION_FAKE:-}" == "1" ]] || exit 1
+    [[ "$2" == -n ]] || exit 2
+    case "$3" in
+      op://Kubernetes/host-services/HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME)
+        printf 'mqtt.example.invalid'
+        ;;
+      op://Kubernetes/host-services/HOME_OPS_RPI_REPORTER_MQTT_USERNAME)
+        printf 'reporter-user'
+        ;;
+      op://Kubernetes/host-services/HOME_OPS_RPI_REPORTER_MQTT_PASSWORD)
+        printf 'reporter-secret'
+        ;;
+      op://Kubernetes/host-services/HOME_OPS_NUT_MONITOR_SYSTEM)
+        printf 'ups@example.invalid'
+        ;;
+      op://Kubernetes/host-services/HOME_OPS_NUT_MONITOR_USER)
+        printf 'nut-user'
+        ;;
+      op://Kubernetes/host-services/HOME_OPS_NUT_MONITOR_PASSWORD)
+        printf 'nut-secret'
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+EOF
+  chmod +x "$fake_op"
+
+  run env PATH="${tmp}:/usr/bin:/bin" OP_CALLS="$calls" BOOTSTRAP_ANSIBLE_OP_SIGNIN_TTY=/dev/null \
+    bash -c "source '${ROOT}/hack/bootstrap/ansible/lib.sh'; ansible_require_host_service_env master; printf '%s:%s\n' \"\$HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME\" \"\$HOME_OPS_NUT_MONITOR_SYSTEM\""
+  assert_success
+  assert_output_contains 'mqtt.example.invalid:ups@example.invalid'
+  [[ "$(grep -c '^signin$' "$calls")" == "1" ]]
+  assert_output_not_contains 'reporter-secret'
+  assert_output_not_contains 'nut-secret'
+}
+
+@test "host service secret helper fails before playbooks when values are missing" {
+  run env PATH="/usr/bin:/bin" \
+    bash -c "source '${ROOT}/hack/bootstrap/ansible/lib.sh'; ansible_require_host_service_env node"
+  assert_failure
+  assert_output_contains 'missing host service secret environment values for node'
+  assert_output_contains 'HOME_OPS_RPI_REPORTER_MQTT_PASSWORD'
+  assert_output_contains 'op://Kubernetes/host-services'
 }
 
 @test "render inventory fails on derived value conflicts" {

--- a/hack/bootstrap/tests/bats/offline-nodes.bats
+++ b/hack/bootstrap/tests/bats/offline-nodes.bats
@@ -83,6 +83,39 @@ JSON
   [[ "$output" == "invalid" ]]
 }
 
+@test "node cmd helper resolves live inventory SSH command" {
+  local fake_ssh capture
+  fake_ssh="${tmp}/ssh"
+  capture="${tmp}/ssh-args"
+  cat > "$fake_ssh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$SSH_CAPTURE"
+EOF
+  chmod +x "$fake_ssh"
+
+  run env PATH="${tmp}:${PATH}" HOME=/tmp/home SSH_CAPTURE="$capture" \
+    NODE_LIVE_INVENTORY_DIR="$inventory" \
+    "${ROOT}/hack/bootstrap/nodes/cmd.sh" \
+      --profile live k3s-worker-0 -- systemctl status isp-rpi-reporter.service
+  assert_success
+  assert_file_contains "$capture" '-o'
+  assert_file_contains "$capture" 'BatchMode=yes'
+  assert_file_contains "$capture" 'StrictHostKeyChecking=accept-new'
+  assert_file_contains "$capture" '-i'
+  assert_file_contains "$capture" '/tmp/home/ansiblekey'
+  assert_file_contains "$capture" 'ethan@192.168.99.20'
+  assert_file_contains "$capture" 'systemctl'
+  assert_file_contains "$capture" 'isp-rpi-reporter.service'
+}
+
+@test "node cmd helper fails closed for absent inventory node" {
+  run env NODE_LIVE_INVENTORY_DIR="$inventory" \
+    "${ROOT}/hack/bootstrap/nodes/cmd.sh" \
+      --profile live k3s-worker-9 -- true
+  assert_failure
+  assert_output_contains 'node is not present in live inventory'
+}
+
 @test "worker status command reports inventory, Kubernetes, Cilium, and Longhorn absence" {
   write_worker_status_kubectl
 

--- a/justfile
+++ b/justfile
@@ -260,6 +260,11 @@ ansible-run:
 ansible-bootstrap:
     ./hack/bootstrap/ansible/run.sh --profile live --kube-bootstrap
 
+# Converge host-level services on one live inventory node without touching Kubernetes workloads.
+[group('ansible')]
+ansible-host-services node:
+    ./hack/bootstrap/ansible/host-services.sh '{{ node }}'
+
 # Show read-only node lifecycle status for a live cluster node.
 [group('node')]
 node-status node:
@@ -276,6 +281,11 @@ node-pods node:
     #!/usr/bin/env bash
     set -euo pipefail
     kubectl --context default get pods -A --field-selector 'spec.nodeName={{ node }},status.phase!=Succeeded' -o wide
+
+# Run one SSH command against a live inventory node without implicit sudo.
+[group('node')]
+node-cmd node +command:
+    ./hack/bootstrap/nodes/cmd.sh --profile live '{{ node }}' -- {{ command }}
 
 # Show read-only control-plane quorum and embedded-etcd status for a live cluster node.
 [group('node')]
@@ -443,6 +453,11 @@ node-lima-pods node:
     #!/usr/bin/env bash
     set -euo pipefail
     kubectl --context '{{ lima_context }}' get pods -A --field-selector 'spec.nodeName={{ node }},status.phase!=Succeeded' -o wide
+
+# Run one SSH command against a Lima inventory node without implicit sudo.
+[group('node-lima')]
+node-lima-cmd node +command:
+    ./hack/bootstrap/nodes/cmd.sh --profile lima '{{ node }}' -- {{ command }}
 
 # Show read-only control-plane quorum and embedded-etcd status for a Lima cluster node.
 [group('node-lima')]


### PR DESCRIPTION
## Summary
- add a scoped Ansible host-services path for the RPi MQTT reporter and NUT client
- load host-service settings from 1Password fields before live Ansible playbooks run
- enable host services for live inventory and wire them into site/join playbooks
- add node-cmd helpers and offline regression coverage

## 1Password fields
By default, live Ansible reads host-service values from fields with these exact names under `op://Kubernetes/host-services`:
- `HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME`
- `HOME_OPS_RPI_REPORTER_MQTT_USERNAME`
- `HOME_OPS_RPI_REPORTER_MQTT_PASSWORD`
- `HOME_OPS_NUT_MONITOR_SYSTEM`
- `HOME_OPS_NUT_MONITOR_USER`
- `HOME_OPS_NUT_MONITOR_PASSWORD`

The item can be overridden with `BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_VAULT` and `BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_ITEM`.

## Validation
- `just bootstrap-test`
- targeted `pre-commit run --files ...`
- live canary: `./hack/bootstrap/ansible/host-services.sh --yes k3s-master-2`

## Canary notes
- `k3s-master-2` stayed Ready
- K3s service stayed active with `NRestarts=0` and unchanged `ActiveEnterTimestamp`
- `isp-rpi-reporter.service` and `nut-monitor.service` are active
- services are enabled/started by default, but not restarted on change unless explicitly opted in