### PR TITLE
fix: make portainer pvc file-restore friendly

### DIFF
--- a/apps/portainer/kustomization.yaml
+++ b/apps/portainer/kustomization.yaml
@@ -58,6 +58,5 @@ patches:
       - op: replace
         path: /metadata/name
         value: portainer-pvc
-      - op: replace
-        path: /spec/dataSourceRef/name
-        value: portainer-bootstrap
+      - op: remove
+        path: /spec/dataSourceRef


### PR DESCRIPTION
## Summary
- remove Portainer PVC create-time dataSourceRef so file-level VolSync recovery can reconcile without immutable PVC drift

## Validation
- kustomize build apps/portainer
- pre-commit run --files apps/portainer/kustomization.yaml
- live restore: restored May 12 Portainer snapshot bcc508ff into a new PVC, Portainer rolled out healthy
- live backup verification: temporary ReplicationSource saved Restic snapshot 760ae8ff from the recovered Portainer PVC