### PR TITLE
fix: pin volsync source trigger token

### DIFF
--- a/components/volsync/b2/replicationsource.yaml
+++ b/components/volsync/b2/replicationsource.yaml
@@ -29,4 +29,5 @@ spec:
     volumeSnapshotClassName: longhorn
   sourcePVC: app-pvc
   trigger:
+    manual: manual-20260518T232320Z
     schedule: "0 6 * * *"


### PR DESCRIPTION
## Summary
- add the completed manual backup token to the shared VolSync ReplicationSource component
- keep Git aligned with the successful post-cutover validation backups from the Longhorn PVCs

## Validation
- rendered all seven ReplicationSource consumers and confirmed manual=manual-20260518T232320Z, sourcePVC=*-pvc, copyMethod=Clone
- pre-commit run --files components/volsync/b2/replicationsource.yaml apps/hass/appdaemon/kustomization.yaml apps/hass/codeserver/kustomization.yaml apps/hass/hass/kustomization.yaml apps/hass/zwave/kustomization.yaml apps/mealie/kustomization.yaml apps/portainer/kustomization.yaml apps/unifi/unifi/kustomization.yaml