### PR TITLE
fix: restore portainer volsync datasource ref

### DIFF
--- a/apps/portainer/kustomization.yaml
+++ b/apps/portainer/kustomization.yaml
@@ -58,5 +58,6 @@ patches:
       - op: replace
         path: /metadata/name
         value: portainer-pvc
-      - op: remove
-        path: /spec/dataSourceRef
+      - op: replace
+        path: /spec/dataSourceRef/name
+        value: portainer-bootstrap


### PR DESCRIPTION
## Summary
- restore Portainer PVC dataSourceRef to the matching portainer-bootstrap ReplicationDestination
- keep the PVC name rewrite so existing live Portainer state stays Argo-compatible

## Validation
- pre-commit run --files apps/portainer/kustomization.yaml
- just app-diff portainer
- verified Portainer pod is Running and ReplicationSource completed a fresh backup

## Notes
HASS PVCs were recovered and backed up, but dataSourceRef is intentionally not restored there yet because live testing reproduced Longhorn clone/share-manager and fsck failures on those PVCs.