### PR TITLE
fix: scale down longhorn-backed workloads

### DIFF
--- a/apps/hass/appdaemon/manifests/deployment.yaml
+++ b/apps/hass/appdaemon/manifests/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:

--- a/apps/hass/codeserver/manifests/deployment.yaml
+++ b/apps/hass/codeserver/manifests/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:

--- a/apps/hass/hass/manifests/deployment.yaml
+++ b/apps/hass/hass/manifests/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hass
   namespace: hass
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:

--- a/apps/hass/zwave/manifests/deployment.yaml
+++ b/apps/hass/zwave/manifests/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:

--- a/apps/mealie/manifests/deployment.yaml
+++ b/apps/mealie/manifests/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: RollingUpdate
   selector:

--- a/apps/portainer/manifests/deployment.yaml
+++ b/apps/portainer/manifests/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: portainer
   namespace: portainer
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:

--- a/apps/unifi/unifi/manifests/deployment.yaml
+++ b/apps/unifi/unifi/manifests/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
## Summary
- scale appdaemon, codeserver, hass, zwave, mealie, portainer, and unifi deployments to zero
- quiesce the remaining Longhorn-backed PVC workloads ahead of a Longhorn reset and VolSync-backed restore

## Validation
- kustomize build --enable-helm apps/hass
- kustomize build --enable-helm apps/mealie
- kustomize build --enable-helm apps/portainer
- kustomize build --enable-helm apps/unifi
- pre-commit run --files apps/hass/appdaemon/manifests/deployment.yaml apps/hass/codeserver/manifests/deployment.yaml apps/hass/hass/manifests/deployment.yaml apps/hass/zwave/manifests/deployment.yaml apps/mealie/manifests/deployment.yaml apps/portainer/manifests/deployment.yaml apps/unifi/unifi/manifests/deployment.yaml