### PR TITLE
chore: move cnpg clusters to local-path

### DIFF
--- a/apps/hass/hass-db/manifests/cnpg-cluster.yaml
+++ b/apps/hass/hass-db/manifests/cnpg-cluster.yaml
@@ -20,8 +20,12 @@ spec:
   superuserSecret:
     name: hass-db-superuser
   storage:
-    storageClass: longhorn-noreplicas
+    storageClass: local-path
     size: 14Gi
+  affinity:
+    enablePodAntiAffinity: true
+    podAntiAffinityType: required
+    topologyKey: kubernetes.io/hostname
   bootstrap:
     recovery:
       source: &src barman-cloud

--- a/apps/powerdns/manifests/cnpg-cluster.yaml
+++ b/apps/powerdns/manifests/cnpg-cluster.yaml
@@ -20,8 +20,12 @@ spec:
   superuserSecret:
     name: powerdns-db-superuser
   storage:
-    storageClass: longhorn-noreplicas
+    storageClass: local-path
     size: 2Gi
+  affinity:
+    enablePodAntiAffinity: true
+    podAntiAffinityType: required
+    topologyKey: kubernetes.io/hostname
   bootstrap:
     initdb:
       database: powerdns


### PR DESCRIPTION
## Summary
- move Hass and PowerDNS CNPG instance storage from longhorn-noreplicas to local-path
- add required hostname anti-affinity so CNPG instances remain spread across nodes

## Validation
- pre-commit run --files apps/hass/hass-db/manifests/cnpg-cluster.yaml apps/powerdns/manifests/cnpg-cluster.yaml
- kustomize build --enable-helm apps/hass
- kustomize build --enable-helm apps/powerdns
- server-side dry-run for Cluster/hass-db2 and Cluster/powerdns-db with argocd-controller field manager

## Follow-up
After merge and Argo sync, rebuild CNPG instances one at a time with kubectl cnpg destroy so replacement PVCs are created on local-path.