### PR TITLE
fix: verify nodes are schedulable after uncordon

### DIFF
--- a/hack/bootstrap/nodes/control-plane-uncordon.sh
+++ b/hack/bootstrap/nodes/control-plane-uncordon.sh
@@ -116,5 +116,6 @@ node_assert_no_joining_taint "$node_json" "$kubernetes_node_name"
 
 node_log "uncordoning ${kubernetes_node_name}"
 node_kubectl "$context" uncordon "$kubernetes_node_name"
+node_wait_for_schedulable "$context" "$kubernetes_node_name" "${NODE_UNCORDON_VERIFY_TIMEOUT:-60}"
 node_wait_for_longhorn_ready_for_uncordon "$context" "$kubernetes_node_name" 600
 node_log "control-plane uncordon complete: ${kubernetes_node_name}"

--- a/hack/bootstrap/nodes/lib/k8s.sh
+++ b/hack/bootstrap/nodes/lib/k8s.sh
@@ -258,6 +258,15 @@ node_assert_cordoned() {
   [[ "$schedulable" == cordoned ]] || node_die "node must be cordoned first: ${node}"
 }
 
+node_assert_schedulable() {
+  local node_json="$1"
+  local node="$2"
+  local schedulable
+
+  schedulable="$(node_schedulable_from_node_json <<<"$node_json")"
+  [[ "$schedulable" == schedulable ]] || node_die "node is still cordoned after uncordon: ${node}"
+}
+
 node_assert_no_joining_taint() {
   local node_json="$1"
   local node="$2"

--- a/hack/bootstrap/nodes/lib/wait.sh
+++ b/hack/bootstrap/nodes/lib/wait.sh
@@ -51,6 +51,26 @@ node_wait_for_ready() {
   done
 }
 
+node_wait_for_schedulable() {
+  local context="$1"
+  local node="$2"
+  local timeout="${3:-300}"
+  local deadline=$((SECONDS + timeout))
+  local node_json
+
+  while true; do
+    node_json="$(node_node_json_if_present "$context" "$node")"
+    if [[ -n "$node_json" ]] && (node_assert_schedulable "$node_json" "$node") >/dev/null 2>&1; then
+      return 0
+    fi
+    if ((SECONDS >= deadline)); then
+      [[ -n "$node_json" ]] || node_die "Kubernetes node disappeared while waiting for uncordon: ${node}"
+      node_assert_schedulable "$node_json" "$node"
+    fi
+    sleep 2
+  done
+}
+
 node_wait_for_boot_id_change() {
   local context="$1"
   local node="$2"

--- a/hack/bootstrap/nodes/uncordon.sh
+++ b/hack/bootstrap/nodes/uncordon.sh
@@ -120,5 +120,6 @@ node_assert_no_joining_taint "$node_json" "$kubernetes_node_name"
 
 node_log "uncordoning ${kubernetes_node_name}"
 node_kubectl "$context" uncordon "$kubernetes_node_name"
+node_wait_for_schedulable "$context" "$kubernetes_node_name" "${NODE_UNCORDON_VERIFY_TIMEOUT:-60}"
 node_wait_for_longhorn_ready_for_uncordon "$context" "$kubernetes_node_name"
 node_log "uncordon complete: ${kubernetes_node_name}"

--- a/hack/bootstrap/tests/bats/offline-nodes.bats
+++ b/hack/bootstrap/tests/bats/offline-nodes.bats
@@ -1150,6 +1150,32 @@ EOF
   [[ -f "${tmp}/reboot-state/rebooted-k3s-worker-0" ]]
 }
 
+@test "worker uncordon verifies Kubernetes schedulability before reporting success" {
+  local fake_ansible_playbook state_dir
+  write_uncordon_kubectl
+  state_dir="${tmp}/uncordon-state"
+  mkdir -p "$state_dir"
+  fake_ansible_playbook="${tmp}/ansible-playbook"
+  cat > "$fake_ansible_playbook" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'fake ansible-playbook %s\n' "$*"
+EOF
+  chmod +x "$fake_ansible_playbook"
+
+  run env PATH="${tmp}:${PATH}" NODE_LIMA_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_uncordon_kubectl" FAKE_UNCORDON_STATE_DIR="$state_dir" FAKE_UNCORDON_NOOP=true NODE_UNCORDON_VERIFY_TIMEOUT=0 \
+    "${ROOT}/hack/bootstrap/nodes/uncordon.sh" --profile lima --context test --yes k3s-worker-0
+  assert_failure
+  assert_output_contains 'node is still cordoned after uncordon: lima-k3s-worker-0'
+
+  rm -f "${state_dir}/taint-removed" "${state_dir}/uncordoned"
+  run env PATH="${tmp}:${PATH}" NODE_LIMA_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_uncordon_kubectl" FAKE_UNCORDON_STATE_DIR="$state_dir" NODE_UNCORDON_VERIFY_TIMEOUT=0 \
+    "${ROOT}/hack/bootstrap/nodes/uncordon.sh" --profile lima --context test --yes k3s-worker-0
+  assert_success
+  assert_output_contains 'node/lima-k3s-worker-0 uncordoned'
+  assert_output_contains 'uncordon complete: lima-k3s-worker-0'
+}
+
 @test "node converge plans no-op inventory and emits JSON shape" {
   local nodes_json
   nodes_json="${tmp}/nodes.json"

--- a/hack/bootstrap/tests/helpers/nodes.bash
+++ b/hack/bootstrap/tests/helpers/nodes.bash
@@ -324,6 +324,95 @@ EOF
   chmod +x "$fake_kubectl"
 }
 
+write_uncordon_kubectl() {
+  fake_uncordon_kubectl="${tmp}/kubectl-uncordon"
+  cat > "$fake_uncordon_kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--context" ]]; then
+  shift 2
+fi
+
+state_dir="${FAKE_UNCORDON_STATE_DIR:?}"
+node_name="${FAKE_UNCORDON_NODE:-lima-k3s-worker-0}"
+
+if [[ "${1:-}" == "get" && "${2:-}" == "--raw=/readyz" ]]; then
+  printf 'ok\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "node/${node_name}" ]]; then
+  spec_entries=()
+  if [[ ! -f "${state_dir}/uncordoned" ]]; then
+    spec_entries+=('"unschedulable": true')
+  fi
+  if [[ ! -f "${state_dir}/taint-removed" ]]; then
+    spec_entries+=('"taints": [{"key": "node.home-ops.sh/joining", "value": "true", "effect": "NoSchedule"}]')
+  fi
+  spec="$(IFS=,; printf '%s' "${spec_entries[*]}")"
+  cat <<JSON
+{
+  "metadata": {
+    "name": "${node_name}",
+    "labels": {}
+  },
+  "spec": {${spec}},
+  "status": {
+    "conditions": [
+      {"type": "Ready", "status": "True"}
+    ]
+  }
+}
+JSON
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "-n" && "${3:-}" == "kube-system" && "${4:-}" == "pods" ]]; then
+  cat <<JSON
+{
+  "items": [
+    {
+      "metadata": {"name": "cilium-one"},
+      "spec": {"nodeName": "${node_name}"},
+      "status": {
+        "phase": "Running",
+        "containerStatuses": [{"ready": true}]
+      }
+    }
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "crd" && "${3:-}" == "volumes.longhorn.io" ]]; then
+  printf 'Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "volumes.longhorn.io" not found\n' >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "taint" && "${2:-}" == "node" && "${3:-}" == "$node_name" && "${4:-}" == "node.home-ops.sh/joining-" ]]; then
+  mkdir -p "$state_dir"
+  touch "${state_dir}/taint-removed"
+  printf 'node/%s untainted\n' "$node_name"
+  exit 0
+fi
+
+if [[ "${1:-}" == "uncordon" && "${2:-}" == "$node_name" ]]; then
+  mkdir -p "$state_dir"
+  if [[ "${FAKE_UNCORDON_NOOP:-false}" != true ]]; then
+    touch "${state_dir}/uncordoned"
+  fi
+  printf 'node/%s uncordoned\n' "$node_name"
+  exit 0
+fi
+
+printf 'unexpected fake uncordon kubectl args: %s\n' "$*" >&2
+exit 1
+EOF
+  chmod +x "$fake_uncordon_kubectl"
+}
+
 write_control_plane_kubectl() {
   fake_control_plane_kubectl="${tmp}/kubectl-control-plane"
   cat > "$fake_control_plane_kubectl" <<'EOF'


### PR DESCRIPTION
## Summary
- verify worker and control-plane nodes become schedulable after kubectl uncordon
- add a shared wait/assert helper for post-uncordon spec.unschedulable checks
- add an offline BATS regression where kubectl uncordon returns success but the node remains cordoned

## Validation
- targeted BATS uncordon regression
- nearby node lifecycle BATS tests
- shellcheck -x on changed shell files
- just bootstrap-test
- git diff --check

## Live validation
- just node-uncordon k3s-master-0 reported successful after temporary cordon setup
- kubectl get node k3s-master-0 shows UNSCHEDULABLE=<none>