### PR TITLE
fix: allow unifi backup restore database

### DIFF
--- a/apps/unifi/unifi-db/manifests/replicaset.yaml
+++ b/apps/unifi/unifi-db/manifests/replicaset.yaml
@@ -46,6 +46,10 @@ spec:
           db: unifi_audit
         - name: dbOwner
           db: unifi_audit
+        - name: readWrite
+          db: unifi_restore
+        - name: dbOwner
+          db: unifi_restore
       scramCredentialsSecretName: unifi-db-scram
       connectionStringSecretNamespace: unifi
   additionalMongodConfig:


### PR DESCRIPTION
## Summary
- grant the UniFi Mongo user ownership of the temporary unifi_restore database used by backup imports

## Validation
- pre-commit run --files apps/unifi/unifi-db/manifests/replicaset.yaml
- kustomize build --enable-helm apps/unifi
- live-applied MongoDBCommunity role update with argocd-controller field manager
- verified MongoDBCommunity returned to Running