### PR TITLE
chore: switch os update plan to trixie

### DIFF
--- a/.github/workflows/os-updates.yaml
+++ b/.github/workflows/os-updates.yaml
@@ -50,7 +50,7 @@ jobs:
           set -euo pipefail
 
           month="$(date -u +%Y-%m)"
-          version="bookworm-$(date -u +%Y-%m-%d)"
+          version="trixie-$(date -u +%Y-%m-%d)"
           branch="chore/os-updates-${month}"
           title="chore: trigger os updates for ${month}"
 
@@ -77,7 +77,7 @@ jobs:
           path = Path("apps/system-upgrade/manifests/os-plan.yaml")
           version = os.environ["VERSION"]
           text = path.read_text()
-          pattern = re.compile(r"^  version: bookworm-\d{4}-\d{2}-\d{2}$", re.MULTILINE)
+          pattern = re.compile(r"^  version: trixie-\d{4}-\d{2}-\d{2}$", re.MULTILINE)
           replacement = f"  version: {version}"
           updated, count = pattern.subn(replacement, text, count=1)
 
@@ -118,7 +118,7 @@ jobs:
           - bump the Raspberry Pi OS update trigger to \`${VERSION}\`
 
           ## Rollout
-          Merging this PR starts the opt-in System Upgrade Controller rollout for nodes selected by \`plan.upgrade.cattle.io/raspios-bookworm\`.
+          Merging this PR starts the opt-in System Upgrade Controller rollout for nodes selected by \`plan.upgrade.cattle.io/raspios-trixie\`.
           EOF
 
           pr_number="$(gh pr list \

--- a/apps/system-upgrade/manifests/os-plan.yaml
+++ b/apps/system-upgrade/manifests/os-plan.yaml
@@ -3,21 +3,21 @@
 apiVersion: upgrade.cattle.io/v1
 kind: Plan
 metadata:
-  name: raspios-bookworm
+  name: raspios-trixie
   namespace: system-upgrade
   labels:
-    os-upgrade: raspios-bookworm
+    os-upgrade: raspios-trixie
 spec:
   concurrency: 1
   exclusive: true
   jobActiveDeadlineSecs: 7200
   postCompleteDelay: "5m"
-  version: bookworm-2026-05-09
+  version: trixie-2026-05-14
   nodeSelector:
     matchExpressions:
-      - key: plan.upgrade.cattle.io/raspios-bookworm
+      - key: plan.upgrade.cattle.io/raspios-trixie
         operator: Exists
-      - key: plan.upgrade.cattle.io/raspios-bookworm
+      - key: plan.upgrade.cattle.io/raspios-trixie
         operator: NotIn
         values:
           - "disabled"
@@ -25,7 +25,7 @@ spec:
   serviceAccountName: system-upgrade
   secrets:
     - name: raspios-upgrade-script
-      path: /host/run/system-upgrade/secrets/raspios-bookworm
+      path: /host/run/system-upgrade/secrets/raspios-trixie
       ignoreUpdates: true
   tolerations:
     - key: CriticalAddonsOnly
@@ -46,6 +46,6 @@ spec:
     force: true
     skipWaitForDeleteTimeout: 180
   upgrade:
-    image: debian:bookworm-slim@sha256:67b30a61dc87758f0caf819646104f29ecbda97d920aaf5edc834128ac8493d3
+    image: debian:trixie-slim@sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b
     command: ["chroot", "/host"]
-    args: ["sh", "/run/system-upgrade/secrets/raspios-bookworm/upgrade.sh"]
+    args: ["sh", "/run/system-upgrade/secrets/raspios-trixie/upgrade.sh"]

--- a/apps/system-upgrade/manifests/raspios-upgrade.sh
+++ b/apps/system-upgrade/manifests/raspios-upgrade.sh
@@ -2,7 +2,7 @@
 set -eu
 
 marker_dir="/var/lib/rancher/system-upgrade/reboot"
-marker="${marker_dir}/raspios-bookworm"
+marker="${marker_dir}/raspios-trixie"
 boot_id="$(cat /proc/sys/kernel/random/boot_id)"
 
 mkdir -p "${marker_dir}"


### PR DESCRIPTION
## Summary
- rename the Raspberry Pi OS update Plan from Bookworm to Trixie
- switch the opt-in label, secret mount path, reboot marker, and upgrade image to Trixie
- update the monthly OS Updates workflow regex/body to bump trixie-* versions

## Validation
- pre-commit run --files .github/workflows/os-updates.yaml apps/system-upgrade/manifests/os-plan.yaml apps/system-upgrade/manifests/raspios-upgrade.sh
- kustomize build apps/system-upgrade
- verified the os-updates version regex matches exactly one Trixie Plan version
- docker buildx imagetools inspect debian:trixie-slim
- review agent approved

## Note
This updates already-Trixie nodes only. It does not migrate Bookworm APT sources to Trixie.