### PR TITLE
fix: refresh envoy gateway crds

### DIFF
--- a/.github/scripts/extract_image_info.py
+++ b/.github/scripts/extract_image_info.py
@@ -25,6 +25,12 @@ FALLBACK_IMAGE_REGEX = re.compile(
     r"(?:@([A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*:[0-9A-Fa-f]{32,}))?"  # group 3: optional @digest
 )
 
+# CRD schemas and chart docs can include these as examples. They are not pullable images.
+PLACEHOLDER_IMAGE_REFERENCES = {
+    "registry/image:tag",
+    "registry/image@sha256:digest",
+}
+
 def is_valid_docker_image(image):
     """Validates whether an image reference conforms to Docker standard."""
     return bool(DOCKER_IMAGE_REGEX.fullmatch(image))
@@ -100,8 +106,52 @@ def extract_images_from_pr_diff():
     print(f"📊 Extracted {len(images)} images from PR diff.")
     return images
 
+def should_ignore_image_reference(image_tag):
+    """Returns true for known non-pullable placeholder image references."""
+    if image_tag in PLACEHOLDER_IMAGE_REFERENCES:
+        print(f"⚠️ Skipping known placeholder image reference: {image_tag}")
+        return True
+
+    return False
+
+def extract_image_from_helm_diff_line(line):
+    """Extracts a Docker image reference from an added Helm diff line."""
+    line = line.strip()
+    if not line.startswith("+ "):
+        return None
+
+    image_tag = None
+
+    match = IMAGE_KEY_REGEX.match(line)
+    if match:
+        image_tag = match.group('image_quoted') or match.group('image')
+    else:
+        match = FALLBACK_IMAGE_REGEX.search(line)
+        if match:
+            repo_image = match.group(1)
+            tag = match.group(2) or ""
+            digest = match.group(3) or ""
+
+            if not tag and not digest:
+                print(f"⚠️ Skipping potential image reference (missing tag/digest): {repo_image}")
+                return None
+
+            image_tag = f"{repo_image}@{digest}" if digest else f"{repo_image}:{tag}"
+
+    if not image_tag:
+        return None
+    if should_ignore_image_reference(image_tag):
+        return None
+
+    parsed_image = parse_docker_image(image_tag)
+    if not parsed_image:
+        print(f"❌ Invalid Docker Image Reference: {image_tag}")
+        return None
+
+    return parsed_image
+
 def extract_images_from_helm_diff():
-    """Extracts unique image updates from Helm diff.txt, prioritizing `+ image:` lines but allowing a stricter fallback match."""
+    """Extracts unique image updates from Helm diff.txt."""
     unique_images = set()  # Using a set to deduplicate images
     diff_txt_path = os.getenv("DIFF_TXT_PATH", "diff.txt")
 
@@ -118,41 +168,18 @@ def extract_images_from_helm_diff():
 
         print(f"🔎 [{i+1}/{len(diff_lines)}] Processing: {repr(line)}")
 
-        image_tag = None  # Initialize variable for image match
+        parsed_image = extract_image_from_helm_diff_line(line)
+        if not parsed_image:
+            continue
 
-        # **Primary Match: `+ image:` lines**
-        match = IMAGE_KEY_REGEX.match(line)
-        if match:
-            image_tag = match.group('image_quoted') or match.group('image')
+        image, tag, digest = parsed_image
+
+        image_entry = (image, tag, digest)
+        if image_entry not in unique_images:
+            print(f"✅ Found New Image: {image}, Tag: {tag}, Digest: {digest}")
+            unique_images.add(image_entry)
         else:
