### PR TITLE
fix: expose embedded etcd metrics

### DIFF
--- a/hack/bootstrap/ansible/home-ops/tasks/k3s/first-server.yml
+++ b/hack/bootstrap/ansible/home-ops/tasks/k3s/first-server.yml
@@ -15,12 +15,7 @@
     name: "{{ home_ops_k3s_server_service_name }}"
     daemon_reload: true
     enabled: true
-    state: >-
-      {{
-        'restarted'
-        if home_ops_k3s_server_service.changed or (home_ops_k3s_registries_config.changed | default(false))
-        else 'started'
-      }}
+    state: started
 
 - name: Wait for first K3s API port
   ansible.builtin.wait_for:

--- a/hack/bootstrap/ansible/home-ops/tasks/k3s/join-agents.yml
+++ b/hack/bootstrap/ansible/home-ops/tasks/k3s/join-agents.yml
@@ -19,12 +19,7 @@
     name: "{{ home_ops_k3s_agent_service_name }}"
     daemon_reload: true
     enabled: true
-    state: >-
-      {{
-        'restarted'
-        if home_ops_k3s_agent_service.changed or (home_ops_k3s_registries_config.changed | default(false))
-        else 'started'
-      }}
+    state: started
 
 - name: Wait for joined worker node object
   ansible.builtin.command: "{{ k3s_kubectl_binary }} get node/{{ home_ops_node_name }}"

--- a/hack/bootstrap/ansible/home-ops/tasks/k3s/join-servers.yml
+++ b/hack/bootstrap/ansible/home-ops/tasks/k3s/join-servers.yml
@@ -21,14 +21,16 @@
     name: "{{ home_ops_k3s_server_service_name }}"
     daemon_reload: true
     enabled: true
-    state: >-
-      {{
-        'restarted'
-        if home_ops_k3s_server_service.changed
-        or (home_ops_kube_proxy_config.changed | default(false))
-        or (home_ops_k3s_registries_config.changed | default(false))
-        else 'started'
-      }}
+    state: started
+
+- name: Restart fresh joining K3s server after kube-proxy disable config
+  ansible.builtin.systemd:
+    name: "{{ home_ops_k3s_server_service_name }}"
+    daemon_reload: true
+    state: restarted
+  when:
+    - not (home_ops_k3s_installed | default(false) | bool)
+    - home_ops_kube_proxy_config.changed | default(false) | bool
 
 - name: Wait for local K3s API port
   ansible.builtin.wait_for:

--- a/hack/bootstrap/ansible/home-ops/vars/defaults.yml
+++ b/hack/bootstrap/ansible/home-ops/vars/defaults.yml
@@ -34,6 +34,7 @@ home_ops_k3s_runtime_dir: /var/lib/rancher/k3s/server
 home_ops_k3s_config_dir: /etc/rancher/k3s
 home_ops_k3s_token_file: /etc/rancher/k3s/home-ops-token
 home_ops_k3s_embedded_registry: true
+home_ops_k3s_etcd_expose_metrics: true
 home_ops_k3s_registries_file: "{{ home_ops_k3s_config_dir }}/registries.yaml"
 home_ops_k3s_registry_mirrors:
   docker.io:
@@ -91,11 +92,13 @@ home_ops_fsnotify_max_queued_events: 65536
 home_ops_first_server_args: >-
   {{ '--cluster-init' if (groups[group_name_master] | length) > 1 else '' }}
   {{ '--embedded-registry' if home_ops_k3s_embedded_registry | bool else '' }}
+  {{ '--etcd-expose-metrics' if ((home_ops_k3s_etcd_expose_metrics | bool) and ((groups[group_name_master] | length) > 1)) else '' }}
   --token-file {{ home_ops_k3s_token_file }}
   {{ extra_server_args | default('') }}
 home_ops_join_server_args: >-
   --server https://{{ home_ops_first_master_join_ip }}:6443
   {{ '--embedded-registry' if home_ops_k3s_embedded_registry | bool else '' }}
+  {{ '--etcd-expose-metrics' if ((home_ops_k3s_etcd_expose_metrics | bool) and ((groups[group_name_master] | length) > 1)) else '' }}
   --token-file {{ home_ops_k3s_token_file }}
   {{ extra_server_args | default('') }}
 home_ops_agent_args: >-

