### PR TITLE
fix: move remaining app pvc workloads to local-path

### DIFF
--- a/apps/hass/appdaemon/kustomization.yaml
+++ b/apps/hass/appdaemon/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - manifests/deployment.yaml
+  - manifests/local-pvc.yaml
   - manifests/service.yaml
   - manifests/externalsecret.yaml
   - manifests/httproute.yaml
@@ -20,7 +21,13 @@ patches:
         value: appdaemon
       - op: replace
         path: /spec/sourcePVC
-        value: appdaemon-pvc
+        value: appdaemon-pvc-local
+      - op: replace
+        path: /spec/restic/copyMethod
+        value: Direct
+      - op: replace
+        path: /spec/restic/storageClassName
+        value: local-path
       - op: replace
         path: /spec/restic/repository
         value: appdaemon-volsync-b2

--- a/apps/hass/appdaemon/manifests/deployment.yaml
+++ b/apps/hass/appdaemon/manifests/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 0
+  replicas: 1
   strategy:
     type: Recreate
   selector:
@@ -70,6 +70,6 @@ spec:
       volumes:
       - name: appdaemon-data
         persistentVolumeClaim:
-          claimName: appdaemon-pvc
+          claimName: appdaemon-pvc-local
       - name: tmp
         emptyDir: {}

--- a/apps/hass/appdaemon/manifests/local-pvc.yaml
+++ b/apps/hass/appdaemon/manifests/local-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: appdaemon-pvc-local
+  namespace: hass
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: local-path

--- a/apps/hass/codeserver/kustomization.yaml
+++ b/apps/hass/codeserver/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - manifests/deployment.yaml
+  - manifests/local-pvc.yaml
   - manifests/service.yaml
   - manifests/httproute.yaml
 components:
@@ -19,7 +20,13 @@ patches:
         value: codeserver
       - op: replace
         path: /spec/sourcePVC
-        value: codeserver-pvc
+        value: codeserver-pvc-local
+      - op: replace
+        path: /spec/restic/copyMethod
+        value: Direct
+      - op: replace
+        path: /spec/restic/storageClassName
+        value: local-path
       - op: replace
         path: /spec/restic/repository
         value: codeserver-volsync-b2

--- a/apps/hass/codeserver/manifests/deployment.yaml
+++ b/apps/hass/codeserver/manifests/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 0
+  replicas: 1
   strategy:
     type: Recreate
   selector:
@@ -82,15 +82,15 @@ spec:
       volumes:
       - name: codeserver
         persistentVolumeClaim:
-          claimName: codeserver-pvc
+          claimName: codeserver-pvc-local
       - name: appdaemon-data
         persistentVolumeClaim:
-          claimName: appdaemon-pvc
+          claimName: appdaemon-pvc-local
       - name: hass-data
         persistentVolumeClaim:
-          claimName: hass-pvc
+          claimName: hass-pvc-local
       - name: zwave-data
         persistentVolumeClaim:
-          claimName: zwave-pvc
+          claimName: zwave-pvc-local
       - name: tmp
         emptyDir: {}

--- a/apps/hass/codeserver/manifests/local-pvc.yaml
+++ b/apps/hass/codeserver/manifests/local-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: codeserver-pvc-local
+  namespace: hass
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: local-path

--- a/apps/hass/hass/kustomization.yaml
+++ b/apps/hass/hass/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - manifests/namespace.yaml
   - manifests/deployment.yaml
+  - manifests/local-pvc.yaml
   - manifests/service.yaml
   - manifests/httproute.yaml
 components:
@@ -20,7 +21,13 @@ patches:
         value: hass
       - op: replace
         path: /spec/sourcePVC
-        value: hass-pvc
+        value: hass-pvc-local
+      - op: replace
+        path: /spec/restic/copyMethod
+        value: Direct
+      - op: replace
+        path: /spec/restic/storageClassName
+        value: local-path
       - op: replace
         path: /spec/restic/repository
         value: hass-volsync-b2

--- a/apps/hass/hass/manifests/deployment.yaml
+++ b/apps/hass/hass/manifests/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hass
   namespace: hass
 spec:
-  replicas: 0
+  replicas: 1
   strategy:
     type: Recreate
   selector:
@@ -55,4 +55,4 @@ spec:
       volumes:
         - name: hass-data
           persistentVolumeClaim:
-            claimName: hass-pvc
+            claimName: hass-pvc-local

--- a/apps/hass/hass/manifests/local-pvc.yaml
+++ b/apps/hass/hass/manifests/local-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hass-pvc-local
+  namespace: hass
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: local-path

--- a/apps/hass/zwave/kustomization.yaml
+++ b/apps/hass/zwave/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - manifests/deployment.yaml
+  - manifests/local-pvc.yaml
   - manifests/service.yaml
   - manifests/externalsecret.yaml
   - manifests/httproute.yaml
@@ -20,7 +21,13 @@ patches:
         value: zwave
       - op: replace
         path: /spec/sourcePVC
-        value: zwave-pvc
+        value: zwave-pvc-local
+      - op: replace
+        path: /spec/restic/copyMethod
+        value: Direct
+      - op: replace
+        path: /spec/restic/storageClassName
+        value: local-path
       - op: replace
         path: /spec/restic/repository
         value: zwave-volsync-b2

--- a/apps/hass/zwave/manifests/deployment.yaml
+++ b/apps/hass/zwave/manifests/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 0
+  replicas: 1
   strategy:
     type: Recreate
   selector:
