### PR TITLE
fix: cut over app workloads to longhorn pvcs

### DIFF
--- a/apps/hass/appdaemon/kustomization.yaml
+++ b/apps/hass/appdaemon/kustomization.yaml
@@ -21,13 +21,7 @@ patches:
         value: appdaemon
       - op: replace
         path: /spec/sourcePVC
-        value: appdaemon-pvc-local
-      - op: replace
-        path: /spec/restic/copyMethod
-        value: Direct
-      - op: replace
-        path: /spec/restic/storageClassName
-        value: local-path
+        value: appdaemon-pvc
       - op: replace
         path: /spec/restic/repository
         value: appdaemon-volsync-b2

--- a/apps/hass/appdaemon/manifests/deployment.yaml
+++ b/apps/hass/appdaemon/manifests/deployment.yaml
@@ -70,6 +70,6 @@ spec:
       volumes:
       - name: appdaemon-data
         persistentVolumeClaim:
-          claimName: appdaemon-pvc-local
+          claimName: appdaemon-pvc
       - name: tmp
         emptyDir: {}

--- a/apps/hass/codeserver/kustomization.yaml
+++ b/apps/hass/codeserver/kustomization.yaml
@@ -20,13 +20,7 @@ patches:
         value: codeserver
       - op: replace
         path: /spec/sourcePVC
-        value: codeserver-pvc-local
-      - op: replace
-        path: /spec/restic/copyMethod
-        value: Direct
-      - op: replace
-        path: /spec/restic/storageClassName
-        value: local-path
+        value: codeserver-pvc
       - op: replace
         path: /spec/restic/repository
         value: codeserver-volsync-b2

--- a/apps/hass/codeserver/manifests/deployment.yaml
+++ b/apps/hass/codeserver/manifests/deployment.yaml
@@ -82,15 +82,15 @@ spec:
       volumes:
       - name: codeserver
         persistentVolumeClaim:
-          claimName: codeserver-pvc-local
+          claimName: codeserver-pvc
       - name: appdaemon-data
         persistentVolumeClaim:
-          claimName: appdaemon-pvc-local
+          claimName: appdaemon-pvc
       - name: hass-data
         persistentVolumeClaim:
-          claimName: hass-pvc-local
+          claimName: hass-pvc
       - name: zwave-data
         persistentVolumeClaim:
-          claimName: zwave-pvc-local
+          claimName: zwave-pvc
       - name: tmp
         emptyDir: {}

--- a/apps/hass/hass/kustomization.yaml
+++ b/apps/hass/hass/kustomization.yaml
@@ -21,13 +21,7 @@ patches:
         value: hass
       - op: replace
         path: /spec/sourcePVC
-        value: hass-pvc-local
-      - op: replace
-        path: /spec/restic/copyMethod
-        value: Direct
-      - op: replace
-        path: /spec/restic/storageClassName
-        value: local-path
+        value: hass-pvc
       - op: replace
         path: /spec/restic/repository
         value: hass-volsync-b2

--- a/apps/hass/hass/manifests/deployment.yaml
+++ b/apps/hass/hass/manifests/deployment.yaml
@@ -55,4 +55,4 @@ spec:
       volumes:
         - name: hass-data
           persistentVolumeClaim:
-            claimName: hass-pvc-local
+            claimName: hass-pvc

--- a/apps/hass/zwave/kustomization.yaml
+++ b/apps/hass/zwave/kustomization.yaml
@@ -21,13 +21,7 @@ patches:
         value: zwave
       - op: replace
         path: /spec/sourcePVC
-        value: zwave-pvc-local
-      - op: replace
-        path: /spec/restic/copyMethod
-        value: Direct
-      - op: replace
-        path: /spec/restic/storageClassName
-        value: local-path
+        value: zwave-pvc
       - op: replace
         path: /spec/restic/repository
         value: zwave-volsync-b2

--- a/apps/hass/zwave/manifests/deployment.yaml
+++ b/apps/hass/zwave/manifests/deployment.yaml
@@ -70,4 +70,4 @@ spec:
       volumes:
       - name: zwave-data
         persistentVolumeClaim:
