### PR TITLE
feat: add node reboot lifecycle command

### DIFF
--- a/docs/cluster-operations.md
+++ b/docs/cluster-operations.md
@@ -119,6 +119,7 @@ Node lifecycle:
 | List live nodes | `just node-list` |
 | Plan additive-only live node joins | `just node-converge-plan` |
 | Join missing live inventory nodes after confirmation | `just node-converge` |
+| Reboot a drained live node | `just node-reboot <node>` |
 | Join one explicit live node | `just node-join <node>` |
 | Finalize and uncordon one live node | `just node-uncordon <node>` |
 | Plan additive-only Lima node joins | `just node-lima-converge-plan` |
@@ -457,6 +458,7 @@ just node-control-plane-status k3s-master-0
 just node-control-plane-delete-preflight k3s-master-0
 just node-converge-plan
 just node-drain k3s-worker-0
+just node-reboot k3s-worker-0
 just node-longhorn-evict k3s-worker-0
 just node-delete k3s-worker-0
 just node-refresh-ssh-host-key k3s-worker-0
@@ -474,6 +476,7 @@ just node-lima-control-plane-status home-ops-k3s-test-server-1
 just node-lima-control-plane-delete-preflight home-ops-k3s-test-server-1
 just node-lima-converge-plan
 just node-lima-drain home-ops-k3s-test-server-2
+just node-lima-reboot home-ops-k3s-test-server-2
 just node-lima-longhorn-evict home-ops-k3s-test-server-2
 just node-lima-delete home-ops-k3s-test-server-2
 just node-lima-refresh-ssh-host-key home-ops-k3s-test-server-2
