### PR TITLE
fix: make hass app pvcs file-restore friendly

### DIFF
--- a/apps/hass/appdaemon/kustomization.yaml
+++ b/apps/hass/appdaemon/kustomization.yaml
@@ -54,6 +54,5 @@ patches:
       - op: replace
         path: /metadata/name
         value: appdaemon-pvc
-      - op: replace
-        path: /spec/dataSourceRef/name
-        value: appdaemon-bootstrap
+      - op: remove
+        path: /spec/dataSourceRef

--- a/apps/hass/codeserver/kustomization.yaml
+++ b/apps/hass/codeserver/kustomization.yaml
@@ -53,6 +53,5 @@ patches:
       - op: replace
         path: /metadata/name
         value: codeserver-pvc
-      - op: replace
-        path: /spec/dataSourceRef/name
-        value: codeserver-bootstrap
+      - op: remove
+        path: /spec/dataSourceRef

--- a/apps/hass/hass/kustomization.yaml
+++ b/apps/hass/hass/kustomization.yaml
@@ -57,6 +57,5 @@ patches:
       - op: replace
         path: /spec/accessModes/0
         value: ReadWriteMany
-      - op: replace
-        path: /spec/dataSourceRef/name
-        value: hass-bootstrap
+      - op: remove
+        path: /spec/dataSourceRef

--- a/apps/hass/zwave/kustomization.yaml
+++ b/apps/hass/zwave/kustomization.yaml
@@ -57,6 +57,5 @@ patches:
       - op: replace
         path: /spec/accessModes/0
         value: ReadWriteMany
-      - op: replace
-        path: /spec/dataSourceRef/name
-        value: zwave-bootstrap
+      - op: remove
+        path: /spec/dataSourceRef


### PR DESCRIPTION
## Summary
- remove create-time dataSourceRef patches from HASS app PVC overlays
- allow clean file-level VolSync restores to reconcile without immutable PVC drift

## Validation
- kustomize build apps/hass
- pre-commit run --files apps/hass/appdaemon/kustomization.yaml apps/hass/codeserver/kustomization.yaml apps/hass/hass/kustomization.yaml apps/hass/zwave/kustomization.yaml
- live restored HASS app PVCs from May 12 using VolSync Direct restore + file copy
- live no-drift temporary ReplicationSource backups succeeded for appdaemon, codeserver, hass, and zwave