-          claimName: zwave-pvc-local
+          claimName: zwave-pvc

--- a/apps/mealie/kustomization.yaml
+++ b/apps/mealie/kustomization.yaml
@@ -25,13 +25,7 @@ patches:
         value: mealie
       - op: replace
         path: /spec/sourcePVC
-        value: mealie-pvc-local
-      - op: replace
-        path: /spec/restic/copyMethod
-        value: Direct
-      - op: replace
-        path: /spec/restic/storageClassName
-        value: local-path
+        value: mealie-pvc
       - op: replace
         path: /spec/restic/repository
         value: mealie-volsync-b2

--- a/apps/mealie/manifests/deployment.yaml
+++ b/apps/mealie/manifests/deployment.yaml
@@ -88,4 +88,4 @@ spec:
       volumes:
         - name: mealie-data
           persistentVolumeClaim:
-            claimName: mealie-pvc-local
+            claimName: mealie-pvc

--- a/apps/portainer/kustomization.yaml
+++ b/apps/portainer/kustomization.yaml
@@ -25,13 +25,7 @@ patches:
         value: portainer
       - op: replace
         path: /spec/sourcePVC
-        value: portainer-pvc-local
-      - op: replace
-        path: /spec/restic/copyMethod
-        value: Direct
-      - op: replace
-        path: /spec/restic/storageClassName
-        value: local-path
+        value: portainer-pvc
       - op: replace
         path: /spec/restic/repository
         value: portainer-volsync-b2

--- a/apps/portainer/manifests/deployment.yaml
+++ b/apps/portainer/manifests/deployment.yaml
@@ -62,7 +62,7 @@ spec:
       volumes:
       - name: portainer-data
         persistentVolumeClaim:
-          claimName: portainer-pvc-local
+          claimName: portainer-pvc
       - name: external-wildcard
         secret:
           secretName: external-wildcard

--- a/apps/unifi/unifi/kustomization.yaml
+++ b/apps/unifi/unifi/kustomization.yaml
@@ -31,13 +31,7 @@ patches:
         value: unifi
       - op: replace
         path: /spec/sourcePVC
-        value: unifi-pvc-local
-      - op: replace
-        path: /spec/restic/copyMethod
-        value: Direct
-      - op: replace
-        path: /spec/restic/storageClassName
-        value: local-path
+        value: unifi-pvc
       - op: replace
         path: /spec/restic/repository
         value: unifi-volsync-b2

--- a/apps/unifi/unifi/manifests/deployment.yaml
+++ b/apps/unifi/unifi/manifests/deployment.yaml
@@ -153,7 +153,7 @@ spec:
       volumes:
         - name: unifi-data
           persistentVolumeClaim:
-            claimName: unifi-pvc-local
+            claimName: unifi-pvc
         - name: localtime
           hostPath:
             path: /etc/localtime


### PR DESCRIPTION
## Summary
- switch the seven restored app workloads from local-path PVCs to the restored Longhorn PVCs
- switch the seven VolSync ReplicationSources to back up the Longhorn PVCs using the shared Clone/longhorn source component defaults
- keep the existing HASS scheduling preference in place
- keep the local-path PVC manifests in place as rollback anchors for now

## Validation
- rendered all seven affected apps and confirmed workloads mount *-pvc claims
- rendered all seven ReplicationSources and confirmed sourcePVC=*-pvc, copyMethod=Clone, storageClassName=longhorn
- pre-commit run --files apps/hass/hass/manifests/deployment.yaml apps/hass/hass/kustomization.yaml apps/hass/appdaemon/kustomization.yaml apps/hass/appdaemon/manifests/deployment.yaml apps/hass/codeserver/kustomization.yaml apps/hass/codeserver/manifests/deployment.yaml apps/hass/zwave/kustomization.yaml apps/hass/zwave/manifests/deployment.yaml apps/mealie/kustomization.yaml apps/mealie/manifests/deployment.yaml apps/portainer/kustomization.yaml apps/portainer/manifests/deployment.yaml apps/unifi/unifi/kustomization.yaml apps/unifi/unifi/manifests/deployment.yaml
- server-side dry-run for apps/hass, apps/mealie, apps/portainer, apps/unifi