### PR TITLE
feat: manage github actions worker runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - home-ops
+    - image-pull

--- a/.github/workflows/helm-diff.yml
+++ b/.github/workflows/helm-diff.yml
@@ -167,7 +167,7 @@ jobs:
   verify-new-images:
     needs: helm-diff
     if: needs.helm-diff.outputs.HAS_DIFF == 'true'
-    runs-on: ARM64
+    runs-on: [self-hosted, Linux, ARM64, home-ops, image-pull]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -213,11 +213,11 @@ jobs:
             PULL_STATUS="❌"
             PLATFORM_STATUS="—"
 
-            if sudo crictl --debug pull "$IMAGE_FULL"; then
+            if sudo /usr/local/bin/home-ops-crictl pull "$IMAGE_FULL"; then
               PULL_STATUS="✅"
 
               # Inspect pulled image -> verify linux/arm64
-              INSPECT_JSON="$(sudo crictl inspecti -o json "$IMAGE_FULL" || true)"
+              INSPECT_JSON="$(sudo /usr/local/bin/home-ops-crictl inspecti -o json "$IMAGE_FULL" || true)"
               if [ -n "$INSPECT_JSON" ]; then
                 ARCH="$(printf '%s' "$INSPECT_JSON" | jq -r '.info.imageSpec.architecture // .imageSpec.architecture // empty')"
                 OS="$(printf '%s' "$INSPECT_JSON"   | jq -r '.info.imageSpec.os           // .imageSpec.os           // empty')"

--- a/.github/workflows/pull-image.yml
+++ b/.github/workflows/pull-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   verify-image-pull:
-    runs-on: ARM64
+    runs-on: [self-hosted, Linux, ARM64, home-ops, image-pull]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -35,10 +35,10 @@ jobs:
           PULL_STATUS="❌"
           PLATFORM_STATUS="—"
 
-          if sudo crictl --debug pull "$IMAGE_FULL"; then
+          if sudo /usr/local/bin/home-ops-crictl pull "$IMAGE_FULL"; then
             PULL_STATUS="✅"
             # Inspect the pulled image to verify OS/arch
-            INSPECT_JSON="$(sudo crictl inspecti -o json "$IMAGE_FULL" || true)"
+            INSPECT_JSON="$(sudo /usr/local/bin/home-ops-crictl inspecti -o json "$IMAGE_FULL" || true)"
             if [ -n "$INSPECT_JSON" ]; then
               ARCH="$(printf '%s' "$INSPECT_JSON" | jq -r '.info.imageSpec.architecture // .imageSpec.architecture // empty')"
               OS="$(printf '%s' "$INSPECT_JSON" | jq -r '.info.imageSpec.os           // .imageSpec.os           // empty')"

--- a/docs/cluster-operations.md
+++ b/docs/cluster-operations.md
@@ -441,6 +441,20 @@ automatically before they join K3s. Existing K3s nodes do not auto-reboot; if a
 boot-level change is required, drain and reboot that node through the node
 lifecycle flow, then rerun Ansible.
 
+Host services are part of the same Ansible backend. All nodes get the RPi MQTT
+reporter, control-plane nodes get the NUT client, and worker nodes get a
+repository-scoped GitHub Actions runner for ARM64 image-pull verification.
+Runner configuration mints a short-lived GitHub App installation token from
+`HOME_OPS_GITHUB_APP_ID`, `HOME_OPS_GITHUB_APP_INSTALLATION_ID`, and
+`HOME_OPS_GITHUB_APP_PRIVATE_KEY` fields on `op://Kubernetes/host-services`.
+Store `HOME_OPS_GITHUB_APP_PRIVATE_KEY` as base64-encoded full PEM key data so
+it fits cleanly in a 1Password field. The app installation needs repository
+Administration permission set to read/write for `sholdee/home-ops`. After
+changing the app permission, update or reinstall the app installation so the
+installation grants the new permission. The runner installer is pinned and
+checksum-verified; the installed runner keeps GitHub's normal runner
+auto-update behavior.
+
 Generated live inventory, vars, kubeconfigs, and run output are written under
 `hack/bootstrap/.out/ansible-live/`.
 

--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -206,6 +206,21 @@ sysctls, and base kernel modules. Fresh nodes may reboot automatically before
 joining K3s. Existing K3s nodes stop with a reboot-required message instead of
 rebooting themselves; use the node lifecycle drain/reboot/uncordon flow.
 
+It also converges host services: RPi MQTT reporter on all nodes, NUT client on
+control-plane nodes, and a GitHub Actions runner on workers for ARM64 image
+verification. Host-service secrets are loaded from
+`op://Kubernetes/host-services`; new worker runner registration mints a
+short-lived GitHub App installation token from the
+`HOME_OPS_GITHUB_APP_ID`, `HOME_OPS_GITHUB_APP_INSTALLATION_ID`, and
+`HOME_OPS_GITHUB_APP_PRIVATE_KEY` fields. Store
+`HOME_OPS_GITHUB_APP_PRIVATE_KEY` as base64-encoded full PEM key data so it fits
+cleanly in a 1Password field. The app installation needs repository
+Administration permission set to read/write for `sholdee/home-ops`. After
+changing the app permission, update or reinstall the app installation so the
+installation grants the new permission. The runner uses a dedicated
+`github-runner` user and a narrow `home-ops-crictl` sudo wrapper for image
+pull/inspect checks.
+
 ## Node Lifecycle
 
 Node lifecycle commands operate on an existing cluster and are intentionally