-            # **Fallback Match: Look for valid `repo/image` format with a tag or digest**
-            match = FALLBACK_IMAGE_REGEX.search(line)
-            if match:
-                repo_image = match.group(1)
-                tag = match.group(2) or ""
-                digest = match.group(3) or ""
-
-                if not tag and not digest:
-                    print(f"⚠️ Skipping potential image reference (missing tag/digest): {repo_image}")
-                    continue  # Skip matches that lack a tag/digest
-
-                image_tag = f"{repo_image}@{digest}" if digest else f"{repo_image}:{tag}"
-
-        if image_tag:
-            # Extract components
-            parsed_image = parse_docker_image(image_tag)
-            if not parsed_image:
-                print(f"❌ Invalid Docker Image Reference: {image_tag}")
-                continue
-
-            image, tag, digest = parsed_image
-
-            image_entry = (image, tag, digest)
-            if image_entry not in unique_images:
-                print(f"✅ Found New Image: {image}, Tag: {tag}, Digest: {digest}")
-                unique_images.add(image_entry)
-            else:
-                print(f"ℹ️ Skipped Duplicate Image: {image}, Tag: {tag}, Digest: {digest}")
+            print(f"ℹ️ Skipped Duplicate Image: {image}, Tag: {tag}, Digest: {digest}")
 
     print(f"📊 Extracted {len(unique_images)} unique images.")
     return list(unique_images)  # Convert set back to list before returning

--- a/.github/scripts/test_extract_image_info.py
+++ b/.github/scripts/test_extract_image_info.py
@@ -1,0 +1,84 @@
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("extract_image_info.py")
+SPEC = importlib.util.spec_from_file_location("extract_image_info", SCRIPT_PATH)
+extract_image_info = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(extract_image_info)
+
+
+def extract_line(line):
+    output = io.StringIO()
+    with redirect_stdout(output):
+        return extract_image_info.extract_image_from_helm_diff_line(line)
+
+
+class HelmDiffImageExtractionTest(unittest.TestCase):
+    def test_extracts_added_image_key_lines(self):
+        self.assertEqual(
+            extract_line("+        image: docker.io/envoyproxy/gateway:v1.8.0"),
+            ("docker.io/envoyproxy/gateway", "v1.8.0", ""),
+        )
+
+    def test_extracts_quoted_added_image_key_lines(self):
+        self.assertEqual(
+            extract_line('+        image: "ghcr.io/example/app:v1.2.3"'),
+            ("ghcr.io/example/app", "v1.2.3", ""),
+        )
+
+    def test_ignores_crd_schema_description_image_references(self):
+        self.assertIsNone(
+            extract_line(
+                "+                                URL can be in the format of `registry/image:tag` or `registry/image@sha256:digest`."
+            )
+        )
+
+    def test_extracts_non_image_key_config_values(self):
+        self.assertEqual(
+            extract_line("+        value: ghcr.io/example/app:v1.2.3"),
+            ("ghcr.io/example/app", "v1.2.3", ""),
+        )
+
+    def test_ignores_crd_schema_default_image_references(self):
+        self.assertIsNone(
+            extract_line("+                                default: registry/image:tag")
+        )
+
+    def test_helm_diff_file_extraction_ignores_crd_schema_references(self):
+        diff_text = """
++        image: docker.io/envoyproxy/gateway:v1.8.0
++                                URL can be in the format of `registry/image:tag` or `registry/image@sha256:digest`.
++                                default: registry/image:tag
+        """
+        previous_path = os.environ.get("DIFF_TXT_PATH")
+        diff_file_path = None
+        try:
+            with tempfile.NamedTemporaryFile("w", delete=False) as diff_file:
+                diff_file.write(diff_text)
+                diff_file_path = diff_file.name
+
+            os.environ["DIFF_TXT_PATH"] = diff_file_path
+            output = io.StringIO()
+            with redirect_stdout(output):
+                images = extract_image_info.extract_images_from_helm_diff()
+            self.assertEqual(
+                set(images),
+                {("docker.io/envoyproxy/gateway", "v1.8.0", "")},
+            )
+        finally:
+            if previous_path is None:
+                os.environ.pop("DIFF_TXT_PATH", None)
+            else:
+                os.environ["DIFF_TXT_PATH"] = previous_path
+            if diff_file_path:
+                Path(diff_file_path).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/bootstrap-test.yml
+++ b/.github/workflows/bootstrap-test.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Check aggregate task wiring
         run: just --dry-run check
 
