### PR TITLE
fix: recover powerdns database from backup

### DIFF
--- a/apps/powerdns/kustomization.yaml
+++ b/apps/powerdns/kustomization.yaml
@@ -19,3 +19,20 @@ resources:
   - manifests/service.yaml
   - manifests/httproute.yaml
   - manifests/netpol.yaml
+patches:
+  - target:
+      group: postgresql.cnpg.io
+      version: v1
+      kind: Cluster
+      name: powerdns-db
+    patch: |-
+      - op: remove
+        path: /spec/bootstrap/initdb
+      - op: add
+        path: /spec/bootstrap/recovery
+        value:
+          source: barman-cloud
+          database: powerdns
+          owner: powerdns
+          secret:
+            name: powerdns-db-app-user


### PR DESCRIPTION
## Summary
- switch the PowerDNS CNPG cluster bootstrap path from initdb to Barman recovery
- keep the rendered steady-state spec aligned with live recovery operations

## Validation
- pre-commit run --files apps/powerdns/kustomization.yaml
- kustomize build apps/powerdns | kubectl --context default -n powerdns apply --server-side --dry-run=server --field-manager=argocd-controller -f -