### PR TITLE
fix: grant rpi reporter video access

### DIFF
--- a/hack/bootstrap/ansible/home-ops/templates/isp-rpi-reporter.service.j2
+++ b/hack/bootstrap/ansible/home-ops/templates/isp-rpi-reporter.service.j2
@@ -8,6 +8,9 @@ Requires=network.target
 Type=notify
 User={{ home_ops_rpi_reporter_daemon_user }}
 Group={{ home_ops_rpi_reporter_daemon_group }}
+{% if home_ops_rpi_reporter_supplementary_groups | length > 0 %}
+SupplementaryGroups={{ home_ops_rpi_reporter_supplementary_groups | join(' ') }}
+{% endif %}
 WorkingDirectory={{ home_ops_rpi_reporter_path }}/
 ExecStart={{ home_ops_rpi_reporter_path }}/venv/bin/python3 -u {{ home_ops_rpi_reporter_path }}/ISP-RPi-mqtt-daemon.py
 StandardOutput=null

--- a/hack/bootstrap/ansible/home-ops/vars/defaults.yml
+++ b/hack/bootstrap/ansible/home-ops/vars/defaults.yml
@@ -114,6 +114,8 @@ home_ops_rpi_reporter_path: /opt/RPi-Reporter-MQTT2HA-Daemon
 home_ops_rpi_reporter_service_name: isp-rpi-reporter
 home_ops_rpi_reporter_daemon_user: daemon
 home_ops_rpi_reporter_daemon_group: daemon
+home_ops_rpi_reporter_supplementary_groups:
+  - video
 home_ops_rpi_reporter_update_existing: false
 home_ops_rpi_reporter_apply_retain_patch: true
 home_ops_rpi_reporter_manage_config: false

--- a/hack/bootstrap/tests/bats/offline-ansible.bats
+++ b/hack/bootstrap/tests/bats/offline-ansible.bats
@@ -89,6 +89,7 @@ assert_file_contains_before() {
   [[ "$(yq -r '.k3s_token' "$home_ops_vars")" == "{{ lookup('ansible.builtin.env', 'K3S_TOKEN') }}" ]]
   [[ "$(yq -r '.home_ops_etcdctl_version_override' "$home_ops_vars")" == "" ]]
   [[ "$(yq -r '.home_ops_rpi_reporter_enabled' "$home_ops_vars")" == "true" ]]
+  [[ "$(yq -r '.home_ops_rpi_reporter_supplementary_groups | join(",")' "$home_ops_vars")" == "video" ]]
   [[ "$(yq -r '.home_ops_nut_client_enabled' "$home_ops_vars")" == "true" ]]
   [[ "$(yq -r '.home_ops_github_runner_enabled' "$home_ops_vars")" == "true" ]]
   [[ "$(yq -r '.home_ops_github_runner_version' "$home_ops_vars")" == "2.334.0" ]]
@@ -204,6 +205,32 @@ EOF
   assert_file_contains "$rendered_server_service" '--node-taint node.home-ops.sh/joining=true:NoSchedule'
   assert_file_contains "$rendered_server_service" 'KillMode=process'
   assert_file_not_contains "$rendered_server_service" 'NoScheduleKillMode'
+
+  local render_rpi_reporter_playbook rendered_rpi_reporter_service
+  render_rpi_reporter_playbook="${tmp}/render-rpi-reporter-service.yml"
+  rendered_rpi_reporter_service="${tmp}/isp-rpi-reporter.service"
+  cat > "$render_rpi_reporter_playbook" <<EOF
+---
+- name: Render RPi reporter service template
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars_files:
+    - ${ROOT}/hack/bootstrap/ansible/home-ops/vars/defaults.yml
+  vars:
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
+  tasks:
+    - name: Render RPi reporter service
+      ansible.builtin.template:
+        src: ${ROOT}/hack/bootstrap/ansible/home-ops/templates/isp-rpi-reporter.service.j2
+        dest: ${rendered_rpi_reporter_service}
+        mode: "0644"
+EOF
+  run ansible-playbook -i localhost, "$render_rpi_reporter_playbook"
+  assert_success
+  assert_file_contains "$rendered_rpi_reporter_service" 'User=daemon'
+  assert_file_contains "$rendered_rpi_reporter_service" 'Group=daemon'
+  assert_file_contains "$rendered_rpi_reporter_service" 'SupplementaryGroups=video'
 
   local render_crictl_playbook rendered_crictl_wrapper
   render_crictl_playbook="${tmp}/render-crictl-wrapper.yml"


### PR DESCRIPTION
## Summary
- render the RPi reporter systemd unit with a configurable SupplementaryGroups setting
- default the reporter to the video group so vcgencmd can read /dev/vcio on freshly rebuilt Trixie nodes
- add BATS coverage for the rendered unit and derived inventory value

## Debugging
- k3s-worker-0 and k3s-worker-1 on Debian 13 had /dev/vcio as root:video 0660 but the reporter ran as daemon:daemon without group video
- Bookworm control node had daemon in group video, which is why the same service worked there
- vcgencmd as daemon failed on Trixie with the same /dev/vcio error the reporter logged

## Validation
- just bootstrap-test
- pre-commit run --files hack/bootstrap/ansible/home-ops/vars/defaults.yml hack/bootstrap/ansible/home-ops/templates/isp-rpi-reporter.service.j2 hack/bootstrap/tests/bats/offline-ansible.bats
- live-tested a systemd drop-in on k3s-worker-1 and k3s-worker-0; both reporter processes now run with groups 1 44 and no /dev/vcio traceback after a reporter interval