### PR TITLE
fix: use namespace age for cluster age metric

### DIFF
--- a/apps/monitoring/kromgo/manifests/config.yaml
+++ b/apps/monitoring/kromgo/manifests/config.yaml
@@ -27,7 +27,7 @@ metrics:
       - { color: "orange", min: 75, max: 85 }
       - { color: "red", min: 85, max: 9999 }
   - name: cluster_age_days
-    query: round((time() - min(kube_node_created)) / 86400)
+    query: round((time() - max(kube_namespace_created{namespace="kube-system"})) / 86400)
     suffix: "d"
     colors:
       - { color: "green", min: 0, max: 9999 }


### PR DESCRIPTION
## Summary
- update Kromgo cluster_age_days to use kube-system namespace creation time instead of node creation time
- keep the metric stable across one-at-a-time node replacement/reimage operations

## Validation
- pre-commit run --files apps/monitoring/kromgo/manifests/config.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/monitoring/kromgo/
