### PR TITLE
fix: use local-path for alertmanager storage

### DIFF
--- a/apps/monitoring/values.yaml
+++ b/apps/monitoring/values.yaml
@@ -48,11 +48,11 @@ alertmanager:
     storage:
       volumeClaimTemplate:
         spec:
-          storageClassName: longhorn
+          storageClassName: local-path
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:
-              storage: 10Gi
+              storage: 1Gi
 grafana:
   enabled: false
   forceDeployDashboards: true


### PR DESCRIPTION
## Summary
- move Alertmanager persistence from longhorn to local-path
- reduce Alertmanager PVC request from 10Gi to 1Gi

## Validation
- pre-commit run --files apps/monitoring/values.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/monitoring