--- a/hack/bootstrap/tests/bats/offline-ansible.bats
+++ b/hack/bootstrap/tests/bats/offline-ansible.bats
@@ -98,7 +98,9 @@ assert_file_contains_before() {
   [[ "$(yq -r '.home_ops_github_runner_service_file' "$home_ops_vars")" == '{{ systemd_dir }}/{{ home_ops_github_runner_service_name }}' ]]
   [[ "$(yq -r '.home_ops_github_runner_crictl_timeout' "$home_ops_vars")" == "30s" ]]
   [[ "$(yq -r '.home_ops_k3s_embedded_registry' "$home_ops_vars")" == "true" ]]
+  [[ "$(yq -r '.home_ops_k3s_etcd_expose_metrics' "$home_ops_vars")" == "true" ]]
   assert_file_contains "$home_ops_vars" '--embedded-registry'
+  assert_file_contains "$home_ops_vars" '--etcd-expose-metrics'
   [[ "$(yq -r '.home_ops_rpi_reporter_update_existing' "$home_ops_vars")" == "false" ]]
   [[ "$(yq -r '.home_ops_rpi_reporter_restart_on_change' "$home_ops_vars")" == "false" ]]
   [[ "$(yq -r '.home_ops_rpi_reporter_interval_in_minutes' "$home_ops_vars")" == "2" ]]
@@ -282,12 +284,32 @@ EOF
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/k3s/registries.yml" 'templates/registries.yaml.j2'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/k3s/registries.yml" 'home_ops_k3s_registries_file'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/k3s/registries.yml" 'register: home_ops_k3s_registries_config'
-  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/k3s/first-server.yml" 'home_ops_k3s_registries_config.changed'
-  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/k3s/join-agents.yml" 'home_ops_k3s_registries_config.changed'
-  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/k3s/join-servers.yml" 'home_ops_k3s_registries_config.changed'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/vars/defaults.yml" '--embedded-registry'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/templates/registries.yaml.j2" 'mirrors:'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/templates/registries.yaml.j2" 'home_ops_k3s_registry_mirrors'
+}
+
+@test "K3s service tasks do not restart already-running nodes for config drift" {
+  local first_server join_agents join_servers task
+
+  first_server="${ROOT}/hack/bootstrap/ansible/home-ops/tasks/k3s/first-server.yml"
+  join_agents="${ROOT}/hack/bootstrap/ansible/home-ops/tasks/k3s/join-agents.yml"
+  join_servers="${ROOT}/hack/bootstrap/ansible/home-ops/tasks/k3s/join-servers.yml"
+
+  for task in \
+    "$first_server" \
+    "$join_agents" \
+    "$join_servers"; do
+    assert_file_contains "$task" 'state: started'
+    assert_file_not_contains "$task" "'restarted'"
+  done
+
+  assert_file_not_contains "$first_server" 'state: restarted'
+  assert_file_not_contains "$join_agents" 'state: restarted'
+  [[ "$(grep -c 'state: restarted' "$join_servers")" == "1" ]]
+  assert_file_contains "$join_servers" 'Restart fresh joining K3s server after kube-proxy disable config'
+  assert_file_contains "$join_servers" 'not (home_ops_k3s_installed | default(false) | bool)'
+  assert_file_contains "$join_servers" 'home_ops_kube_proxy_config.changed | default(false) | bool'
 }
 
 @test "static Ansible lifecycle invariants are present" {
@@ -333,7 +355,7 @@ EOF
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/control-plane-join.yml" 'tasks/k3s/kube-proxy-disable.yml'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/control-plane-finalize.yml" 'tasks/k3s/kube-proxy-disable.yml'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/playbooks/disable-kube-proxy.yml" '../home-ops/tasks/k3s/kube-proxy-disable.yml'
-  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/k3s/join-servers.yml" 'home_ops_kube_proxy_config.changed'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/k3s/join-servers.yml" 'home_ops_kube_proxy_config.changed | default(false) | bool'
   assert_file_contains "$ROOT/hack/bootstrap/nodes/control-plane-join.sh" 'node_assert_kube_proxy_disable_dropin'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/host-services.sh" 'home-ops/host-services.yml'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/host-services/rpi-reporter.yml" 'home_ops_rpi_reporter_update_existing'


### PR DESCRIPTION
## Summary
- enable K3s embedded etcd metrics in the home-ops Ansible server args for HA control-plane inventories
- keep the existing kube-prometheus-stack kubeEtcd scrape resources usable on control-plane node IPs port 2381
- add BATS coverage that rendered home-ops inventory includes the flag

## Notes
K3s documents `--etcd-expose-metrics` as the server flag for exposing embedded etcd metrics to the client interface. The monitoring chart already renders kubeEtcd endpoints for the live control-plane IPs on port 2381.

## Validation
- git diff --check
- just bootstrap-test
