### PR TITLE
fix: use rwo appdaemon pvc

### DIFF
--- a/apps/hass/appdaemon/kustomization.yaml
+++ b/apps/hass/appdaemon/kustomization.yaml
@@ -55,8 +55,5 @@ patches:
         path: /metadata/name
         value: appdaemon-pvc
       - op: replace
-        path: /spec/accessModes/0
-        value: ReadWriteMany
-      - op: replace
         path: /spec/dataSourceRef/name
         value: appdaemon-bootstrap


### PR DESCRIPTION
## Summary
- stop overriding appdaemon-pvc to ReadWriteMany
- keep the VolSync bootstrap dataSourceRef while using the component default ReadWriteOnce mode

## Validation
- pre-commit run --files apps/hass/appdaemon/kustomization.yaml
- kustomize build --enable-helm apps/hass
- live appdaemon/codeserver rollout verified after recreating appdaemon-pvc as RWO
