### PR TITLE
fix: pin volsync restore trigger token

### DIFF
--- a/components/volsync/b2/replicationdestination.yaml
+++ b/components/volsync/b2/replicationdestination.yaml
@@ -27,4 +27,4 @@ spec:
     storageClassName: longhorn-retain
     volumeSnapshotClassName: longhorn
   trigger:
-    manual: restore-once
+    manual: restore-20260518T224205Z


### PR DESCRIPTION
## Summary
- update the shared VolSync ReplicationDestination manual trigger token to the completed Longhorn restore token
- prevent ArgoCD from reverting the component to the stale restore-once trigger after staged PVC restores

## Validation
- rendered all seven VolSync destination consumers and confirmed Snapshot restore to longhorn-retain
- pre-commit run --files components/volsync/b2/replicationdestination.yaml apps/hass/appdaemon/kustomization.yaml apps/hass/codeserver/kustomization.yaml apps/hass/hass/kustomization.yaml apps/hass/zwave/kustomization.yaml apps/mealie/kustomization.yaml apps/portainer/kustomization.yaml apps/unifi/unifi/kustomization.yaml