### PR TITLE
fix: allow unifi fresh restore startup

### DIFF
--- a/apps/unifi/unifi-db/manifests/replicaset.yaml
+++ b/apps/unifi/unifi-db/manifests/replicaset.yaml
@@ -42,6 +42,10 @@ spec:
           db: admin
         - name: clusterMonitor
           db: admin
+        - name: readWrite
+          db: unifi_audit
+        - name: dbOwner
+          db: unifi_audit
       scramCredentialsSecretName: unifi-db-scram
       connectionStringSecretNamespace: unifi
   additionalMongodConfig:

--- a/apps/unifi/unifi/manifests/cleanup.sh
+++ b/apps/unifi/unifi/manifests/cleanup.sh
@@ -7,8 +7,16 @@ INTERVAL_SECONDS=${INTERVAL_SECONDS:-86400}
 
 log(){ echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ") [INFO] $*"; }
 
+ensure_backup_state(){
+  mkdir -p "$BACKUP_DIR"
+  if [ ! -e "$META_FILE" ]; then
+    printf '{}\n' > "$META_FILE"
+  fi
+}
+
 cleanup(){
   log "Cleanup job started"
+  ensure_backup_state
 
   find "$BACKUP_DIR" -maxdepth 1 -type f -name '*.unf' -mtime +7 -print0 \
     | while IFS= read -r -d '' file; do
@@ -22,7 +30,7 @@ cleanup(){
         if [ ! -e "$BACKUP_DIR/$name" ]; then
           log "Removing metadata for missing file: $name"
           tmp=$(mktemp)
-          jq "del(.\"$name\")" "$META_FILE" > "$tmp"
+          jq --arg name "$name" 'del(.[$name])' "$META_FILE" > "$tmp"
           mv "$tmp" "$META_FILE"
         fi
       done


### PR DESCRIPTION
## Summary
- initialize UniFi autobackup state when the restored PVC is intentionally empty
- grant the UniFi Mongo user access to the unifi_audit database used during startup

## Validation
- pre-commit run --files apps/unifi/unifi/manifests/cleanup.sh apps/unifi/unifi-db/manifests/replicaset.yaml
- kustomize build --enable-helm apps/unifi
- live-applied cleanup ConfigMap and MongoDBCommunity with argocd-controller field manager
- verified deployment/unifi rolled out with both containers ready
- forced UniFi keystore reimport from mounted unifi-cert and verified https://unifi.mgmt.sholdee.net returns HTTP 200