@@ -70,4 +70,4 @@ spec:
       volumes:
       - name: zwave-data
         persistentVolumeClaim:
-          claimName: zwave-pvc
+          claimName: zwave-pvc-local

--- a/apps/hass/zwave/manifests/local-pvc.yaml
+++ b/apps/hass/zwave/manifests/local-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: zwave-pvc-local
+  namespace: hass
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: local-path

--- a/apps/mealie/kustomization.yaml
+++ b/apps/mealie/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: mealie
 resources:
   - manifests/namespace.yaml
   - manifests/deployment.yaml
+  - manifests/local-pvc.yaml
   - manifests/service.yaml
   - manifests/httproute.yaml
   - manifests/netpol.yaml
@@ -24,7 +25,13 @@ patches:
         value: mealie
       - op: replace
         path: /spec/sourcePVC
-        value: mealie-pvc
+        value: mealie-pvc-local
+      - op: replace
+        path: /spec/restic/copyMethod
+        value: Direct
+      - op: replace
+        path: /spec/restic/storageClassName
+        value: local-path
       - op: replace
         path: /spec/restic/repository
         value: mealie-volsync-b2

--- a/apps/mealie/manifests/deployment.yaml
+++ b/apps/mealie/manifests/deployment.yaml
@@ -6,9 +6,12 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 0
+  replicas: 1
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       app: mealie
@@ -85,4 +88,4 @@ spec:
       volumes:
         - name: mealie-data
           persistentVolumeClaim:
-            claimName: mealie-pvc
+            claimName: mealie-pvc-local

--- a/apps/mealie/manifests/local-pvc.yaml
+++ b/apps/mealie/manifests/local-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mealie-pvc-local
+  namespace: mealie
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: local-path

--- a/apps/portainer/kustomization.yaml
+++ b/apps/portainer/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: portainer
 resources:
   - manifests/namespace.yaml
   - manifests/deployment.yaml
+  - manifests/local-pvc.yaml
   - manifests/service.yaml
   - manifests/httproute.yaml
   - manifests/netpol.yaml
@@ -24,7 +25,13 @@ patches:
         value: portainer
       - op: replace
         path: /spec/sourcePVC
-        value: portainer-pvc
+        value: portainer-pvc-local
+      - op: replace
+        path: /spec/restic/copyMethod
+        value: Direct
+      - op: replace
+        path: /spec/restic/storageClassName
+        value: local-path
       - op: replace
         path: /spec/restic/repository
         value: portainer-volsync-b2

--- a/apps/portainer/manifests/deployment.yaml
+++ b/apps/portainer/manifests/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: portainer
   namespace: portainer
 spec:
-  replicas: 0
+  replicas: 1
   strategy:
     type: Recreate
   selector:
@@ -62,7 +62,7 @@ spec:
       volumes:
       - name: portainer-data
         persistentVolumeClaim:
-          claimName: portainer-pvc
+          claimName: portainer-pvc-local
       - name: external-wildcard
         secret:
           secretName: external-wildcard

--- a/apps/portainer/manifests/local-pvc.yaml
+++ b/apps/portainer/manifests/local-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: portainer-pvc-local
+  namespace: portainer
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: local-path

--- a/apps/unifi/unifi/kustomization.yaml
+++ b/apps/unifi/unifi/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - manifests/namespace.yaml
   - manifests/deployment.yaml
+  - manifests/local-pvc.yaml
   - manifests/service.yaml
   - manifests/httproute.yaml
   - manifests/externalsecret.yaml
@@ -30,7 +31,13 @@ patches:
         value: unifi
       - op: replace
         path: /spec/sourcePVC
-        value: unifi-pvc
+        value: unifi-pvc-local
+      - op: replace
+        path: /spec/restic/copyMethod
+        value: Direct
+      - op: replace
+        path: /spec/restic/storageClassName
+        value: local-path
       - op: replace
         path: /spec/restic/repository
         value: unifi-volsync-b2

--- a/apps/unifi/unifi/manifests/deployment.yaml
+++ b/apps/unifi/unifi/manifests/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
-  replicas: 0
+  replicas: 1
   strategy:
     type: Recreate
   selector:
@@ -153,7 +153,7 @@ spec:
       volumes:
         - name: unifi-data
           persistentVolumeClaim:
-            claimName: unifi-pvc
+            claimName: unifi-pvc-local
         - name: localtime
           hostPath:
             path: /etc/localtime

--- a/apps/unifi/unifi/manifests/local-pvc.yaml
+++ b/apps/unifi/unifi/manifests/local-pvc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: unifi-pvc-local
+  namespace: unifi
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: local-path


### PR DESCRIPTION
## Summary
- add restored local-path PVCs for the remaining app workloads still using Longhorn-backed claims
- point workloads at the local claims and scale them back to one replica
- recreate VolSync sources against the local claims with direct copy mode while keeping old Longhorn claims present for rollback

## Live prep completed
- restored all seven new local-path PVCs from Restic backups as of 2026-05-13T05:00:00Z, selecting May 12 snapshots
- HASS local PVCs are pinned on k3s-worker-0; mealie, portainer, and unifi local PVCs are pinned on k3s-worker-1

## Validation
- kustomize build --enable-helm apps/hass
- kustomize build --enable-helm apps/mealie
- kustomize build --enable-helm apps/portainer
- kustomize build --enable-helm apps/unifi
- kubectl --context default apply --server-side --dry-run=server --field-manager=argocd-controller -f rendered apps
- pre-commit run --files changed manifests