### PR TITLE
chore: move unifi mongo to local-path

### DIFF
--- a/apps/unifi/unifi-db/manifests/replicaset.yaml
+++ b/apps/unifi/unifi-db/manifests/replicaset.yaml
@@ -65,7 +65,7 @@ spec:
             resources:
               requests:
                 storage: 5Gi
-            storageClassName: longhorn-mongo
+            storageClassName: local-path
         - metadata:
             name: logs-volume
           spec:
@@ -73,4 +73,4 @@ spec:
             resources:
               requests:
                 storage: 1Gi
-            storageClassName: longhorn-mongo
+            storageClassName: local-path


### PR DESCRIPTION
## Summary
- move the UniFi MongoDBCommunity data and logs volume claim templates from longhorn-mongo to local-path

## Validation
- kustomize build --enable-helm apps/unifi
- pre-commit run --files apps/unifi/unifi-db/manifests/replicaset.yaml

Note: existing MongoDB PVC storageClassName values are immutable; recreate the operator StatefulSet/PVCs before merge so the new local-path templates are used.