### PR TITLE
chore: tighten node command and reporter gates

### DIFF
--- a/hack/bootstrap/ansible/home-ops/tasks/host-services/main.yml
+++ b/hack/bootstrap/ansible/home-ops/tasks/host-services/main.yml
@@ -1,6 +1,13 @@
 ---
+- name: Detect Raspberry Pi host for RPi reporter
+  ansible.builtin.import_tasks: ../node-prep/raspberry-pi.yml
+  when: home_ops_rpi_reporter_enabled | bool
+
 - name: Apply RPi reporter host service
   ansible.builtin.import_tasks: rpi-reporter.yml
+  when:
+    - home_ops_rpi_reporter_enabled | bool
+    - home_ops_raspberry_pi | default(false) | bool
 
 - name: Apply NUT client host service on control-plane nodes
   ansible.builtin.import_tasks: nut-client.yml

--- a/hack/bootstrap/tests/bats/offline-ansible.bats
+++ b/hack/bootstrap/tests/bats/offline-ansible.bats
@@ -203,6 +203,8 @@ EOF
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/templates/k3s-server.service.j2" 'home_ops_node_taints'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/vars/defaults.yml" 'home_ops_node_taints'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/node-prep/main.yml" 'boot-cmdline.yml'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/main.yml" '../node-prep/raspberry-pi.yml'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/main.yml" 'home_ops_raspberry_pi | default(false) | bool'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/vars/defaults.yml" 'pcie_port_pm=off'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/node-prep/raspberry-pi-config.yml" 'ANSIBLE MANAGED BLOCK home-ops raspberry pi config'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/node-prep/sysctl.yml" 'fs.inotify.max_user_watches'

--- a/justfile
+++ b/justfile
@@ -289,7 +289,7 @@ node-pods node:
     kubectl --context default get pods -A --field-selector 'spec.nodeName={{ node }},status.phase!=Succeeded' -o wide
 
 # Run one SSH command against a live inventory node without implicit sudo.
-[group('node')]
+[group('node-mutate')]
 node-cmd node +command:
     ./hack/bootstrap/nodes/cmd.sh --profile live '{{ node }}' -- {{ quote(command) }}
 
@@ -466,7 +466,7 @@ node-lima-pods node:
     kubectl --context '{{ lima_context }}' get pods -A --field-selector 'spec.nodeName={{ node }},status.phase!=Succeeded' -o wide
 
 # Run one SSH command against a Lima inventory node without implicit sudo.
-[group('node-lima')]
+[group('node-lima-mutate')]
 node-lima-cmd node +command:
     ./hack/bootstrap/nodes/cmd.sh --profile lima '{{ node }}' -- {{ quote(command) }}
 


### PR DESCRIPTION
## Summary
- move arbitrary SSH node command recipes into mutate groups
- detect Raspberry Pi hosts before applying the RPi MQTT reporter host service
- add offline regression coverage for the host-service Pi gate

## Validation
- ansible-playbook --syntax-check -i hack/bootstrap/.out/ansible-live/inventory/live/hosts.yml hack/bootstrap/ansible/home-ops/host-services.yml
- bats hack/bootstrap/tests/bats/offline-ansible.bats hack/bootstrap/tests/bats/offline-nodes.bats
- just bootstrap-test
- just ansible-plan
- pre-commit run --all-files