### PR TITLE
fix: release kube-vip during control-plane delete

### DIFF
--- a/hack/bootstrap/nodes/lib/ansible.sh
+++ b/hack/bootstrap/nodes/lib/ansible.sh
@@ -48,15 +48,55 @@ node_stop_k3s_server() {
   local profile="$1"
   local inventory_node="$2"
   local inventory_file
+  local kube_vip_address
+  local stop_script
 
   inventory_file="$(node_ansible_inventory_file "$profile")"
+  kube_vip_address="$(node_kube_vip_address "$profile" || true)"
+  read -r -d '' stop_script <<EOF || true
+set -eu
+
+systemctl disable --now k3s
+
+kube_vip_address="${kube_vip_address}"
+if [ -z "\$kube_vip_address" ]; then
+  printf 'kube_vip_release=skipped:no_apiserver_endpoint\n'
+  exit 0
+fi
+
+printf 'kube_vip_release_address=%s\n' "\$kube_vip_address"
+
+if command -v pkill >/dev/null 2>&1; then
+  if pkill -f '[/]kube-vip manager' >/dev/null 2>&1; then
+    printf 'kube_vip_release_process=killed\n'
+  else
+    printf 'kube_vip_release_process=absent\n'
+  fi
+else
+  printf 'kube_vip_release_process=unknown:no_pkill\n'
+fi
+
+if command -v ip >/dev/null 2>&1; then
+  interfaces="\$(ip -o -4 addr show | awk -v vip="\${kube_vip_address}/32" '\$4 == vip {split(\$2, iface, "@"); print iface[1]}' | sort -u)"
+  if [ -n "\$interfaces" ]; then
+    printf '%s\n' "\$interfaces" | while IFS= read -r iface; do
+      [ -n "\$iface" ] || continue
+      if ip addr del "\${kube_vip_address}/32" dev "\$iface" >/dev/null 2>&1; then
+        printf 'kube_vip_release_interface=%s\n' "\$iface"
+      else
+        printf 'kube_vip_release_interface_failed=%s\n' "\$iface"
+      fi
+    done
+  else
+    printf 'kube_vip_release_interface=absent\n'
+  fi
+else
+  printf 'kube_vip_release_interface=unknown:no_ip\n'
+fi
+EOF
+
   node_require_tool ansible
-  ANSIBLE_HOST_KEY_CHECKING=False ansible \
-    -i "$inventory_file" \
-    "$inventory_node" \
-    --become \
-    -m ansible.builtin.systemd \
-    -a "name=k3s enabled=false state=stopped"
+  node_run_remote_shell "$inventory_file" "$inventory_node" "$stop_script"
 }
 
 node_run_worker_ansible_action() {
@@ -134,6 +174,34 @@ node_effective_ansible_group_var() {
   group_vars="$(node_effective_ansible_inventory_dir "$profile")/group_vars/all.yml"
   [[ -f "$group_vars" ]] || return 1
   "$NODE_YQ_BIN" -r ".${key}" "$group_vars"
+}
+
+node_kube_vip_address() {
+  local profile="$1"
+  local value
+  local kube_vip_file
+
+  value="$(node_effective_ansible_group_var "$profile" apiserver_endpoint 2>/dev/null || true)"
+  value="$(node_trim "$value")"
+  case "$value" in
+    ""|null)
+      kube_vip_file="${REPO_ROOT}/apps/kube-system/kube-vip/manifests/daemonset.yaml"
+      if [[ -f "$kube_vip_file" ]]; then
+        value="$("$NODE_YQ_BIN" -r '.spec.template.spec.containers[] | select(.name == "kube-vip") | .env[] | select(.name == "address") | .value // ""' "$kube_vip_file")"
+        value="$(node_trim "$value")"
+      fi
+      ;;
+  esac
+  case "$value" in
+    ""|null)
+      return 1
+      ;;
+  esac
+  if [[ ! "$value" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+    node_warn "apiserver_endpoint is not an IPv4 address; skipping kube-vip release: ${value}"
+    return 1
+  fi
+  printf '%s\n' "$value"
 }
 
 node_kube_proxy_replacement_enabled() {

--- a/hack/bootstrap/tests/bats/offline-nodes.bats
+++ b/hack/bootstrap/tests/bats/offline-nodes.bats
@@ -1067,11 +1067,15 @@ EOF
   assert_failure
   assert_output_contains 'live first-master lifecycle requires a stable API endpoint'
 
+  yq -i 'del(.apiserver_endpoint)' "${inventory}/group_vars/all.yml"
   mkdir -p "${tmp}/first-control-plane-state"
   run env PATH="${tmp}:${PATH}" FAKE_KUBECTL_STATE_DIR="${tmp}/first-control-plane-state" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_control_plane_kubectl" \
     "${ROOT}/hack/bootstrap/nodes/delete.sh" --profile live --context test --yes k3s-master-0
   assert_success
   assert_output_contains 'first inventory master selected; live context must remain reachable through the stable API endpoint'
+  assert_output_contains 'kube_vip_release_address=192.168.99.77'
+  assert_output_contains 'kube_vip_release_process=killed'
+  assert_output_contains 'kube_vip_release_interface=eth0.99'
   assert_output_contains 'snapshot_name=pre-remove-k3s-master-0-'
   assert_output_contains 'Member c9e409fd1205cc0a removed from cluster'
   assert_output_contains 'node "k3s-master-0" deleted'
@@ -1081,6 +1085,9 @@ EOF
   run env PATH="${tmp}:${PATH}" FAKE_KUBECTL_STATE_DIR="${tmp}/control-plane-state" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_control_plane_kubectl" \
     "${ROOT}/hack/bootstrap/nodes/delete.sh" --profile live --context test --yes k3s-master-1
   assert_success
+  assert_output_contains 'kube_vip_release_address=192.168.99.77'
+  assert_output_contains 'kube_vip_release_process=killed'
+  assert_output_contains 'kube_vip_release_interface=eth0.99'
   assert_output_contains 'snapshot_name=pre-remove-k3s-master-1-'
   assert_output_contains 'Member 70594c7c481c118 removed from cluster'
   assert_output_contains 'node "k3s-master-1" deleted'
@@ -1090,6 +1097,7 @@ EOF
     "${ROOT}/hack/bootstrap/nodes/delete.sh" --profile live --context test --yes k3s-master-1
   assert_success
   assert_output_contains 'stopping k3s server on k3s-master-1 before deleted-node cleanup'
+  assert_output_contains 'kube_vip_release_address=192.168.99.77'
   assert_output_contains 'verifying k3s-master-1 is absent from etcd membership using k3s-master-0'
   assert_output_contains 'control-plane delete cleanup complete: k3s-master-1'
 

--- a/hack/bootstrap/tests/helpers/nodes.bash
+++ b/hack/bootstrap/tests/helpers/nodes.bash
@@ -34,6 +34,7 @@ ansible_user: ethan
 ansible_ssh_private_key_file: ~/ansiblekey
 kube_proxy_replacement: true
 k3s_version: v1.35.4+k3s1
+apiserver_endpoint: 192.168.99.77
 EOF
 }
 
@@ -498,6 +499,13 @@ printf '%s | CHANGED | rc=0 >>\n' "$target"
 
 if [[ "$joined_args" == *"ansible.builtin.systemd"* ]]; then
   printf '{"changed": true}\n'
+  exit 0
+fi
+
+if [[ "$joined_args" == *"systemctl disable --now k3s"* && "$joined_args" == *"kube_vip_release_address"* && "$joined_args" == *'split($2, iface, "@")'* ]]; then
+  printf 'kube_vip_release_address=192.168.99.77\n'
+  printf 'kube_vip_release_process=killed\n'
+  printf 'kube_vip_release_interface=eth0.99\n'
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- stop k3s servers through a shell helper that also releases kube-vip on the deleted control-plane node
- derive the VIP from rendered Ansible vars or fall back to the GitOps kube-vip manifest
- normalize VLAN interface names before deleting the VIP address
- add regression coverage for control-plane delete kube-vip release behavior

## Validation
- shellcheck hack/bootstrap/nodes/lib/ansible.sh hack/bootstrap/tests/helpers/nodes.bash
- bats hack/bootstrap/tests/bats/offline-nodes.bats --filter 'control-plane drain and delete enforce stable API and cleanup semantics'
- just bootstrap-test
- git diff --check