--- a/hack/bootstrap/ansible/home-ops/tasks/host-services/github-actions-runner.yml
+++ b/hack/bootstrap/ansible/home-ops/tasks/host-services/github-actions-runner.yml
@@ -1,0 +1,266 @@
+---
+- name: Resolve GitHub Actions runner architecture
+  ansible.builtin.set_fact:
+    home_ops_github_runner_arch: >-
+      {{
+        {
+          'aarch64': 'arm64',
+          'arm64': 'arm64',
+          'x86_64': 'x64',
+          'amd64': 'x64'
+        }.get(ansible_facts.architecture, '')
+      }}
+  when: home_ops_github_runner_enabled | bool
+
+- name: Validate GitHub Actions runner architecture
+  ansible.builtin.assert:
+    that:
+      - home_ops_github_runner_arch | length > 0
+    fail_msg: "Unsupported GitHub Actions runner architecture: {{ ansible_facts.architecture }}"
+  when: home_ops_github_runner_enabled | bool
+
+- name: Set GitHub Actions runner archive checksum
+  ansible.builtin.set_fact:
+    home_ops_github_runner_checksum: "{{ home_ops_github_runner_checksums[home_ops_github_runner_arch] | default('') }}"
+  when: home_ops_github_runner_enabled | bool
+
+- name: Validate GitHub Actions runner archive checksum
+  ansible.builtin.assert:
+    that:
+      - home_ops_github_runner_checksum | length > 0
+    fail_msg: "Missing GitHub Actions runner checksum for architecture: {{ home_ops_github_runner_arch }}"
+  when: home_ops_github_runner_enabled | bool
+
+- name: Install GitHub Actions runner prerequisites
+  ansible.builtin.package:
+    name: "{{ home_ops_github_runner_packages }}"
+    state: present
+  when: home_ops_github_runner_enabled | bool
+
+- name: Create GitHub Actions runner group
+  ansible.builtin.group:
+    name: "{{ home_ops_github_runner_group }}"
+    system: true
+    state: present
+  when: home_ops_github_runner_enabled | bool
+
+- name: Create GitHub Actions runner user
+  ansible.builtin.user:
+    name: "{{ home_ops_github_runner_user }}"
+    group: "{{ home_ops_github_runner_group }}"
+    home: "{{ home_ops_github_runner_home }}"
+    create_home: true
+    shell: /bin/bash
+    system: true
+    password_lock: true
+    state: present
+  when: home_ops_github_runner_enabled | bool
+
+- name: Create GitHub Actions runner install directory
+  ansible.builtin.file:
+    path: "{{ home_ops_github_runner_install_dir }}"
+    state: directory
+    owner: "{{ home_ops_github_runner_user }}"
+    group: "{{ home_ops_github_runner_group }}"
+    mode: "0755"
+  when: home_ops_github_runner_enabled | bool
+
+- name: Check GitHub Actions runner listener
+  ansible.builtin.stat:
+    path: "{{ home_ops_github_runner_install_dir }}/bin/Runner.Listener"
+  register: home_ops_github_runner_listener
+  when: home_ops_github_runner_enabled | bool
+
+- name: Set GitHub Actions runner install version
+  ansible.builtin.set_fact:
+    home_ops_github_runner_install_version: "{{ home_ops_github_runner_version | regex_replace('^v', '') }}"
+  when:
+    - home_ops_github_runner_enabled | bool
+    - not (home_ops_github_runner_listener.stat.exists | default(false))
+
+- name: Download GitHub Actions runner
+  ansible.builtin.get_url:
+    url: >-
+      https://github.com/actions/runner/releases/download/v{{ home_ops_github_runner_install_version }}/actions-runner-linux-{{ home_ops_github_runner_arch }}-{{ home_ops_github_runner_install_version }}.tar.gz
+    dest: "/tmp/actions-runner-linux-{{ home_ops_github_runner_arch }}-{{ home_ops_github_runner_install_version }}.tar.gz"
+    owner: root
+    group: root
+    mode: "0644"
+    checksum: "sha256:{{ home_ops_github_runner_checksum }}"
+  register: home_ops_github_runner_archive
+  when:
+    - home_ops_github_runner_enabled | bool
+    - not (home_ops_github_runner_listener.stat.exists | default(false))
+
+- name: Extract GitHub Actions runner
+  ansible.builtin.unarchive:
+    src: "{{ home_ops_github_runner_archive.dest }}"
+    dest: "{{ home_ops_github_runner_install_dir }}"
+    remote_src: true
+    owner: "{{ home_ops_github_runner_user }}"
+    group: "{{ home_ops_github_runner_group }}"
+  when:
+    - home_ops_github_runner_enabled | bool
+    - not (home_ops_github_runner_listener.stat.exists | default(false))
+
+- name: Install GitHub Actions runner OS dependencies
+  ansible.builtin.command:
+    cmd: "{{ home_ops_github_runner_install_dir }}/bin/installdependencies.sh"
+  changed_when: false
+  when:
+    - home_ops_github_runner_enabled | bool
+    - not (home_ops_github_runner_listener.stat.exists | default(false))
+
+- name: Check GitHub Actions runner local registration
+  ansible.builtin.stat:
+    path: "{{ home_ops_github_runner_install_dir }}/.runner"
+  register: home_ops_github_runner_registration
+  when: home_ops_github_runner_enabled | bool
+
+- name: Validate GitHub Actions runner registration token source
+  ansible.builtin.assert:
+    that:
+      - home_ops_github_runner_access_token | length > 0
+    fail_msg: >-
+      Missing generated HOME_OPS_GITHUB_RUNNER_ACCESS_TOKEN. The bootstrap
+      wrapper should mint it from the host-services GitHub App fields before
+      configuring a new runner.
+  when:
+    - home_ops_github_runner_enabled | bool
+    - not (home_ops_github_runner_registration.stat.exists | default(false))
+
+- name: Request GitHub Actions runner registration token
+  ansible.builtin.uri:
+    url: "{{ home_ops_github_runner_api_url }}/repos/{{ home_ops_github_runner_repo_owner }}/{{ home_ops_github_runner_repo_name }}/actions/runners/registration-token"
+    method: POST
+    status_code: 201
+    return_content: true
+    headers:
+      Accept: application/vnd.github+json
+      Authorization: "Bearer {{ home_ops_github_runner_access_token }}"
+      X-GitHub-Api-Version: "{{ home_ops_github_runner_api_version }}"
+  register: home_ops_github_runner_registration_token
+  delegate_to: localhost
+  become: false
+  no_log: true
+  when:
+    - home_ops_github_runner_enabled | bool
+    - not (home_ops_github_runner_registration.stat.exists | default(false))
+
+- name: Configure GitHub Actions runner
+  ansible.builtin.command:
+    argv:
+      - sudo
+      - -H
+      - -u
+      - "{{ home_ops_github_runner_user }}"
+      - --
+      - ./config.sh
+      - --unattended
+      - --url
+      - "{{ home_ops_github_runner_url }}"
+      - --token
+      - "{{ home_ops_github_runner_registration_token.json.token }}"
+      - --name
+      - "{{ home_ops_github_runner_name }}"
+      - --work
+      - "{{ home_ops_github_runner_work_dir }}"
+      - --labels
+      - "{{ home_ops_github_runner_labels | join(',') }}"
+      - --replace
+    chdir: "{{ home_ops_github_runner_install_dir }}"
+    creates: "{{ home_ops_github_runner_install_dir }}/.runner"
+  no_log: true
+  when:
+    - home_ops_github_runner_enabled | bool
+    - not (home_ops_github_runner_registration.stat.exists | default(false))
+
+- name: Check GitHub Actions runner service unit
+  ansible.builtin.stat:
+    path: "{{ home_ops_github_runner_service_file }}"
+  register: home_ops_github_runner_service_unit
+  when: home_ops_github_runner_enabled | bool
+
+- name: Read existing GitHub Actions runner service unit
+  ansible.builtin.slurp:
+    path: "{{ home_ops_github_runner_service_file }}"
+  register: home_ops_github_runner_service_unit_content
+  when:
+    - home_ops_github_runner_enabled | bool
+    - home_ops_github_runner_service_unit.stat.exists | default(false)
+
+- name: Decode existing GitHub Actions runner service unit
+  ansible.builtin.set_fact:
+    home_ops_github_runner_service_unit_text: "{{ home_ops_github_runner_service_unit_content.content | b64decode }}"
+  when:
+    - home_ops_github_runner_enabled | bool
+    - home_ops_github_runner_service_unit.stat.exists | default(false)
+
+- name: Validate existing GitHub Actions runner service unit
+  ansible.builtin.assert:
+    that:
+      - "home_ops_github_runner_install_dir ~ '/runsvc.sh' in home_ops_github_runner_service_unit_text"
+      - "'User=' ~ home_ops_github_runner_user in home_ops_github_runner_service_unit_text"
+      - "'WorkingDirectory=' ~ home_ops_github_runner_install_dir in home_ops_github_runner_service_unit_text"
+    fail_msg: >-
+      Existing GitHub Actions runner service {{ home_ops_github_runner_service_name }}
+      is not managed from {{ home_ops_github_runner_install_dir }} as
+      {{ home_ops_github_runner_user }}. Uninstall the legacy runner service first
+      from its install directory with sudo ./svc.sh uninstall, then rerun host services.
+  when:
+    - home_ops_github_runner_enabled | bool
+    - home_ops_github_runner_service_unit.stat.exists | default(false)
+
+- name: Install GitHub Actions runner service
+  ansible.builtin.command:
+    cmd: "./svc.sh install {{ home_ops_github_runner_user }}"
+    chdir: "{{ home_ops_github_runner_install_dir }}"
+    creates: "{{ home_ops_github_runner_service_file }}"
+  register: home_ops_github_runner_service_install
+  when: home_ops_github_runner_enabled | bool
+
+- name: Check K3s crictl helper
+  ansible.builtin.stat:
+    path: /var/lib/rancher/k3s/data/current/bin/crictl
+  register: home_ops_github_runner_k3s_crictl
+  when: home_ops_github_runner_enabled | bool
+
+- name: Validate K3s crictl helper exists
+  ansible.builtin.assert:
+    that:
+      - home_ops_github_runner_k3s_crictl.stat.exists | default(false)
+    fail_msg: >-
+      K3s crictl was not found at /var/lib/rancher/k3s/data/current/bin/crictl;
+      install or join K3s before enabling the GitHub Actions runner.
+  when: home_ops_github_runner_enabled | bool
+
+- name: Expose crictl on the default runner PATH
+  ansible.builtin.template:
+    src: home-ops-crictl.j2
+    dest: "{{ home_ops_github_runner_crictl_wrapper_path }}"
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - home_ops_github_runner_enabled | bool
+    - home_ops_github_runner_k3s_crictl.stat.exists | default(false)
+
+- name: Allow GitHub Actions runner to verify images with crictl
+  ansible.builtin.copy:
+    dest: "{{ home_ops_github_runner_sudoers_file }}"
+    owner: root
+    group: root
+    mode: "0440"
+    validate: "visudo -cf %s"
+    content: |
+      {{ home_ops_github_runner_user }} ALL=(root) NOPASSWD: {{ home_ops_github_runner_crictl_wrapper_path }} pull *
+      {{ home_ops_github_runner_user }} ALL=(root) NOPASSWD: {{ home_ops_github_runner_crictl_wrapper_path }} inspecti -o json *
+  when: home_ops_github_runner_enabled | bool
+
+- name: Enable and start GitHub Actions runner service
+  ansible.builtin.systemd:
+    name: "{{ home_ops_github_runner_service_name }}"
+    enabled: true
+    daemon_reload: "{{ home_ops_github_runner_service_install.changed | default(false) }}"
+    state: started
+  when: home_ops_github_runner_enabled | bool