@@ -481,7 +484,7 @@ just node-lima-join home-ops-k3s-test-server-2
 just node-lima-uncordon home-ops-k3s-test-server-2
 ```
 
-For normal maintenance or reboots, use drain and uncordon only.
+For normal maintenance, use drain, reboot when needed, and uncordon.
 `longhorn-evict` is for node replacement.
 
 `node-converge` is additive-only convenience after inventory edits. It joins

--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -221,13 +221,14 @@ explicit.
 | Plan additive-only joins | `just node-converge-plan` | `just node-lima-converge-plan` |
 | Join missing inventory nodes | `just node-converge` | `just node-lima-converge` |
 | Drain | `just node-drain <node>` | `just node-lima-drain <node>` |
+| Reboot a drained node | `just node-reboot <node>` | `just node-lima-reboot <node>` |
 | Evict Longhorn replicas | `just node-longhorn-evict <node>` | `just node-lima-longhorn-evict <node>` |
 | Delete | `just node-delete <node>` | `just node-lima-delete <node>` |
 | Refresh SSH host key | `just node-refresh-ssh-host-key <node>` | `just node-lima-refresh-ssh-host-key <node>` |
 | Join from inventory | `just node-join <node>` | `just node-lima-join <node>` |
 | Remove joining taint and uncordon | `just node-uncordon <node>` | `just node-lima-uncordon <node>` |
 
-For maintenance or reboot work, use `drain` and `uncordon` only.
+For maintenance work, use `drain`, `reboot` when needed, and `uncordon`.
 `longhorn-evict` is for node replacement and fails before mutating Longhorn if
 remaining storage nodes cannot hold the maximum configured replica count.
 

--- a/hack/bootstrap/nodes/lib/k8s.sh
+++ b/hack/bootstrap/nodes/lib/k8s.sh
@@ -145,6 +145,10 @@ node_ready_from_node_json() {
   '
 }
 
+node_boot_id_from_node_json() {
+  "$NODE_JQ_BIN" -r '.status.nodeInfo.bootID // ""'
+}
+
 node_schedulable_from_node_json() {
   "$NODE_JQ_BIN" -r '
     if (.spec.unschedulable // false) then

--- a/hack/bootstrap/nodes/lib/wait.sh
+++ b/hack/bootstrap/nodes/lib/wait.sh
@@ -51,6 +51,31 @@ node_wait_for_ready() {
   done
 }
 
+node_wait_for_boot_id_change() {
+  local context="$1"
+  local node="$2"
+  local previous_boot_id="$3"
+  local timeout="${4:-600}"
+  local deadline=$((SECONDS + timeout))
+  local node_json ready boot_id
+
+  [[ -n "$previous_boot_id" ]] ||
+    node_die "previous bootID is required to verify reboot completion: ${node}"
+
+  while true; do
+    node_json="$(node_node_json_if_present "$context" "$node")"
+    if [[ -n "$node_json" ]]; then
+      ready="$(node_ready_from_node_json <<<"$node_json")"
+      boot_id="$(node_boot_id_from_node_json <<<"$node_json")"
+      if [[ "$ready" == Ready && -n "$boot_id" && "$boot_id" != "$previous_boot_id" ]]; then
+        return 0
+      fi
+    fi
+    ((SECONDS < deadline)) || node_die "timed out waiting for node reboot: ${node}"
+    sleep 5
+  done
+}
+
 node_wait_for_cilium_ready() {
   local context="$1"
   local node="$2"

--- a/hack/bootstrap/nodes/reboot.sh
+++ b/hack/bootstrap/nodes/reboot.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=hack/bootstrap/nodes/lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: hack/bootstrap/nodes/reboot.sh [options] NODE
+
+Options:
+  --profile NAME   Node lifecycle profile: live or lima. Defaults to live.
+  --context NAME   Kubernetes context. Defaults to the profile context.
+  --yes            Skip confirmation prompt.
+  -h, --help       Show help.
+EOF
+}
+
+profile=live
+context=""
+yes=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      profile="$2"
+      shift 2
+      ;;
+    --context)
+      context="$2"
+      shift 2
+      ;;
+    --yes)
+      yes=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      node_die "unknown argument: $1"
+      ;;
+    *)
+      if [[ -n "${node_name:-}" ]]; then
+        node_die "only one node may be provided"
+      fi
+      node_name="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "${node_name:-}" ]] || node_die "NODE is required"
+node_validate_profile "$profile"
+context="${context:-$(node_context_for_profile "$profile")}"
+
+node_require_tool "$NODE_KUBECTL_BIN"
+node_require_tool "$NODE_YQ_BIN"
+node_require_tool "$NODE_JQ_BIN"
+node_require_tool ansible
+
+IFS=$'\t' read -r inventory_node_name inventory_role < <(node_resolve_inventory_node "$profile" "$node_name")
+kubernetes_node_name="$(node_expected_kubernetes_node_name "$profile" "$inventory_node_name" "$node_name")"
+
+if [[ "$inventory_role" == master ]]; then
+  node_handoff_control_plane_api_if_needed "$profile" "$context" "$inventory_node_name" "$kubernetes_node_name"
+fi
+node_assert_api_reachable "$context"
+node_json="$(node_node_json_if_present "$context" "$kubernetes_node_name")"
+[[ -n "$node_json" ]] || node_die "Kubernetes node is absent: ${kubernetes_node_name}"
+
+case "$inventory_role" in
+  master)
+    node_assert_kubernetes_control_plane "$node_json" "$kubernetes_node_name"
+    node_log "running control-plane delete preflight before reboot"
+    "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/control-plane-delete-preflight.sh" \
+      --profile "$profile" \
+      --context "$context" \
+      "$node_name"
+    ;;
+  *)
+    node_assert_inventory_worker "$inventory_node_name" "$inventory_role"
+    node_assert_kubernetes_worker "$node_json" "$kubernetes_node_name"
+    ;;
+esac
+
+node_assert_ready "$node_json" "$kubernetes_node_name"
+node_assert_cordoned "$node_json" "$kubernetes_node_name"
+node_assert_no_ordinary_pods "$context" "$kubernetes_node_name"
+node_wait_for_longhorn_maintenance_safe "$context" "$kubernetes_node_name"
+previous_boot_id="$(node_boot_id_from_node_json <<<"$node_json")"
+[[ -n "$previous_boot_id" ]] ||
+  node_die "node bootID is missing; cannot verify reboot completion: ${kubernetes_node_name}"
+
+node_confirm "$yes" "reboot ${kubernetes_node_name} from ${context}"
+
+inventory_file="$(node_inventory_file "$profile")"
+node_log "scheduling reboot on ${inventory_node_name}"
+node_run_remote_shell "$inventory_file" "$inventory_node_name" \
+  "nohup sh -c 'sleep 1; systemctl reboot' >/dev/null 2>&1 &"
+
+node_log "waiting for ${kubernetes_node_name} to report a new boot ID"
+node_wait_for_boot_id_change "$context" "$kubernetes_node_name" "$previous_boot_id" 900
+node_wait_for_cilium_ready "$context" "$kubernetes_node_name" 600
+node_wait_for_longhorn_ready_for_kubernetes_uncordon "$context" "$kubernetes_node_name" 600
+
+node_json="$(node_node_json_if_present "$context" "$kubernetes_node_name")"
+[[ -n "$node_json" ]] || node_die "Kubernetes node disappeared after reboot: ${kubernetes_node_name}"
+if [[ "$inventory_role" == master ]]; then
+  node_assert_kubernetes_control_plane "$node_json" "$kubernetes_node_name"
+else
+  node_assert_kubernetes_worker "$node_json" "$kubernetes_node_name"
+fi
+node_assert_ready "$node_json" "$kubernetes_node_name"
+node_assert_cordoned "$node_json" "$kubernetes_node_name"
+node_log "reboot complete: ${kubernetes_node_name}; node remains cordoned"

--- a/hack/bootstrap/tests/bats/offline-nodes.bats
+++ b/hack/bootstrap/tests/bats/offline-nodes.bats
@@ -399,6 +399,20 @@ EOF
   assert_output_contains 'etcd still has 1 member(s) for k3s-master-1'
 }
 
+@test "worker reboot requires drained state and waits for a new boot ID" {
+  write_reboot_kubectl
+  write_fake_ansible
+
+  mkdir -p "${tmp}/reboot-state"
+  run env PATH="${tmp}:${PATH}" FAKE_REBOOT_STATE_DIR="${tmp}/reboot-state" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_reboot_kubectl" \
+    "${ROOT}/hack/bootstrap/nodes/reboot.sh" --profile live --context test --yes k3s-worker-0
+  assert_success
+  assert_output_contains 'scheduling reboot on k3s-worker-0'
+  assert_output_contains 'waiting for k3s-worker-0 to report a new boot ID'
+  assert_output_contains 'reboot complete: k3s-worker-0; node remains cordoned'
+  [[ -f "${tmp}/reboot-state/rebooted-k3s-worker-0" ]]
+}
+
 @test "node converge plans no-op inventory and emits JSON shape" {
   local nodes_json
   nodes_json="${tmp}/nodes.json"
@@ -715,6 +729,7 @@ EOF
     hack/bootstrap/nodes/control-plane-join.sh \
     hack/bootstrap/nodes/control-plane-uncordon.sh \
     hack/bootstrap/nodes/delete.sh \
+    hack/bootstrap/nodes/reboot.sh \
     hack/bootstrap/nodes/longhorn-evict.sh \
     hack/bootstrap/nodes/join.sh \
     hack/bootstrap/nodes/uncordon.sh \

--- a/hack/bootstrap/tests/helpers/nodes.bash
+++ b/hack/bootstrap/tests/helpers/nodes.bash
@@ -485,6 +485,15 @@ if [[ "$joined_args" == *"ansible.builtin.systemd"* ]]; then
   exit 0
 fi
 
+if [[ "$joined_args" == *"systemctl reboot"* ]]; then
+  if [[ -n "${FAKE_REBOOT_STATE_DIR:-}" ]]; then
+    mkdir -p "$FAKE_REBOOT_STATE_DIR"
+    touch "${FAKE_REBOOT_STATE_DIR}/rebooted-${target}"
+  fi
+  printf 'reboot_scheduled=true\n'
+  exit 0
+fi
+
 if [[ "$joined_args" == *"90-home-ops-kube-proxy.yaml"* ]]; then
   if [[ "${FAKE_KUBE_PROXY_DROPIN:-present}" == missing ]]; then
     printf 'kube_proxy_disable_dropin=missing\n'
@@ -545,6 +554,104 @@ printf 'https://127.0.0.1:2379, c9e409fd1205cc0a, 3.6.7, 20 kB, false, false, 9,
 printf 'etcd_endpoint_status_end\n'
 EOF
   chmod +x "$fake_ansible"
+}
+
+write_reboot_kubectl() {
+  fake_reboot_kubectl="${tmp}/kubectl-reboot"
+  cat > "$fake_reboot_kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--context" ]]; then
+  shift 2
+fi
+
+state_dir="${FAKE_REBOOT_STATE_DIR:?}"
+
+if [[ "${1:-}" == "config" && "${2:-}" == "view" ]]; then
+  cat <<'JSON'
+{
+  "contexts": [
+    {
+      "name": "test",
+      "context": {"cluster": "test-cluster"}
+    }
+  ],
+  "clusters": [
+    {
+      "name": "test-cluster",
+      "cluster": {"server": "https://192.168.99.77:6443"}
+    }
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "--raw=/readyz" ]]; then
+  printf 'ok\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "node/k3s-worker-0" ]]; then
+  boot_id="boot-before"
+  if [[ -f "${state_dir}/rebooted-k3s-worker-0" ]]; then
+    boot_id="boot-after"
+  fi
+  sed -e "s/__BOOT_ID__/${boot_id}/g" <<'JSON'
+{
+  "metadata": {
+    "name": "k3s-worker-0",
+    "labels": {}
+  },
+  "spec": {
+    "unschedulable": true
+  },
+  "status": {
+    "conditions": [
+      {"type": "Ready", "status": "True"}
+    ],
+    "nodeInfo": {
+      "bootID": "__BOOT_ID__"
+    }
+  }
+}
+JSON
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "pods" ]]; then
+  printf '{"items":[]}\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "-n" && "${3:-}" == "kube-system" && "${4:-}" == "pods" ]]; then
+  cat <<'JSON'
+{
+  "items": [
+    {
+      "metadata": {"name": "cilium-worker"},
+      "spec": {"nodeName": "k3s-worker-0"},
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [{"ready": true}]
+      }
+    }
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "crd" && "${3:-}" == "volumes.longhorn.io" ]]; then
+  printf 'Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "volumes.longhorn.io" not found\n' >&2
+  exit 1
+fi
+
+printf 'unexpected fake reboot kubectl args: %s\n' "$*" >&2
+exit 1
+EOF
+  chmod +x "$fake_reboot_kubectl"
 }
 
 write_deleted_node_longhorn_kubectl() {

--- a/justfile
+++ b/justfile
@@ -313,6 +313,11 @@ node-converge-plan:
 node-drain node:
     ./hack/bootstrap/nodes/drain.sh --profile live --context default '{{ node }}'
 
+# Reboot a drained live worker or control-plane node and wait for it to return Ready.
+[group('node-mutate')]
+node-reboot node:
+    ./hack/bootstrap/nodes/reboot.sh --profile live --context default '{{ node }}'
+
 # Delete a drained live worker or control-plane node after Longhorn state has been evacuated.
 [group('node-mutate')]
 node-delete node:
@@ -484,6 +489,11 @@ node-lima-converge-plan:
 [group('node-lima-mutate')]
 node-lima-drain node:
     ./hack/bootstrap/nodes/drain.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
+
+# Reboot a drained Lima worker or control-plane node and wait for it to return Ready.
+[group('node-lima-mutate')]
+node-lima-reboot node:
+    ./hack/bootstrap/nodes/reboot.sh --profile lima --context '{{ lima_context }}' '{{ node }}'
 
 # Delete a drained Lima worker or control-plane node after Longhorn state has been evacuated.
 [group('node-lima-mutate')]


### PR DESCRIPTION
## Summary
- add a guarded node reboot lifecycle script for drained live and Lima nodes
- verify reboot completion by waiting for Kubernetes node bootID to change
- document the new just recipes and cover the path with BATS

## Review
- review agent approved with no blocking findings

## Validation
- just bootstrap-test
- pre-commit run --all-files