+      - name: Run GitHub script tests
+        run: just github-test
+
       - name: Show runner yq
         run: yq --version
 

--- a/apps/envoy-gateway-system/kustomization.yaml
+++ b/apps/envoy-gateway-system/kustomization.yaml
@@ -15,3 +15,4 @@ helmCharts:
     releaseName: envoy-gateway
     namespace: envoy-gateway-system
     valuesFile: manifests/values.yaml
+    includeCRDs: true

--- a/hack/bootstrap/phases/bootstrap-crds.sh
+++ b/hack/bootstrap/phases/bootstrap-crds.sh
@@ -20,29 +20,32 @@ apply_crds_from_chart() {
 }
 
 gateway_crds=(
+  backends.gateway.envoyproxy.io
   httproutes.gateway.networking.k8s.io
   backendtlspolicies.gateway.networking.k8s.io
+  gatewayclasses.gateway.networking.k8s.io
+  gateways.gateway.networking.k8s.io
+  grpcroutes.gateway.networking.k8s.io
+  listenersets.gateway.networking.k8s.io
+  referencegrants.gateway.networking.k8s.io
+  tcproutes.gateway.networking.k8s.io
+  tlsroutes.gateway.networking.k8s.io
+  udproutes.gateway.networking.k8s.io
   envoyproxies.gateway.envoyproxy.io
   clienttrafficpolicies.gateway.envoyproxy.io
   backendtrafficpolicies.gateway.envoyproxy.io
+  envoyextensionpolicies.gateway.envoyproxy.io
+  envoypatchpolicies.gateway.envoyproxy.io
+  httproutefilters.gateway.envoyproxy.io
   securitypolicies.gateway.envoyproxy.io
+  xbackendtrafficpolicies.gateway.networking.x-k8s.io
+  xmeshes.gateway.networking.x-k8s.io
 )
-gateway_crds_missing=false
-for gateway_crd in "${gateway_crds[@]}"; do
-  if ! crd_exists "$gateway_crd"; then
-    gateway_crds_missing=true
-    break
-  fi
-done
 
-if [[ "$gateway_crds_missing" == true ]]; then
-  envoy_chart="$(chart_value "${REPO_ROOT}/apps/envoy-gateway-system/kustomization.yaml" gateway-helm '.name')"
-  envoy_repo="$(chart_value "${REPO_ROOT}/apps/envoy-gateway-system/kustomization.yaml" gateway-helm '.repo')"
-  envoy_version="$(chart_value "${REPO_ROOT}/apps/envoy-gateway-system/kustomization.yaml" gateway-helm '.version')"
-  apply_crds_from_chart gateway-api "$envoy_chart" "$envoy_repo" "$envoy_version" envoy-gateway-system
-else
-  log "Gateway API and Envoy Gateway CRDs already present"
-fi
+envoy_chart="$(chart_value "${REPO_ROOT}/apps/envoy-gateway-system/kustomization.yaml" gateway-helm '.name')"
+envoy_repo="$(chart_value "${REPO_ROOT}/apps/envoy-gateway-system/kustomization.yaml" gateway-helm '.repo')"
+envoy_version="$(chart_value "${REPO_ROOT}/apps/envoy-gateway-system/kustomization.yaml" gateway-helm '.version')"
+apply_crds_from_chart gateway-api "$envoy_chart" "$envoy_repo" "$envoy_version" envoy-gateway-system
 for gateway_crd in "${gateway_crds[@]}"; do
   wait_crd "$gateway_crd"
 done