--- a/hack/bootstrap/ansible/home-ops/tasks/host-services/main.yml
+++ b/hack/bootstrap/ansible/home-ops/tasks/host-services/main.yml
@@ -5,3 +5,7 @@
 - name: Apply NUT client host service on control-plane nodes
   ansible.builtin.import_tasks: nut-client.yml
   when: inventory_hostname in groups[group_name_master]
+
+- name: Apply GitHub Actions runner host service on worker nodes
+  ansible.builtin.import_tasks: github-actions-runner.yml
+  when: inventory_hostname in groups[group_name_node]

--- a/hack/bootstrap/ansible/home-ops/templates/home-ops-crictl.j2
+++ b/hack/bootstrap/ansible/home-ops/templates/home-ops-crictl.j2
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+crictl=/var/lib/rancher/k3s/data/current/bin/crictl
+runtime_endpoint={{ home_ops_github_runner_crictl_runtime_endpoint | quote }}
+timeout={{ home_ops_github_runner_crictl_timeout | quote }}
+
+case "${1:-}" in
+  pull)
+    [[ "$#" -eq 2 ]] || {
+      echo "usage: home-ops-crictl pull IMAGE" >&2
+      exit 2
+    }
+    exec "$crictl" \
+      --runtime-endpoint "$runtime_endpoint" \
+      --image-endpoint "$runtime_endpoint" \
+      --timeout "$timeout" \
+      pull "$2"
+    ;;
+  inspecti)
+    [[ "$#" -eq 4 && "${2:-}" == "-o" && "${3:-}" == "json" ]] || {
+      echo "usage: home-ops-crictl inspecti -o json IMAGE" >&2
+      exit 2
+    }
+    exec "$crictl" \
+      --runtime-endpoint "$runtime_endpoint" \
+      --image-endpoint "$runtime_endpoint" \
+      --timeout "$timeout" \
+      inspecti -o json "$4"
+    ;;
+  *)
+    echo "unsupported home-ops-crictl command: ${1:-}" >&2
+    exit 2
+    ;;
+esac

