### PR TITLE
fix: skip cilium cli upgrade after takeover

### DIFF
--- a/hack/bootstrap/ansible/home-ops/tasks/network/cilium.yml
+++ b/hack/bootstrap/ansible/home-ops/tasks/network/cilium.yml
@@ -102,25 +102,16 @@
   register: home_ops_cilium_checksum
   changed_when: false
 
-- name: Read previous Cilium bootstrap checksum
-  ansible.builtin.command: "cat {{ home_ops_cilium_checksum_file }}"
-  register: home_ops_previous_cilium_checksum
-  failed_when: false
-  changed_when: false
-
-- name: Install or upgrade Cilium
+- name: Install bootstrap Cilium when absent
   ansible.builtin.command: >-
-    cilium {{ 'install' if home_ops_cilium_daemonset.rc != 0 else 'upgrade' }}
+    cilium install
     --version {{ cilium_tag }}
     --values {{ home_ops_cilium_values_file }}
   environment:
     KUBECONFIG: /etc/rancher/k3s/k3s.yaml
   register: home_ops_cilium_install
   changed_when: home_ops_cilium_install.rc == 0
-  when: >-
-    home_ops_cilium_daemonset.rc != 0 or
-    home_ops_previous_cilium_checksum.rc != 0 or
-    home_ops_previous_cilium_checksum.stdout != home_ops_cilium_checksum.stdout
+  when: home_ops_cilium_daemonset.rc != 0
 
 - name: Persist Cilium bootstrap checksum
   ansible.builtin.copy:

--- a/hack/bootstrap/tests/bats/offline-ansible.bats
+++ b/hack/bootstrap/tests/bats/offline-ansible.bats
@@ -359,6 +359,9 @@ EOF
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/node-prep/swap.yml" 'dphys-swapfile'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/node-prep/cpu-governor.yml" 'home-ops-cpu-governor'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/templates/cilium-values.yaml.j2" "cilium_iface != 'auto'"
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/network/cilium.yml" 'Install bootstrap Cilium when absent'
+  assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/network/cilium.yml" 'when: home_ops_cilium_daemonset.rc != 0'
+  assert_file_not_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/network/cilium.yml" 'cilium upgrade'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/k3s/reset-server-db.yml" 'db-before-rejoin'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/node-control-plane.sh" '--join-ip ADDRESS'
   assert_file_contains "$ROOT/hack/bootstrap/ansible/home-ops/tasks/k3s/kube-proxy-disable.yml" 'disable-kube-proxy: true'


### PR DESCRIPTION
## Summary
- stop Ansible from running `cilium upgrade` against existing ArgoCD-managed Cilium installs
- keep Ansible responsible only for bootstrap `cilium install` when the DaemonSet is absent
- add BATS coverage for the takeover invariant

## Why
Live `just ansible-run` failed after PR #2979 because the Cilium checksum changed and Ansible attempted `cilium upgrade`, but this cluster has no Cilium Helm release after ArgoCD takeover.

## Validation
- `just bootstrap-test`
- `pre-commit run --files hack/bootstrap/ansible/home-ops/tasks/network/cilium.yml hack/bootstrap/tests/bats/offline-ansible.bats`