--- a/hack/bootstrap/tests/bats/offline-parse.bats
+++ b/hack/bootstrap/tests/bats/offline-parse.bats
@@ -14,7 +14,19 @@ setup_file() {
   [[ "$(yq -r '.helmCharts[] | select(.name == "argo-cd") | .version' "$ROOT/apps/argocd/kustomization.yaml")" != "null" ]]
   [[ "$(yq -r '.helmCharts[] | select(.name == "external-secrets") | .version' "$ROOT/apps/external-secrets/kustomization.yaml")" != "null" ]]
   [[ "$(yq -r '.helmCharts[] | select(.name == "gateway-helm") | .version' "$ROOT/apps/envoy-gateway-system/kustomization.yaml")" != "null" ]]
+  [[ "$(yq -r '.helmCharts[] | select(.name == "gateway-helm") | .includeCRDs' "$ROOT/apps/envoy-gateway-system/kustomization.yaml")" == "true" ]]
   [[ "$(yq -r '.helmCharts[] | select(.name == "kube-prometheus-stack") | .version' "$ROOT/apps/monitoring/kustomization.yaml")" != "null" ]]
+}
+
+@test "bootstrap refreshes Envoy Gateway controller CRDs introduced by chart upgrades" {
+  assert_file_not_contains "$ROOT/hack/bootstrap/phases/bootstrap-crds.sh" 'gateway_crds_missing'
+  assert_file_contains "$ROOT/hack/bootstrap/phases/bootstrap-crds.sh" 'gatewayclasses.gateway.networking.k8s.io'
+  assert_file_contains "$ROOT/hack/bootstrap/phases/bootstrap-crds.sh" 'gateways.gateway.networking.k8s.io'
+  assert_file_contains "$ROOT/hack/bootstrap/phases/bootstrap-crds.sh" 'grpcroutes.gateway.networking.k8s.io'
+  assert_file_contains "$ROOT/hack/bootstrap/phases/bootstrap-crds.sh" 'listenersets.gateway.networking.k8s.io'
+  assert_file_contains "$ROOT/hack/bootstrap/phases/bootstrap-crds.sh" 'tcproutes.gateway.networking.k8s.io'
+  assert_file_contains "$ROOT/hack/bootstrap/phases/bootstrap-crds.sh" 'tlsroutes.gateway.networking.k8s.io'
+  assert_file_contains "$ROOT/hack/bootstrap/phases/bootstrap-crds.sh" 'udproutes.gateway.networking.k8s.io'
 }
 
 @test "lima app bootstrap removes active CNPG plugins instead of only disabling WAL archiving" {

--- a/justfile
+++ b/justfile
@@ -10,16 +10,22 @@ lima_app_env := "LIMA_AGENT_COUNT=4 LIMA_AGENT_CPUS=4 LIMA_AGENT_MEMORY_GIB=6 LI
 default:
     @just --list --unsorted
 
-# Run full local validation, including pre-commit and bootstrap script tests.
+# Run full local validation, including pre-commit, GitHub script tests, and bootstrap script tests.
 [group('core')]
 check:
     just pre-commit
+    just github-test
     just bootstrap-test
 
 # Run every pre-commit hook against the repository.
 [group('core')]
 pre-commit:
     pre-commit run --all-files
+
+# Run lightweight tests for GitHub workflow helper scripts.
+[group('core')]
+github-test:
+    python3 -B .github/scripts/test_extract_image_info.py
 
 # Show current and target cluster status without mutating anything.
 [group('cluster')]


### PR DESCRIPTION
## Summary
- include Envoy Gateway Helm chart CRDs in the rendered app
- refresh the full Gateway API and Envoy Gateway CRD bundle during bootstrap instead of relying on a stale subset check
- add offline coverage for the Gateway CRD refresh behavior

## Validation
- kustomize build --enable-helm apps/envoy-gateway-system
- server-side dry-run against lima-home-ops-k3s-test
- bats hack/bootstrap/tests/bats/offline-parse.bats
- pre-commit run --files apps/envoy-gateway-system/kustomization.yaml hack/bootstrap/phases/bootstrap-crds.sh hack/bootstrap/tests/bats/offline-parse.bats

## Live remediation
Applied the full gateway-helm 1.8.0 CRD bundle to lima-home-ops-k3s-test. Envoy Gateway recovered to 3/3 ready and ArgoCD reports envoy-gateway-system Synced/Healthy.