--- a/hack/bootstrap/ansible/home-ops/vars/defaults.yml
+++ b/hack/bootstrap/ansible/home-ops/vars/defaults.yml
@@ -21,6 +21,7 @@ home_ops_debian_packages:
   - curl
   - iproute2
   - iptables
+  - jq
   - nfs-common
   - open-iscsi
   - socat
@@ -137,3 +138,38 @@ home_ops_nut_pollfreqalert: 5
 home_ops_nut_powerdownflag: /etc/killpower
 home_ops_nut_rbwarntime: 43200
 home_ops_nut_shutdowncmd: /sbin/shutdown -h +0
+
+home_ops_github_runner_enabled: false
+home_ops_github_runner_repo_owner: sholdee
+home_ops_github_runner_repo_name: home-ops
+home_ops_github_runner_url: "https://github.com/{{ home_ops_github_runner_repo_owner }}/{{ home_ops_github_runner_repo_name }}"
+home_ops_github_runner_api_url: https://api.github.com
+home_ops_github_runner_api_version: "2022-11-28"
+home_ops_github_runner_access_token: "{{ lookup('ansible.builtin.env', 'HOME_OPS_GITHUB_RUNNER_ACCESS_TOKEN') }}"
+home_ops_github_runner_version: 2.334.0
+home_ops_github_runner_checksums:
+  arm64: f44255bd3e80160eb25f71bc83d06ea025f6908748807a584687b3184759f7e4
+  x64: 048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271
+home_ops_github_runner_install_dir: /opt/actions-runner
+home_ops_github_runner_home: /var/lib/github-runner
+home_ops_github_runner_user: github-runner
+home_ops_github_runner_group: "{{ home_ops_github_runner_user }}"
+home_ops_github_runner_name: "{{ inventory_hostname }}"
+home_ops_github_runner_service_name: "actions.runner.{{ home_ops_github_runner_repo_owner }}-{{ home_ops_github_runner_repo_name }}.{{ home_ops_github_runner_name }}.service"
+home_ops_github_runner_service_file: "{{ systemd_dir }}/{{ home_ops_github_runner_service_name }}"
+home_ops_github_runner_work_dir: _work
+home_ops_github_runner_labels:
+  - home-ops
+  - k3s
+  - image-pull
+home_ops_github_runner_packages:
+  - git
+  - gzip
+  - jq
+  - python3
+  - sudo
+  - tar
+home_ops_github_runner_crictl_wrapper_path: /usr/local/bin/home-ops-crictl
+home_ops_github_runner_crictl_runtime_endpoint: unix:///run/k3s/containerd/containerd.sock
+home_ops_github_runner_crictl_timeout: 30
+home_ops_github_runner_sudoers_file: /etc/sudoers.d/home-ops-github-runner

--- a/hack/bootstrap/ansible/inventory/live/group_vars/all.yml
+++ b/hack/bootstrap/ansible/inventory/live/group_vars/all.yml
@@ -17,6 +17,7 @@ home_ops_validate_ansible_host_ip: true
 
 home_ops_rpi_reporter_enabled: true
 home_ops_nut_client_enabled: true
+home_ops_github_runner_enabled: true
 
 k3s_node_ip: "{{ ansible_host }}"
 extra_args: >-

--- a/hack/bootstrap/ansible/lib/host-services.sh
+++ b/hack/bootstrap/ansible/lib/host-services.sh
@@ -17,9 +17,12 @@ ansible_host_service_secret_vars() {
 HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME
 HOME_OPS_RPI_REPORTER_MQTT_USERNAME
 HOME_OPS_RPI_REPORTER_MQTT_PASSWORD
+HOME_OPS_GITHUB_APP_ID
+HOME_OPS_GITHUB_APP_INSTALLATION_ID
+HOME_OPS_GITHUB_APP_PRIVATE_KEY
 EOF
       ;;
-    master|all)
+    master)
       cat <<'EOF'
 HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME
 HOME_OPS_RPI_REPORTER_MQTT_USERNAME
@@ -29,14 +32,156 @@ HOME_OPS_NUT_MONITOR_USER
 HOME_OPS_NUT_MONITOR_PASSWORD
 EOF
       ;;
+    all)
+      cat <<'EOF'
+HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME
+HOME_OPS_RPI_REPORTER_MQTT_USERNAME
+HOME_OPS_RPI_REPORTER_MQTT_PASSWORD
+HOME_OPS_NUT_MONITOR_SYSTEM
+HOME_OPS_NUT_MONITOR_USER
+HOME_OPS_NUT_MONITOR_PASSWORD
+HOME_OPS_GITHUB_APP_ID
+HOME_OPS_GITHUB_APP_INSTALLATION_ID
+HOME_OPS_GITHUB_APP_PRIVATE_KEY
+EOF
+      ;;
     *)
       ansible_die "unknown host service secret role: ${role}"
       ;;
   esac
 }
 
+ansible_host_service_needs_github_runner() {
+  local role="$1"
+  [[ "$role" == node || "$role" == all ]]
+}
+
+ansible_base64url() {
+  openssl base64 -A | tr '+/' '-_' | tr -d '='
+}
+
+ansible_github_app_private_key() {
+  local private_key
+
+  private_key="$HOME_OPS_GITHUB_APP_PRIVATE_KEY"
+  if [[ "$private_key" == *"-----BEGIN "* ]]; then
+    if [[ "$private_key" == *\\n* ]]; then
+      printf '%b' "$private_key"
+    else
+      printf '%s\n' "$private_key"
+    fi
+  else
+    printf '%s' "$private_key" | tr -d '[:space:]' | openssl base64 -d -A
+  fi
+}
+
+ansible_github_app_jwt() {
+  local now iat exp header payload signing_input signature key_file
+
+  now="$(date +%s)"
+  iat=$((now - 60))
+  exp=$((now + 540))
+  header="$(printf '{"alg":"RS256","typ":"JWT"}' | ansible_base64url)"
+  payload="$(
+    jq -cn \
+      --argjson iat "$iat" \
+      --argjson exp "$exp" \
+      --arg iss "$HOME_OPS_GITHUB_APP_ID" \
+      '{iat:$iat, exp:$exp, iss:$iss}' |
+      ansible_base64url
+  )"
+  signing_input="${header}.${payload}"
+
+  key_file="$(mktemp "${TMPDIR:-/tmp}/home-ops-github-app-key.XXXXXX")"
+  chmod 600 "$key_file"
+  if ! ansible_github_app_private_key > "$key_file"; then
+    rm -f "$key_file"
+    ansible_die "HOME_OPS_GITHUB_APP_PRIVATE_KEY is not valid base64-encoded PEM private key data"
+  fi
+
+  if ! openssl pkey -in "$key_file" -noout >/dev/null 2>&1; then
+    rm -f "$key_file"
+    ansible_die "HOME_OPS_GITHUB_APP_PRIVATE_KEY is not a valid PEM private key after decoding; store the base64-encoded full PEM including BEGIN/END lines"
+  fi
+
+  if ! signature="$(
+    printf '%s' "$signing_input" |
+      openssl dgst -sha256 -sign "$key_file" |
+      ansible_base64url
+  )"; then
+    rm -f "$key_file"
+    ansible_die "could not sign GitHub App JWT with HOME_OPS_GITHUB_APP_PRIVATE_KEY"
+  fi
+  rm -f "$key_file"
+
+  printf '%s.%s\n' "$signing_input" "$signature"
+}
+
+ansible_github_app_installation_access_token() {
+  local api_url api_version jwt body response response_body response_status token message
+
+  api_url="${HOME_OPS_GITHUB_API_URL:-https://api.github.com}"
+  api_version="${HOME_OPS_GITHUB_API_VERSION:-2022-11-28}"
+  if ! jwt="$(ansible_github_app_jwt)"; then
+    ansible_die "could not create GitHub App JWT for host services"
+  fi
+  body="$(
+    jq -cn \
+      --arg repo "${HOME_OPS_GITHUB_RUNNER_REPO_NAME:-home-ops}" \
+      '{repositories: [$repo], permissions: {administration: "write"}}'
+  )"
+
+  if ! response="$(
+    curl -sS \
+      --request POST \
+      --url "${api_url}/app/installations/${HOME_OPS_GITHUB_APP_INSTALLATION_ID}/access_tokens" \
+      --header "Accept: application/vnd.github+json" \
+      --header "Authorization: Bearer ${jwt}" \
+      --header "X-GitHub-Api-Version: ${api_version}" \
+      --data "$body" \
+      --write-out $'\n%{http_code}'
+  )"; then
+    ansible_die "could not mint GitHub App installation access token for host services"
+  fi
+  response_status="${response##*$'\n'}"
+  response_body="${response%$'\n'*}"
+
+  if [[ "$response_status" != 201 ]]; then
+    message="$(
+      jq -r '
+        .message as $message |
+        (.errors // [] | map(.message // .code // tostring) | join("; ")) as $errors |
+        [$message, $errors] | map(select(. != null and . != "")) | join(": ")
+      ' <<<"$response_body" 2>/dev/null || printf '%s' "$response_body"
+    )"
+    if [[ "$message" == *"permissions requested are not granted"* ]]; then
+      message="${message} Grant the GitHub App repository Administration permission as Read and write, then update or reinstall the app installation for sholdee/home-ops."
+    fi
+    ansible_die "GitHub App installation access token request failed (${response_status}): ${message}"
+  fi
+
+  if ! token="$(jq -er '.token // empty' <<<"$response_body")"; then
+    ansible_die "GitHub App installation access token response did not include a token"
+  fi
+
+  printf '%s\n' "$token"
+}
+
+ansible_prepare_github_runner_access_token() {
+  [[ -z "${HOME_OPS_GITHUB_RUNNER_ACCESS_TOKEN:-}" ]] || return
+
+  ansible_require_tool curl
+  ansible_require_tool jq
+  ansible_require_tool openssl
+  ansible_log "minting GitHub App installation token for runner registration"
+  HOME_OPS_GITHUB_RUNNER_ACCESS_TOKEN="$(ansible_github_app_installation_access_token)"
+  export HOME_OPS_GITHUB_RUNNER_ACCESS_TOKEN
+}
+
 ansible_load_host_service_secrets_from_op() {
-  local var value ref needs_op=false
+  local role="${1:-all}"
+  local var value item_json needs_op=false
+  local op_args=()
 
   while IFS= read -r var; do
     [[ -n "$var" ]] || continue
@@ -44,29 +189,48 @@ ansible_load_host_service_secrets_from_op() {
       needs_op=true
       break
     fi
-  done < <(ansible_host_service_secret_vars all)
+  done < <(ansible_host_service_secret_vars "$role")
 
   ansible_bool "$needs_op" || return
 
   command -v op >/dev/null 2>&1 || return 0
   ansible_op_signin_if_needed
+  if [[ -n "$BOOTSTRAP_ANSIBLE_OP_ACCOUNT" ]]; then
+    op_args=(--account "$BOOTSTRAP_ANSIBLE_OP_ACCOUNT")
+  fi
+
+  item_json="$(
+    op item get "$BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_ITEM" \
+      --vault "$BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_VAULT" \
+      --format json \
+      "${op_args[@]}" 2>/dev/null || true
+  )"
+  [[ -n "$item_json" ]] || return 0
 
   while IFS= read -r var; do
     [[ -n "$var" ]] || continue
     [[ -z "${!var:-}" ]] || continue
 
-    ref="$(ansible_host_service_secret_ref "$var")"
-    value="$(ansible_op_read_optional "$ref" || true)"
+    value="$(
+      jq -r --arg field "$var" '
+        [
+          .fields[]? |
+          select((.label // "") == $field or (.id // "") == $field) |
+          .value // empty
+        ] |
+        .[0] // empty
+      ' <<<"$item_json"
+    )"
     [[ -n "$value" ]] || continue
     export "${var}=${value}"
-  done < <(ansible_host_service_secret_vars all)
+  done < <(ansible_host_service_secret_vars "$role")
 }
 
 ansible_require_host_service_env() {
   local role="$1"
   local var missing=()
 
-  ansible_load_host_service_secrets_from_op
+  ansible_load_host_service_secrets_from_op "$role"
 
   while IFS= read -r var; do
     [[ -n "$var" ]] || continue
@@ -83,5 +247,9 @@ ansible_require_host_service_env() {
         "op://${BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_VAULT}/${BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_ITEM}"
     } >&2
     exit 1
+  fi
+
+  if ansible_host_service_needs_github_runner "$role"; then
+    ansible_prepare_github_runner_access_token
   fi
 }

--- a/hack/bootstrap/nodes/cmd.sh
+++ b/hack/bootstrap/nodes/cmd.sh
@@ -49,6 +49,13 @@ done
 
 [[ -n "$input_node" ]] || node_die "NODE is required"
 [[ $# -gt 0 ]] || node_die "remote command is required after --"
+if [[ "${1:-}" == "--" ]]; then
+  shift
+fi
+if [[ $# -eq 1 && "${1:-}" == "-- "* ]]; then
+  set -- "${1#-- }"
+fi
+[[ $# -gt 0 ]] || node_die "remote command is required after --"
 
 node_validate_profile "$profile"
 node_require_tool "$NODE_YQ_BIN"

--- a/hack/bootstrap/tests/bats/offline-ansible.bats
+++ b/hack/bootstrap/tests/bats/offline-ansible.bats
@@ -75,6 +75,11 @@ render_home_ops_inventory() {
   [[ "$(yq -r '.home_ops_etcdctl_version_override' "$home_ops_vars")" == "" ]]
   [[ "$(yq -r '.home_ops_rpi_reporter_enabled' "$home_ops_vars")" == "true" ]]
   [[ "$(yq -r '.home_ops_nut_client_enabled' "$home_ops_vars")" == "true" ]]
+  [[ "$(yq -r '.home_ops_github_runner_enabled' "$home_ops_vars")" == "true" ]]
+  [[ "$(yq -r '.home_ops_github_runner_version' "$home_ops_vars")" == "2.334.0" ]]
+  [[ "$(yq -r '.home_ops_github_runner_user' "$home_ops_vars")" == "github-runner" ]]
+  [[ "$(yq -r '.home_ops_github_runner_service_name' "$home_ops_vars")" == 'actions.runner.{{ home_ops_github_runner_repo_owner }}-{{ home_ops_github_runner_repo_name }}.{{ home_ops_github_runner_name }}.service' ]]
+  [[ "$(yq -r '.home_ops_github_runner_service_file' "$home_ops_vars")" == '{{ systemd_dir }}/{{ home_ops_github_runner_service_name }}' ]]
   [[ "$(yq -r '.home_ops_rpi_reporter_update_existing' "$home_ops_vars")" == "false" ]]
   [[ "$(yq -r '.home_ops_rpi_reporter_restart_on_change' "$home_ops_vars")" == "false" ]]
   [[ "$(yq -r '.home_ops_nut_client_restart_on_change' "$home_ops_vars")" == "false" ]]
@@ -218,6 +223,35 @@ EOF
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/rpi-reporter.yml" 'no_log: true'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/nut-client.yml" 'nut-client'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/nut-client.yml" 'no_log: true'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/main.yml" 'github-actions-runner.yml'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/github-actions-runner.yml" 'actions/runners/registration-token'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/github-actions-runner.yml" 'bin/installdependencies.sh'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/github-actions-runner.yml" 'checksum: "sha256:{{ home_ops_github_runner_checksum }}"'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/github-actions-runner.yml" 'home_ops_github_runner_registration_token.json.token'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/github-actions-runner.yml" '- sudo'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/github-actions-runner.yml" '- "{{ home_ops_github_runner_user }}"'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/github-actions-runner.yml" 'home_ops_github_runner_sudoers_file'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/github-actions-runner.yml" 'home_ops_github_runner_service_file'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/github-actions-runner.yml" 'Uninstall the legacy runner service first'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/github-actions-runner.yml" 'no_log: true'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/github-actions-runner.yml" 'home-ops-crictl.j2'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/templates/home-ops-crictl.j2" 'unsupported home-ops-crictl command'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib/host-services.sh" 'HOME_OPS_GITHUB_APP_ID'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib/host-services.sh" 'HOME_OPS_GITHUB_APP_INSTALLATION_ID'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib/host-services.sh" 'HOME_OPS_GITHUB_APP_PRIVATE_KEY'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib/host-services.sh" "op item get \"\$BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_ITEM\""
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib/host-services.sh" 'ansible_github_app_installation_access_token'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib/host-services.sh" 'permissions: {administration: "write"}'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib/host-services.sh" "mktemp \"\${TMPDIR:-/tmp}/home-ops-github-app-key.XXXXXX\""
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib/host-services.sh" 'openssl base64 -d -A'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib/host-services.sh" 'HOME_OPS_GITHUB_APP_PRIVATE_KEY is not valid base64-encoded PEM private key data'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/lib/host-services.sh" 'could not create GitHub App JWT for host services'
+  assert_file_contains "$ROOT/.github/workflows/pull-image.yml" 'runs-on: [self-hosted, Linux, ARM64, home-ops, image-pull]'
+  assert_file_contains "$ROOT/.github/workflows/helm-diff.yml" 'runs-on: [self-hosted, Linux, ARM64, home-ops, image-pull]'
+  assert_file_contains "$ROOT/.github/workflows/pull-image.yml" 'sudo /usr/local/bin/home-ops-crictl pull'
+  assert_file_contains "$ROOT/.github/workflows/helm-diff.yml" 'sudo /usr/local/bin/home-ops-crictl pull'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/vars/defaults.yml" 'home_ops_github_runner_access_token'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/inventory/live/group_vars/all.yml" 'home_ops_github_runner_enabled: true'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/control-plane-join.yml" 'tasks/host-services/main.yml'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/worker-join.yml" 'tasks/host-services/main.yml'
 }
@@ -225,35 +259,24 @@ EOF
 @test "host service secret helper loads missing values from 1Password fields" {
   local fake_op
   fake_op="${tmp}/op"
-  cat > "$fake_op" <<'EOF'
+cat > "$fake_op" <<'EOF'
 #!/usr/bin/env bash
 if [[ "$1" == whoami ]]; then
   exit 0
 fi
-[[ "$1" == read && "$2" == -n ]] || exit 2
-case "$3" in
-  op://Kubernetes/host-services/HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME)
-    printf 'mqtt.example.invalid'
-    ;;
-  op://Kubernetes/host-services/HOME_OPS_RPI_REPORTER_MQTT_USERNAME)
-    printf 'reporter-user'
-    ;;
-  op://Kubernetes/host-services/HOME_OPS_RPI_REPORTER_MQTT_PASSWORD)
-    printf 'reporter-secret'
-    ;;
-  op://Kubernetes/host-services/HOME_OPS_NUT_MONITOR_SYSTEM)
-    printf 'ups@example.invalid'
-    ;;
-  op://Kubernetes/host-services/HOME_OPS_NUT_MONITOR_USER)
-    printf 'nut-user'
-    ;;
-  op://Kubernetes/host-services/HOME_OPS_NUT_MONITOR_PASSWORD)
-    printf 'nut-secret'
-    ;;
-  *)
-    exit 1
-    ;;
-esac
+[[ "$1" == item && "$2" == get && "$3" == host-services ]] || exit 2
+cat <<'JSON'
+{
+  "fields": [
+    {"id": "HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME", "label": "HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME", "value": "mqtt.example.invalid"},
+    {"id": "HOME_OPS_RPI_REPORTER_MQTT_USERNAME", "label": "HOME_OPS_RPI_REPORTER_MQTT_USERNAME", "value": "reporter-user"},
+    {"id": "HOME_OPS_RPI_REPORTER_MQTT_PASSWORD", "label": "HOME_OPS_RPI_REPORTER_MQTT_PASSWORD", "value": "reporter-secret"},
+    {"id": "HOME_OPS_NUT_MONITOR_SYSTEM", "label": "HOME_OPS_NUT_MONITOR_SYSTEM", "value": "ups@example.invalid"},
+    {"id": "HOME_OPS_NUT_MONITOR_USER", "label": "HOME_OPS_NUT_MONITOR_USER", "value": "nut-user"},
+    {"id": "HOME_OPS_NUT_MONITOR_PASSWORD", "label": "HOME_OPS_NUT_MONITOR_PASSWORD", "value": "nut-secret"}
+  ]
+}
+JSON
 EOF
   chmod +x "$fake_op"
 
@@ -279,32 +302,21 @@ case "$1" in
   signin)
     printf 'export OP_SESSION_FAKE=1\n'
     ;;
-  read)
+  item)
     [[ "${OP_SESSION_FAKE:-}" == "1" ]] || exit 1
-    [[ "$2" == -n ]] || exit 2
-    case "$3" in
-      op://Kubernetes/host-services/HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME)
-        printf 'mqtt.example.invalid'
-        ;;
-      op://Kubernetes/host-services/HOME_OPS_RPI_REPORTER_MQTT_USERNAME)
-        printf 'reporter-user'
-        ;;
-      op://Kubernetes/host-services/HOME_OPS_RPI_REPORTER_MQTT_PASSWORD)
-        printf 'reporter-secret'
-        ;;
-      op://Kubernetes/host-services/HOME_OPS_NUT_MONITOR_SYSTEM)
-        printf 'ups@example.invalid'
-        ;;
-      op://Kubernetes/host-services/HOME_OPS_NUT_MONITOR_USER)
-        printf 'nut-user'
-        ;;
-      op://Kubernetes/host-services/HOME_OPS_NUT_MONITOR_PASSWORD)
-        printf 'nut-secret'
-        ;;
-      *)
-        exit 1
-        ;;
-    esac
+    [[ "$2" == get && "$3" == host-services ]] || exit 2
+    cat <<'JSON'
+{
+  "fields": [
+    {"id": "HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME", "label": "HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME", "value": "mqtt.example.invalid"},
+    {"id": "HOME_OPS_RPI_REPORTER_MQTT_USERNAME", "label": "HOME_OPS_RPI_REPORTER_MQTT_USERNAME", "value": "reporter-user"},
+    {"id": "HOME_OPS_RPI_REPORTER_MQTT_PASSWORD", "label": "HOME_OPS_RPI_REPORTER_MQTT_PASSWORD", "value": "reporter-secret"},
+    {"id": "HOME_OPS_NUT_MONITOR_SYSTEM", "label": "HOME_OPS_NUT_MONITOR_SYSTEM", "value": "ups@example.invalid"},
+    {"id": "HOME_OPS_NUT_MONITOR_USER", "label": "HOME_OPS_NUT_MONITOR_USER", "value": "nut-user"},
+    {"id": "HOME_OPS_NUT_MONITOR_PASSWORD", "label": "HOME_OPS_NUT_MONITOR_PASSWORD", "value": "nut-secret"}
+  ]
+}
+JSON
     ;;
   *)
     exit 2
@@ -318,8 +330,54 @@ EOF
   assert_success
   assert_output_contains 'mqtt.example.invalid:ups@example.invalid'
   [[ "$(grep -c '^signin$' "$calls")" == "1" ]]
+  [[ "$(grep -c '^item$' "$calls")" == "1" ]]
   assert_output_not_contains 'reporter-secret'
   assert_output_not_contains 'nut-secret'
+}
+
+@test "host service secret helper mints GitHub App token for worker runner registration" {
+  command -v openssl >/dev/null 2>&1 || skip "openssl not installed"
+
+  local fake_op fake_curl curl_args private_key
+  fake_op="${tmp}/op"
+  fake_curl="${tmp}/curl"
+  curl_args="${tmp}/curl-args"
+  private_key="$(openssl genrsa 2048 2>/dev/null | openssl base64 -A)"
+cat > "$fake_op" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == whoami ]]; then
+  exit 0
+fi
+[[ "$1" == item && "$2" == get && "$3" == host-services ]] || exit 2
+cat <<JSON
+{
+  "fields": [
+    {"id": "HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME", "label": "HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME", "value": "mqtt.example.invalid"},
+    {"id": "HOME_OPS_RPI_REPORTER_MQTT_USERNAME", "label": "HOME_OPS_RPI_REPORTER_MQTT_USERNAME", "value": "reporter-user"},
+    {"id": "HOME_OPS_RPI_REPORTER_MQTT_PASSWORD", "label": "HOME_OPS_RPI_REPORTER_MQTT_PASSWORD", "value": "reporter-secret"},
+    {"id": "HOME_OPS_GITHUB_APP_ID", "label": "HOME_OPS_GITHUB_APP_ID", "value": "12345"},
+    {"id": "HOME_OPS_GITHUB_APP_INSTALLATION_ID", "label": "HOME_OPS_GITHUB_APP_INSTALLATION_ID", "value": "987"},
+    {"id": "HOME_OPS_GITHUB_APP_PRIVATE_KEY", "label": "HOME_OPS_GITHUB_APP_PRIVATE_KEY", "value": "${TEST_GITHUB_APP_PRIVATE_KEY}"}
+  ]
+}
+JSON
+EOF
+cat > "$fake_curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$CURL_ARGS"
+printf '{"token":"installation-token","expires_at":"2026-05-14T05:00:00Z"}\n201'
+EOF
+  chmod +x "$fake_op" "$fake_curl"
+
+  run env PATH="${tmp}:${PATH}" CURL_ARGS="$curl_args" TEST_GITHUB_APP_PRIVATE_KEY="$private_key" \
+    bash -c "source '${ROOT}/hack/bootstrap/ansible/lib.sh'; ansible_require_host_service_env node; printf '%s:%s\n' \"\$HOME_OPS_GITHUB_RUNNER_ACCESS_TOKEN\" \"\$HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME\""
+  assert_success
+  assert_output_contains 'installation-token:mqtt.example.invalid'
+  assert_output_not_contains 'reporter-secret'
+  assert_file_contains "$curl_args" '/app/installations/987/access_tokens'
+  assert_file_contains "$curl_args" 'Authorization: Bearer '
+  assert_file_contains "$curl_args" '"repositories":["home-ops"]'
+  assert_file_contains "$curl_args" '"administration":"write"'
 }
 
 @test "host service secret helper fails before playbooks when values are missing" {
@@ -328,6 +386,9 @@ EOF
   assert_failure
   assert_output_contains 'missing host service secret environment values for node'
   assert_output_contains 'HOME_OPS_RPI_REPORTER_MQTT_PASSWORD'
+  assert_output_contains 'HOME_OPS_GITHUB_APP_ID'
+  assert_output_contains 'HOME_OPS_GITHUB_APP_INSTALLATION_ID'
+  assert_output_contains 'HOME_OPS_GITHUB_APP_PRIVATE_KEY'
   assert_output_contains 'op://Kubernetes/host-services'
 }
 

--- a/hack/bootstrap/tests/bats/offline-nodes.bats
+++ b/hack/bootstrap/tests/bats/offline-nodes.bats
@@ -108,6 +108,45 @@ EOF
   assert_file_contains "$capture" 'isp-rpi-reporter.service'
 }
 
+@test "node cmd just recipes quote shell metacharacters for the remote command" {
+  run just --dry-run node-cmd k3s-worker-0 'set -e; cd /tmp; pwd'
+  assert_success
+  assert_output_contains "./hack/bootstrap/nodes/cmd.sh --profile live 'k3s-worker-0' -- 'set -e; cd /tmp; pwd'"
+
+  run just --dry-run node-lima-cmd home-ops-k3s-test-agent-1 'set -e; cd /tmp; pwd'
+  assert_success
+  assert_output_contains "./hack/bootstrap/nodes/cmd.sh --profile lima 'home-ops-k3s-test-agent-1' -- 'set -e; cd /tmp; pwd'"
+}
+
+@test "node cmd helper tolerates an accidental extra separator before the remote command" {
+  local fake_ssh capture
+  fake_ssh="${tmp}/ssh"
+  capture="${tmp}/ssh-args"
+  cat > "$fake_ssh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$SSH_CAPTURE"
+EOF
+  chmod +x "$fake_ssh"
+
+  run env PATH="${tmp}:${PATH}" HOME=/tmp/home SSH_CAPTURE="$capture" \
+    NODE_LIVE_INVENTORY_DIR="$inventory" \
+    "${ROOT}/hack/bootstrap/nodes/cmd.sh" \
+      --profile live k3s-worker-0 -- -- 'set -e; cd /tmp; pwd'
+  assert_success
+  assert_file_contains "$capture" 'ethan@192.168.99.20'
+  assert_file_contains "$capture" 'set -e; cd /tmp; pwd'
+  run grep -Fx -- '--' "$capture"
+  assert_failure
+
+  run env PATH="${tmp}:${PATH}" HOME=/tmp/home SSH_CAPTURE="$capture" \
+    NODE_LIVE_INVENTORY_DIR="$inventory" \
+    "${ROOT}/hack/bootstrap/nodes/cmd.sh" \
+      --profile live k3s-worker-0 -- '-- set -e; cd /tmp; pwd'
+  assert_success
+  assert_file_contains "$capture" 'set -e; cd /tmp; pwd'
+  assert_file_not_contains "$capture" '-- set -e'
+}
+
 @test "node cmd helper fails closed for absent inventory node" {
   run env NODE_LIVE_INVENTORY_DIR="$inventory" \
     "${ROOT}/hack/bootstrap/nodes/cmd.sh" \

--- a/justfile
+++ b/justfile
@@ -291,7 +291,7 @@ node-pods node:
 # Run one SSH command against a live inventory node without implicit sudo.
 [group('node')]
 node-cmd node +command:
-    ./hack/bootstrap/nodes/cmd.sh --profile live '{{ node }}' -- {{ command }}
+    ./hack/bootstrap/nodes/cmd.sh --profile live '{{ node }}' -- {{ quote(command) }}
 
 # Show read-only control-plane quorum and embedded-etcd status for a live cluster node.
 [group('node')]
@@ -468,7 +468,7 @@ node-lima-pods node:
 # Run one SSH command against a Lima inventory node without implicit sudo.
 [group('node-lima')]
 node-lima-cmd node +command:
-    ./hack/bootstrap/nodes/cmd.sh --profile lima '{{ node }}' -- {{ command }}
+    ./hack/bootstrap/nodes/cmd.sh --profile lima '{{ node }}' -- {{ quote(command) }}
 
 # Show read-only control-plane quorum and embedded-etcd status for a Lima cluster node.
 [group('node-lima')]


### PR DESCRIPTION
## Summary
- manage GitHub Actions self-hosted runners on worker nodes through the home-ops Ansible host-services path
- mint runner registration access through the GitHub App credentials in op://Kubernetes/host-services
- move image verification jobs onto the home-ops ARM64 runner label set with a narrow crictl sudo wrapper
- harden node-cmd quoting so shell metacharacters stay remote

## Validation
- live-tested just ansible-host-services k3s-worker-1
- verified second host-services run is idempotent
- just bootstrap-test
- just ansible-plan
- pre-commit run --all-files