### PR TITLE
feat: add full node reimage orchestration

### DIFF
--- a/docs/cluster-operations.md
+++ b/docs/cluster-operations.md
@@ -133,6 +133,7 @@ Node lifecycle:
 | Render live node network reimage metadata | `just node-reimage-metadata <node> <image-url> <sha256>` |
 | Render live node Raspberry Pi image source | `just node-reimage-image-source <node>` |
 | Build live node Raspberry Pi image | `just node-reimage-build <node>` |
+| Run full live node reimage through rejoin | `just node-reimage-full <node>` |
 | Reboot a drained live node | `just node-reboot <node>` |
 | Join one explicit live node | `just node-join <node>` |
 | Finalize and uncordon one live node | `just node-uncordon <node>` |
@@ -575,6 +576,10 @@ just node-refresh-ssh-host-key k3s-worker-0
 just node-join k3s-worker-0
 just node-uncordon k3s-worker-0
 just node-reimage-plan k3s-worker-0
+just node-reimage-full k3s-worker-0
+just node-uncordon k3s-worker-0
+
+# Primitive/debug flow:
 just node-reimage-build k3s-worker-0
 just node-reimage-serve k3s-worker-0 k3s-master-0
 just node-reimage-apply k3s-worker-0
@@ -631,9 +636,17 @@ when the derived Cilium config has `kube_proxy_replacement: true`.
 
 ### Network Reimage
 
-Network reimage is a post-delete flow for Raspberry Pi nodes. The normal path
-is build, serve, drain, Longhorn eviction when needed, `node-delete`,
-`node-reimage-apply`, `node-join`, `node-uncordon`, and
+Network reimage replaces one Raspberry Pi node in place. The normal operator
+path is `node-reimage-full <node>`, then `node-uncordon <node>` after final
+inspection. The full command runs read-only reimage and storage preflights,
+builds the image before node downtime, automatically selects a healthy serve
+host, verifies the target can reach the image URL, drains, evicts Longhorn,
+deletes the Kubernetes Node, applies the one-shot network reimage, rejoins the
+node, runs host services, and cleans up the image server. It intentionally
+leaves the final uncordon manual.
+
+The primitive/debug path is build, serve, drain, Longhorn eviction when needed,
+`node-delete`, `node-reimage-apply`, `node-join`, `node-uncordon`, and
 `node-reimage-cleanup`.
 
 `node-reimage-build` renders the per-node `rpi-image-gen` source tree, builds

--- a/hack/bootstrap/AGENTS.md
+++ b/hack/bootstrap/AGENTS.md
@@ -35,8 +35,9 @@ normal app graph.
   `nodes/lib.sh`; implementation modules live under `nodes/lib/`.
   `nodes/converge.sh` is an additive-only planner/orchestrator and must
   delegate actual joins to `nodes/join.sh`. Raspberry Pi reimage build, serve,
-  apply, and cleanup helpers are phase-based primitives; they must keep
-  drain/delete/join/uncordon as explicit lifecycle gates.
+  apply, and cleanup helpers are phase-based primitives. The full reimage
+  orchestrator may compose the proven drain/evict/delete/apply/join path for
+  one live node, but final uncordon must remain an explicit operator gate.
 - `tests/bats/`: offline BATS tests for parsing, rendering, Ansible command
   construction, node lifecycle helpers, and bootstrap library helpers.
 - `tests/helpers/`: BATS fixture and assertion helpers.

--- a/hack/bootstrap/ansible/lib/host-services.sh
+++ b/hack/bootstrap/ansible/lib/host-services.sh
@@ -191,7 +191,7 @@ ansible_load_host_service_secrets_from_op() {
     fi
   done < <(ansible_host_service_secret_vars "$role")
 
-  ansible_bool "$needs_op" || return
+  ansible_bool "$needs_op" || return 0
 
   command -v op >/dev/null 2>&1 || return 0
   if [[ -n "${BOOTSTRAP_ANSIBLE_HOST_SERVICES_ITEM_JSON:-}" ]]; then

--- a/hack/bootstrap/nodes/lib/reimage-orchestrate.sh
+++ b/hack/bootstrap/nodes/lib/reimage-orchestrate.sh
@@ -4,6 +4,7 @@ NODE_REIMAGE_BUILD_SCHEMA="home-ops.node-reimage-build/v1"
 NODE_REIMAGE_SERVE_SCHEMA="home-ops.node-reimage-serve/v1"
 NODE_REIMAGE_APPLY_SCHEMA="home-ops.node-reimage-apply/v1"
 NODE_REIMAGE_CLEANUP_SCHEMA="home-ops.node-reimage-cleanup/v1"
+NODE_REIMAGE_FULL_SCHEMA="home-ops.node-reimage-full/v1"
 NODE_REIMAGE_BUILDER_NAME="${NODE_REIMAGE_BUILDER_NAME:-home-ops-rpi-image-builder}"
 NODE_REIMAGE_BUILDER_CPUS="${NODE_REIMAGE_BUILDER_CPUS:-6}"
 NODE_REIMAGE_BUILDER_MEMORY_GIB="${NODE_REIMAGE_BUILDER_MEMORY_GIB:-8}"
@@ -18,6 +19,17 @@ NODE_REIMAGE_FIRSTBOOT_POLL_SECONDS="${NODE_REIMAGE_FIRSTBOOT_POLL_SECONDS:-10}"
 NODE_REIMAGE_STAGE_BIN="${NODE_REIMAGE_STAGE_BIN:-${NODE_SCRIPT_DIR}/reimage-stage.sh}"
 NODE_REIMAGE_REBOOT_BIN="${NODE_REIMAGE_REBOOT_BIN:-${NODE_SCRIPT_DIR}/reimage-reboot.sh}"
 NODE_REFRESH_SSH_HOST_KEY_BIN="${NODE_REFRESH_SSH_HOST_KEY_BIN:-${NODE_SCRIPT_DIR}/refresh-ssh-host-key.sh}"
+NODE_REIMAGE_PLAN_BIN="${NODE_REIMAGE_PLAN_BIN:-${NODE_SCRIPT_DIR}/reimage-plan.sh}"
+NODE_REIMAGE_BUILD_BIN="${NODE_REIMAGE_BUILD_BIN:-${NODE_SCRIPT_DIR}/reimage-build.sh}"
+NODE_REIMAGE_SERVE_BIN="${NODE_REIMAGE_SERVE_BIN:-${NODE_SCRIPT_DIR}/reimage-serve.sh}"
+NODE_REIMAGE_APPLY_BIN="${NODE_REIMAGE_APPLY_BIN:-${NODE_SCRIPT_DIR}/reimage-apply.sh}"
+NODE_REIMAGE_CLEANUP_BIN="${NODE_REIMAGE_CLEANUP_BIN:-${NODE_SCRIPT_DIR}/reimage-cleanup.sh}"
+NODE_DRAIN_BIN="${NODE_DRAIN_BIN:-${NODE_SCRIPT_DIR}/drain.sh}"
+NODE_LONGHORN_EVICT_BIN="${NODE_LONGHORN_EVICT_BIN:-${NODE_SCRIPT_DIR}/longhorn-evict.sh}"
+NODE_DELETE_BIN="${NODE_DELETE_BIN:-${NODE_SCRIPT_DIR}/delete.sh}"
+NODE_JOIN_BIN="${NODE_JOIN_BIN:-${NODE_SCRIPT_DIR}/join.sh}"
+NODE_CONTROL_PLANE_DELETE_PREFLIGHT_BIN="${NODE_CONTROL_PLANE_DELETE_PREFLIGHT_BIN:-${NODE_SCRIPT_DIR}/control-plane-delete-preflight.sh}"
+NODE_ANSIBLE_HOST_SERVICES_BIN="${NODE_ANSIBLE_HOST_SERVICES_BIN:-${BOOTSTRAP_DIR}/ansible/host-services.sh}"
 
 node_reimage_node_dir() {
   local profile="$1"
@@ -43,6 +55,10 @@ node_reimage_apply_state_file() {
 
 node_reimage_cleanup_state_file() {
   printf '%s/cleanup.json\n' "$(node_reimage_state_dir "$1" "$2")"
+}
+
+node_reimage_full_state_file() {
+  printf '%s/full.json\n' "$(node_reimage_state_dir "$1" "$2")"
 }
 
 node_reimage_resolve_existing_inventory_node() {
@@ -430,6 +446,207 @@ node_reimage_write_cleanup_state() {
       remoteDir: $remoteDir
     }' > "$state_file"
   printf '%s\n' "$state_file"
+}
+
+node_reimage_write_full_state() {
+  local profile="$1"
+  local inventory_node="$2"
+  local context="$3"
+  local role="$4"
+  local serve_host="$5"
+  local status="$6"
+  local host_services_status="$7"
+  local state_file
+
+  state_file="$(node_reimage_full_state_file "$profile" "$inventory_node")"
+  mkdir -p "$(dirname "$state_file")"
+  # shellcheck disable=SC2016
+  "$NODE_JQ_BIN" -n \
+    --arg schema "$NODE_REIMAGE_FULL_SCHEMA" \
+    --arg completedAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    --arg profile "$profile" \
+    --arg context "$context" \
+    --arg node "$inventory_node" \
+    --arg role "$role" \
+    --arg serveHost "$serve_host" \
+    --arg status "$status" \
+    --argjson hostServicesStatus "$host_services_status" \
+    '{
+      schemaVersion: $schema,
+      completedAt: $completedAt,
+      profile: $profile,
+      context: $context,
+      node: $node,
+      role: $role,
+      serveHost: $serveHost,
+      status: $status,
+      hostServicesStatus: $hostServicesStatus
+    }' > "$state_file"
+  printf '%s\n' "$state_file"
+}
+
+node_reimage_local_path_pv_report() {
+  local context="$1"
+  local node="$2"
+  local pv_json
+
+  if ! pv_json="$(node_get_json "$context" pv 2>/dev/null)"; then
+    node_warn "local-path PVs not readable in ${context}; continuing without local-path report"
+    return 0
+  fi
+
+  # shellcheck disable=SC2016
+  "$NODE_JQ_BIN" -r --arg node "$node" '
+    .items[]?
+    | select((.spec.storageClassName // "") == "local-path")
+    | [
+        .spec.nodeAffinity.required.nodeSelectorTerms[]?.matchExpressions[]?
+        | select((.key // "") == "kubernetes.io/hostname")
+        | select((.operator // "In") == "In")
+        | .values[]?
+      ] as $node_names
+    | select($node_names | index($node))
+    | "\(.metadata.name) namespace=\(.spec.claimRef.namespace // "-") pvc=\(.spec.claimRef.name // "-") path=\(.spec.local.path // "-")"
+  ' <<<"$pv_json"
+}
+
+node_reimage_ready_inventory_candidates() {
+  local profile="$1"
+  local context="$2"
+  local target_inventory_node="$3"
+  local group inventory_node kubernetes_node node_json
+
+  for group in master node; do
+    while IFS= read -r inventory_node; do
+      [[ -n "$inventory_node" ]] || continue
+      [[ "$inventory_node" != "$target_inventory_node" ]] || continue
+      kubernetes_node="$(node_expected_kubernetes_node_name "$profile" "$inventory_node" "$inventory_node")"
+      node_json="$(node_node_json_if_present "$context" "$kubernetes_node")"
+      [[ -n "$node_json" ]] || continue
+      [[ "$(node_ready_from_node_json <<<"$node_json")" == Ready ]] || continue
+      printf '%s\n' "$inventory_node"
+    done < <(node_inventory_group_names "$profile" "$group")
+  done
+}
+
+node_reimage_probe_serve_host() {
+  local profile="$1"
+  local inventory_node="$2"
+  local host_address="$3"
+  local port="$4"
+  local host_address_q port_q remote_script
+
+  node_reimage_ssh_ok "$profile" "$inventory_node" || return 1
+
+  printf -v host_address_q '%q' "$host_address"
+  printf -v port_q '%q' "$port"
+  read -r -d '' remote_script <<EOF || true
+set -eu
+command -v python3 >/dev/null 2>&1 || {
+  printf 'serve_probe_error=missing_python3\n'
+  exit 2
+}
+python3 - ${host_address_q} ${port_q} <<'PY'
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+try:
+    sock.bind((host, port))
+except OSError as exc:
+    print(f"serve_probe_error=port_unavailable:{exc}")
+    sys.exit(2)
+finally:
+    sock.close()
+print("serve_probe=ok")
+PY
+EOF
+
+  node_run_remote_shell "$(node_ansible_inventory_file "$profile")" "$inventory_node" "$remote_script" >/dev/null
+}
+
+node_reimage_select_serve_host() {
+  local profile="$1"
+  local context="$2"
+  local target_inventory_node="$3"
+  local port="$4"
+  local candidate host_address
+
+  while IFS= read -r candidate; do
+    [[ -n "$candidate" ]] || continue
+    host_address="$(node_reimage_target_address "$profile" "$candidate")"
+    if node_reimage_probe_serve_host "$profile" "$candidate" "$host_address" "$port"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+    node_warn "serve host candidate unavailable: ${candidate}"
+  done < <(node_reimage_ready_inventory_candidates "$profile" "$context" "$target_inventory_node")
+
+  node_die "no Ready inventory node can serve the reimage artifact for ${target_inventory_node}"
+}
+
+node_reimage_assert_target_can_fetch() {
+  local profile="$1"
+  local inventory_node="$2"
+  local image_url="$3"
+  local image_url_q remote_script
+
+  printf -v image_url_q '%q' "$image_url"
+  read -r -d '' remote_script <<EOF || true
+set -eu
+image_url=${image_url_q}
+if command -v curl >/dev/null 2>&1; then
+  curl -fsI --max-time 20 "\$image_url" >/dev/null
+elif command -v wget >/dev/null 2>&1; then
+  wget -q --spider --timeout=20 "\$image_url"
+else
+  printf 'fetch_probe_error=missing_curl_or_wget\n'
+  exit 2
+fi
+printf 'fetch_probe=ok\n'
+EOF
+
+  node_run_remote_shell "$(node_ansible_inventory_file "$profile")" "$inventory_node" "$remote_script" >/dev/null
+}
+
+node_reimage_assert_host_service_inputs() {
+  local profile="$1"
+  local role="$2"
+  local var missing=()
+
+  [[ "$profile" == live ]] || return 0
+
+  # shellcheck source=hack/bootstrap/ansible/lib.sh
+  source "${BOOTSTRAP_DIR}/ansible/lib.sh"
+  ansible_load_host_service_secrets_from_op "$role"
+
+  while IFS= read -r var; do
+    [[ -n "$var" ]] || continue
+    if [[ -z "${!var:-}" ]]; then
+      missing+=("$var")
+    fi
+  done < <(ansible_host_service_secret_vars "$role")
+
+  if ((${#missing[@]} > 0)); then
+    {
+      printf 'ERROR: missing host service secret environment values for %s:\n' "$role"
+      printf '  - %s\n' "${missing[@]}"
+      printf 'Create fields with these exact names in op://%s/%s, or export them before running node-reimage-full.\n' \
+        "$BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_VAULT" \
+        "$BOOTSTRAP_ANSIBLE_HOST_SERVICES_OP_ITEM"
+    } >&2
+    exit 1
+  fi
+
+  if ansible_host_service_needs_github_runner "$role"; then
+    ansible_require_tool openssl
+    if ! ansible_github_app_private_key | openssl pkey -noout >/dev/null 2>&1; then
+      node_die "HOME_OPS_GITHUB_APP_PRIVATE_KEY is not a valid base64-encoded PEM private key"
+    fi
+  fi
 }
 
 node_reimage_ansible_copy() {

--- a/hack/bootstrap/nodes/lib/reimage-orchestrate.sh
+++ b/hack/bootstrap/nodes/lib/reimage-orchestrate.sh
@@ -14,6 +14,10 @@ NODE_REIMAGE_BUILDER_MODE="${NODE_REIMAGE_BUILDER_MODE:-auto}"
 NODE_REIMAGE_DEFAULT_PORT="${NODE_REIMAGE_DEFAULT_PORT:-18080}"
 NODE_REIMAGE_SSH_DOWN_TIMEOUT_SECONDS="${NODE_REIMAGE_SSH_DOWN_TIMEOUT_SECONDS:-180}"
 NODE_REIMAGE_SSH_UP_TIMEOUT_SECONDS="${NODE_REIMAGE_SSH_UP_TIMEOUT_SECONDS:-1800}"
+NODE_REIMAGE_APPLY_OBSERVE_PING="${NODE_REIMAGE_APPLY_OBSERVE_PING:-true}"
+NODE_REIMAGE_PING_DOWN_TIMEOUT_SECONDS="${NODE_REIMAGE_PING_DOWN_TIMEOUT_SECONDS:-300}"
+NODE_REIMAGE_PING_UP_TIMEOUT_SECONDS="${NODE_REIMAGE_PING_UP_TIMEOUT_SECONDS:-900}"
+NODE_REIMAGE_PING_FINAL_DOWN_TIMEOUT_SECONDS="${NODE_REIMAGE_PING_FINAL_DOWN_TIMEOUT_SECONDS:-120}"
 NODE_REIMAGE_FIRSTBOOT_TIMEOUT_SECONDS="${NODE_REIMAGE_FIRSTBOOT_TIMEOUT_SECONDS:-300}"
 NODE_REIMAGE_FIRSTBOOT_POLL_SECONDS="${NODE_REIMAGE_FIRSTBOOT_POLL_SECONDS:-10}"
 NODE_REIMAGE_STAGE_BIN="${NODE_REIMAGE_STAGE_BIN:-${NODE_SCRIPT_DIR}/reimage-stage.sh}"
@@ -740,6 +744,106 @@ node_reimage_wait_port_up() {
     sleep 10
   done
   node_die "timed out waiting for ${host}:${port} to come up"
+}
+
+node_reimage_ping_once() {
+  local host="$1"
+
+  command -v ping >/dev/null 2>&1 || return 2
+  case "$(uname -s)" in
+    Darwin)
+      ping -n -c 1 -W 2000 "$host" >/dev/null 2>&1
+      ;;
+    Linux)
+      ping -n -c 1 -W 2 "$host" >/dev/null 2>&1
+      ;;
+    *)
+      ping -n -c 1 "$host" >/dev/null 2>&1
+      ;;
+  esac
+}
+
+node_reimage_wait_ping_down() {
+  local host="$1"
+  local timeout="$2"
+  local port="${3:-}"
+  local deadline
+
+  deadline=$((SECONDS + timeout))
+  while true; do
+    if ! node_reimage_ping_once "$host"; then
+      return 0
+    fi
+    if [[ -n "$port" ]] && nc -z -w 1 "$host" "$port" >/dev/null 2>&1; then
+      return 2
+    fi
+    ((SECONDS >= deadline)) && return 1
+    sleep 5
+  done
+}
+
+node_reimage_wait_ping_up() {
+  local host="$1"
+  local timeout="$2"
+  local deadline
+
+  deadline=$((SECONDS + timeout))
+  while true; do
+    if node_reimage_ping_once "$host"; then
+      return 0
+    fi
+    ((SECONDS >= deadline)) && return 1
+    sleep 5
+  done
+}
+
+node_reimage_observe_ping_reimage_progress() {
+  local host="$1"
+
+  if [[ "$NODE_REIMAGE_APPLY_OBSERVE_PING" != true ]]; then
+    node_warn "NODE_REIMAGE_APPLY_OBSERVE_PING is not true; skipping ping-based progress logs"
+    return 0
+  fi
+  if ! command -v ping >/dev/null 2>&1; then
+    node_warn "ping is not available; skipping ping-based progress logs"
+    return 0
+  fi
+
+  node_log "waiting for ping to go down on ${host}; node is rebooting into reimage payload"
+  if node_reimage_wait_ping_down "$host" "$NODE_REIMAGE_PING_DOWN_TIMEOUT_SECONDS"; then
+    node_log "ping is down on ${host}; tryboot reboot is in progress"
+  else
+    node_warn "timed out waiting for ping to go down on ${host}; continuing to SSH wait"
+    return 0
+  fi
+
+  node_log "waiting for ping to return on ${host}; initramfs should be applying image"
+  if node_reimage_wait_ping_up "$host" "$NODE_REIMAGE_PING_UP_TIMEOUT_SECONDS"; then
+    node_log "ping is back on ${host}; initramfs payload is likely downloading/writing image"
+  else
+    node_warn "timed out waiting for ping to return on ${host}; continuing to SSH wait"
+    return 0
+  fi
+
+  node_log "waiting for ping to go down again on ${host}; image write should complete before final reboot"
+  set +e
+  node_reimage_wait_ping_down "$host" "$NODE_REIMAGE_PING_FINAL_DOWN_TIMEOUT_SECONDS" 22
+  final_ping_status=$?
+  set -e
+  case "$final_ping_status" in
+    0)
+      node_log "ping is down again on ${host}; image was likely applied and node is rebooting into new OS"
+      ;;
+    1)
+      node_warn "timed out waiting for final ping-down transition on ${host}; continuing to SSH wait"
+      ;;
+    2)
+      node_log "SSH is already reachable on ${host}; final ping-down transition was missed"
+      ;;
+    *)
+      node_warn "unexpected final ping observer status ${final_ping_status}; continuing to SSH wait"
+      ;;
+  esac
 }
 
 node_reimage_wait_ssh_auth() {

--- a/hack/bootstrap/nodes/reimage-apply.sh
+++ b/hack/bootstrap/nodes/reimage-apply.sh
@@ -101,6 +101,8 @@ if [[ "${NODE_REIMAGE_APPLY_SKIP_WAIT:-false}" == true ]]; then
 else
   node_log "waiting for SSH to go down on ${target_address}"
   node_reimage_wait_port_down "$target_address" 22 "$NODE_REIMAGE_SSH_DOWN_TIMEOUT_SECONDS"
+  node_log "SSH is down on ${target_address}; observing ping transitions during reimage"
+  node_reimage_observe_ping_reimage_progress "$target_address"
   node_log "waiting for SSH to come back on ${target_address}"
   node_reimage_wait_port_up "$target_address" 22 "$NODE_REIMAGE_SSH_UP_TIMEOUT_SECONDS"
   node_log "refreshing SSH host key for ${inventory_node}"

--- a/hack/bootstrap/nodes/reimage-full.sh
+++ b/hack/bootstrap/nodes/reimage-full.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=hack/bootstrap/nodes/lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: hack/bootstrap/nodes/reimage-full.sh [options] NODE
+
+Build, serve, drain, delete, network-reimage, rejoin, and clean up one live
+Raspberry Pi node. The node is left joined, cordoned, and temporarily tainted;
+run the uncordon helper after final operator inspection.
+
+Options:
+  --profile NAME      Node lifecycle profile. Only live is supported in v1.
+  --context NAME      Kubernetes context. Defaults to the profile context.
+  --serve-host NODE   Healthy inventory node to host the image. Defaults to auto.
+  --port PORT         HTTP port on the serve host. Defaults to 18080.
+  --yes               Skip confirmation prompt.
+  -h, --help          Show help.
+EOF
+}
+
+profile=live
+context=""
+serve_host=""
+port="$NODE_REIMAGE_DEFAULT_PORT"
+yes=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      profile="$2"
+      shift 2
+      ;;
+    --context)
+      context="$2"
+      shift 2
+      ;;
+    --serve-host)
+      serve_host="$2"
+      shift 2
+      ;;
+    --port)
+      port="$2"
+      shift 2
+      ;;
+    --yes)
+      yes=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      node_die "unknown argument: $1"
+      ;;
+    *)
+      if [[ -n "${node_name:-}" ]]; then
+        node_die "only one node may be provided"
+      fi
+      node_name="$1"
+      shift
+      ;;
+  esac
+done
+
+[[ -n "${node_name:-}" ]] || node_die "NODE is required"
+node_validate_profile "$profile"
+[[ "$profile" == live ]] || node_die "node-reimage-full currently supports only the live profile"
+context="${context:-$(node_context_for_profile "$profile")}"
+[[ "$port" =~ ^[0-9]+$ ]] || node_die "port must be numeric: ${port}"
+
+node_require_tool "$NODE_KUBECTL_BIN"
+node_require_tool "$NODE_YQ_BIN"
+node_require_tool "$NODE_JQ_BIN"
+node_require_tool ansible
+node_require_tool ssh
+
+IFS=$'\t' read -r inventory_node inventory_role < <(
+  node_reimage_resolve_existing_inventory_node "$profile" "$node_name"
+)
+kubernetes_node="$(node_expected_kubernetes_node_name "$profile" "$inventory_node" "$node_name")"
+
+lock_dir="$(node_reimage_image_output_root)/${profile}/.full.lock"
+serve_started=false
+destructive_started=false
+cleanup_completed=false
+
+on_exit() {
+  local status=$?
+  if [[ "$status" -ne 0 && "$serve_started" == true && "$destructive_started" == false ]]; then
+    node_warn "cleaning up image server because reimage-full failed before node deletion"
+    "$NODE_REIMAGE_CLEANUP_BIN" --profile "$profile" --yes "$inventory_node" || true
+    cleanup_completed=true
+  elif [[ "$status" -ne 0 && "$serve_started" == true && "$cleanup_completed" == false ]]; then
+    node_warn "image server may still be running; when safe, run: just node-reimage-cleanup ${inventory_node}"
+  fi
+  if [[ -d "$lock_dir" ]]; then
+    rm -f "${lock_dir}/info"
+    rmdir "$lock_dir" 2>/dev/null || true
+  fi
+}
+trap on_exit EXIT
+
+mkdir -p "$(dirname "$lock_dir")"
+if ! mkdir "$lock_dir" 2>/dev/null; then
+  node_die "another node-reimage-full appears to be running: ${lock_dir}"
+fi
+printf 'node=%s\ncontext=%s\nstarted_at=%s\n' \
+  "$inventory_node" \
+  "$context" \
+  "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" > "${lock_dir}/info"
+
+node_log "phase: preflight"
+node_assert_api_reachable "$context"
+node_json="$(node_node_json_if_present "$context" "$kubernetes_node")"
+[[ -n "$node_json" ]] || node_die "Kubernetes node must exist before full reimage: ${kubernetes_node}"
+node_assert_ready "$node_json" "$kubernetes_node"
+joining_taint="$(node_joining_taint_from_node_json <<<"$node_json")"
+[[ "$joining_taint" == absent ]] ||
+  node_die "Kubernetes node already has a joining taint; finish or repair prior lifecycle state: ${kubernetes_node}"
+
+node_log "phase: reimage-plan"
+"$NODE_REIMAGE_PLAN_BIN" --profile "$profile" --context "$context" "$inventory_node"
+
+node_log "validating live Raspberry Pi and target disk identity"
+disk_path="$(node_reimage_inventory_disk_path "$profile" "$inventory_node")"
+probe="$(node_reimage_probe_host "$profile" "$inventory_node" "$disk_path")"
+node_reimage_validate_probe "$profile" "$inventory_node" "$probe"
+
+node_log "checking host-service secret inputs"
+node_reimage_assert_host_service_inputs "$profile" "$inventory_role"
+
+if [[ "$inventory_role" == master ]]; then
+  node_log "running control-plane delete preflight"
+  "$NODE_CONTROL_PLANE_DELETE_PREFLIGHT_BIN" --profile "$profile" --context "$context" "$inventory_node"
+fi
+
+node_log "checking Longhorn replacement readiness"
+node_assert_longhorn_replacement_ready "$context"
+
+local_path_report="$(node_reimage_local_path_pv_report "$context" "$kubernetes_node" | sed '/^$/d')"
+if [[ -n "$local_path_report" ]]; then
+  node_warn "local-path PVs are bound to ${kubernetes_node}; network reimage destroys their node-local data"
+  node_indent_block <<<"$local_path_report" >&2
+fi
+
+if [[ -n "$serve_host" ]]; then
+  IFS=$'\t' read -r serve_host serve_host_role < <(node_reimage_resolve_existing_inventory_node "$profile" "$serve_host")
+  case "$serve_host_role" in
+    master|node)
+      ;;
+    *)
+      node_die "serve host is not present in ${profile} inventory: ${serve_host}"
+      ;;
+  esac
+  [[ "$serve_host" != "$inventory_node" ]] ||
+    node_die "serve host must not be the node being reimaged: ${inventory_node}"
+  serve_host_address="$(node_reimage_target_address "$profile" "$serve_host")"
+  node_reimage_probe_serve_host "$profile" "$serve_host" "$serve_host_address" "$port" ||
+    node_die "explicit serve host is not usable: ${serve_host}"
+else
+  node_log "selecting image serve host"
+  serve_host="$(node_reimage_select_serve_host "$profile" "$context" "$inventory_node" "$port")"
+fi
+
+node_log "selected image serve host: ${serve_host}"
+
+node_log "phase: build"
+"$NODE_REIMAGE_BUILD_BIN" --profile "$profile" "$inventory_node"
+
+node_log "phase: serve"
+"$NODE_REIMAGE_SERVE_BIN" --profile "$profile" --port "$port" --yes "$inventory_node" "$serve_host"
+serve_started=true
+serve_state="$(node_reimage_serve_state_file "$profile" "$inventory_node")"
+image_url="$(node_reimage_read_state_value "$serve_state" '.imageUrl')"
+sha256="$(node_reimage_read_state_value "$serve_state" '.sha256')"
+
+node_log "verifying target can reach image URL before drain"
+node_reimage_assert_target_can_fetch "$profile" "$inventory_node" "$image_url"
+
+cat <<EOF
+
+node-reimage-full summary:
+  context: ${context}
+  target: ${inventory_node}
+  role: ${inventory_role}
+  serve_host: ${serve_host}
+  image_url: ${image_url}
+  sha256: ${sha256}
+  final_uncordon: operator-run
+EOF
+node_confirm "$yes" "reimage ${inventory_node} in ${context}"
+
+destructive_started=true
+
+node_log "phase: drain"
+"$NODE_DRAIN_BIN" --profile "$profile" --context "$context" --yes "$inventory_node"
+
+node_log "phase: longhorn-evict"
+"$NODE_LONGHORN_EVICT_BIN" --profile "$profile" --context "$context" --yes "$inventory_node"
+
+node_log "phase: delete"
+"$NODE_DELETE_BIN" --profile "$profile" --context "$context" --yes "$inventory_node"
+
+node_log "phase: apply"
+"$NODE_REIMAGE_APPLY_BIN" --profile "$profile" --context "$context" --yes "$inventory_node"
+
+node_log "phase: join"
+"$NODE_JOIN_BIN" --profile "$profile" --context "$context" --yes "$inventory_node"
+
+host_services_status=0
+node_log "phase: host-services"
+if "$NODE_ANSIBLE_HOST_SERVICES_BIN" --yes "$inventory_node"; then
+  :
+else
+  host_services_status=$?
+  node_warn "host-services failed after Kubernetes join; retry with: just ansible-host-services ${inventory_node}"
+fi
+
+node_log "phase: cleanup"
+"$NODE_REIMAGE_CLEANUP_BIN" --profile "$profile" --yes "$inventory_node"
+cleanup_completed=true
+
+if [[ "$host_services_status" -eq 0 ]]; then
+  full_status=complete
+else
+  full_status="host-services-failed"
+fi
+full_state="$(node_reimage_write_full_state \
+  "$profile" \
+  "$inventory_node" \
+  "$context" \
+  "$inventory_role" \
+  "$serve_host" \
+  "$full_status" \
+  "$host_services_status")"
+
+printf 'full_state=%s\n' "$full_state"
+printf 'next=%s\n' "just node-status ${inventory_node} && just node-uncordon ${inventory_node}"
+
+if [[ "$host_services_status" -ne 0 ]]; then
+  exit "$host_services_status"
+fi

--- a/hack/bootstrap/reimage/README.md
+++ b/hack/bootstrap/reimage/README.md
@@ -51,6 +51,22 @@ Debian 13 Trixie
 
 ## Build The Image
 
+For the proven rolling replacement path, use the full orchestrator:
+
+```sh
+just node-reimage-full k3s-worker-0
+just node-uncordon k3s-worker-0
+```
+
+`node-reimage-full` runs the safety preflights, builds before node downtime,
+selects a healthy serve host automatically, verifies target-to-server
+reachability, drains, evicts Longhorn, deletes the Kubernetes Node, applies the
+network reimage, rejoins the node, runs host services, and cleans up the image
+server. It leaves final uncordon to the operator.
+
+The remaining commands are the primitive flow for debugging or manual
+resumption.
+
 Build the image with the orchestrated builder:
 
 ```sh

--- a/hack/bootstrap/reimage/README.md
+++ b/hack/bootstrap/reimage/README.md
@@ -124,6 +124,10 @@ just node-reimage-apply k3s-worker-0
 SSH to go down and return, refreshes the host key, and waits for
 `/var/lib/home-ops/firstboot-complete`. Ping can return before SSH is ready,
 and SSH can return before firstboot has finished.
+Between SSH going down and returning, it also logs best-effort ping
+transitions: initial reboot into tryboot, initramfs image application, and final
+reboot into the new OS. These ping logs are operator progress hints only; the
+success gates remain SSH authentication and the firstboot marker.
 
 Keep the image server running until the reimaging node has fetched the full
 image. The server log is recorded in `state/serve.json`.

--- a/hack/bootstrap/tests/bats/offline-nodes.bats
+++ b/hack/bootstrap/tests/bats/offline-nodes.bats
@@ -855,8 +855,8 @@ true'" > "$script"
   assert_output_contains 'staged reimage manifest targetDiskSerial mismatch'
 }
 
-@test "node reimage apply uses recorded serve state and refreshes host key" {
-  local node_dir artifact metadata sha calls fake_stage fake_reboot fake_refresh fake_nc fake_ssh
+@test "node reimage apply uses recorded serve state, observes ping transitions, and refreshes host key" {
+  local node_dir artifact metadata sha calls fake_stage fake_reboot fake_refresh fake_nc fake_ping fake_ssh
   write_fake_ansible
   node_dir="${tmp}/reimage-out/live/k3s-worker-0"
   mkdir -p "${node_dir}/state"
@@ -886,6 +886,7 @@ EOF
   fake_reboot="${tmp}/reboot"
   fake_refresh="${tmp}/refresh"
   fake_nc="${tmp}/nc"
+  fake_ping="${tmp}/ping"
   fake_ssh="${tmp}/ssh"
   cat > "$fake_stage" <<'EOF'
 #!/usr/bin/env bash
@@ -908,30 +909,88 @@ if [[ -f "$count_file" ]]; then
 fi
 count=$((count + 1))
 printf '%s\n' "$count" > "$count_file"
-if ((count == 1)); then
-  exit 1
+if [[ "${NC_MODE:-normal}" == "final_ssh_early" ]]; then
+  case "$count" in
+    1)
+      exit 1
+      ;;
+    2|3)
+      exit 0
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
 fi
-exit 0
+
+case "$count" in
+  1)
+    exit 1
+    ;;
+  2)
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+  cat > "$fake_ping" <<'EOF'
+#!/usr/bin/env bash
+count_file="${PING_COUNT_FILE:?}"
+count=0
+if [[ -f "$count_file" ]]; then
+  count="$(cat "$count_file")"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$count_file"
+printf 'ping %s\n' "$*" >>"${CALLS_FILE:?}"
+case "$count" in
+  1|3|4)
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
 EOF
   cat > "$fake_ssh" <<'EOF'
 #!/usr/bin/env bash
 printf 'ssh %s\n' "$*" >>"${CALLS_FILE:?}"
 EOF
-  chmod +x "$fake_stage" "$fake_reboot" "$fake_refresh" "$fake_nc" "$fake_ssh"
+  chmod +x "$fake_stage" "$fake_reboot" "$fake_refresh" "$fake_nc" "$fake_ping" "$fake_ssh"
 
   run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_REIMAGE_OUTPUT_ROOT="${tmp}/reimage-out" \
     NODE_REIMAGE_STAGE_BIN="$fake_stage" NODE_REIMAGE_REBOOT_BIN="$fake_reboot" NODE_REFRESH_SSH_HOST_KEY_BIN="$fake_refresh" \
-    NODE_REIMAGE_SSH_DOWN_TIMEOUT_SECONDS=5 NODE_REIMAGE_SSH_UP_TIMEOUT_SECONDS=5 CALLS_FILE="$calls" NC_COUNT_FILE="${tmp}/nc-count" \
+    NODE_REIMAGE_SSH_DOWN_TIMEOUT_SECONDS=5 NODE_REIMAGE_SSH_UP_TIMEOUT_SECONDS=5 \
+    NODE_REIMAGE_PING_DOWN_TIMEOUT_SECONDS=5 NODE_REIMAGE_PING_UP_TIMEOUT_SECONDS=5 NODE_REIMAGE_PING_FINAL_DOWN_TIMEOUT_SECONDS=5 \
+    CALLS_FILE="$calls" NC_COUNT_FILE="${tmp}/nc-count" PING_COUNT_FILE="${tmp}/ping-count" \
     "${ROOT}/hack/bootstrap/nodes/reimage-apply.sh" --profile live --context test --force --yes k3s-worker-0
   assert_success
   assert_output_contains 'apply_state='
+  assert_output_contains 'SSH is down on 192.168.99.20; observing ping transitions during reimage'
+  assert_output_contains 'ping is down on 192.168.99.20; tryboot reboot is in progress'
+  assert_output_contains 'ping is back on 192.168.99.20; initramfs payload is likely downloading/writing image'
+  assert_output_contains 'ping is down again on 192.168.99.20; image was likely applied and node is rebooting into new OS'
   assert_output_contains 'verifying generated image boot marker'
   assert_output_contains 'next=just node-join k3s-worker-0 && just node-uncordon k3s-worker-0'
   assert_file_contains "$calls" 'stage --profile live --context test --metadata-file'
   assert_file_contains "$calls" 'reboot --profile live --context test --yes --force k3s-worker-0'
   assert_file_contains "$calls" 'refresh --profile live --yes k3s-worker-0'
+  assert_file_contains "$calls" 'ping -n -c 1'
   assert_file_contains "$calls" 'ssh -o BatchMode=yes'
   [[ -f "${node_dir}/state/apply.json" ]]
+
+  rm -f "$calls" "${tmp}/nc-count" "${tmp}/ping-count" "${node_dir}/state/apply.json"
+  run env PATH="${tmp}:${PATH}" NODE_LIVE_INVENTORY_DIR="$inventory" NODE_REIMAGE_OUTPUT_ROOT="${tmp}/reimage-out" \
+    NODE_REIMAGE_STAGE_BIN="$fake_stage" NODE_REIMAGE_REBOOT_BIN="$fake_reboot" NODE_REFRESH_SSH_HOST_KEY_BIN="$fake_refresh" \
+    NODE_REIMAGE_SSH_DOWN_TIMEOUT_SECONDS=5 NODE_REIMAGE_SSH_UP_TIMEOUT_SECONDS=5 \
+    NODE_REIMAGE_PING_DOWN_TIMEOUT_SECONDS=5 NODE_REIMAGE_PING_UP_TIMEOUT_SECONDS=5 NODE_REIMAGE_PING_FINAL_DOWN_TIMEOUT_SECONDS=30 \
+    CALLS_FILE="$calls" NC_COUNT_FILE="${tmp}/nc-count" PING_COUNT_FILE="${tmp}/ping-count" NC_MODE=final_ssh_early \
+    "${ROOT}/hack/bootstrap/nodes/reimage-apply.sh" --profile live --context test --force --yes k3s-worker-0
+  assert_success
+  assert_output_contains 'SSH is already reachable on 192.168.99.20; final ping-down transition was missed'
+  assert_output_contains 'refreshing SSH host key for k3s-worker-0'
 }
 
 @test "node reimage generated-image verification waits for firstboot marker" {

--- a/hack/bootstrap/tests/bats/offline-nodes.bats
+++ b/hack/bootstrap/tests/bats/offline-nodes.bats
@@ -138,6 +138,10 @@ EOF
   assert_success
   assert_output_contains "./hack/bootstrap/nodes/reimage-build.sh --profile live 'k3s-worker-0' --ssh-public-key /tmp/ansiblekey.pub"
 
+  run just --dry-run node-reimage-full k3s-worker-0
+  assert_success
+  assert_output_contains "./hack/bootstrap/nodes/reimage-full.sh --profile live --context default 'k3s-worker-0'"
+
   run just --dry-run node-reimage-stage k3s-worker-0 https://images.example/k3s-worker-0.img.xz "$sha" --force
   assert_success
   assert_output_contains "./hack/bootstrap/nodes/reimage-stage.sh --profile live --context default 'k3s-worker-0' 'https://images.example/k3s-worker-0.img.xz' '${sha}' --force"
@@ -210,6 +214,126 @@ EOF
   assert_output_contains 'next_inventory_values:'
   assert_output_contains 'home_ops_reimage_pi_serial: 10000000deadbeef'
   assert_output_contains 'home_ops_reimage_disk_serial: nvme-deadbeef'
+}
+
+@test "node reimage full helpers report local-path PVs and prefer ready control-plane serve hosts" {
+  write_reimage_full_kubectl
+
+  run env NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_reimage_full_kubectl" \
+    bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_reimage_local_path_pv_report test k3s-worker-0"
+  assert_success
+  assert_output_contains 'pv-local namespace=default pvc=app-pvc path=/var/lib/rancher/k3s/storage/pvc-local_default_app'
+
+  run env NODE_LIVE_INVENTORY_DIR="$inventory" NODE_KUBECTL_BIN="$fake_reimage_full_kubectl" \
+    bash -c "source '${ROOT}/hack/bootstrap/nodes/lib.sh'; node_reimage_ready_inventory_candidates live test k3s-worker-0 | paste -sd, -"
+  assert_success
+  [[ "$output" == "k3s-master-0,k3s-master-1,k3s-master-2" ]]
+}
+
+@test "node reimage full orchestrates through join and leaves uncordon manual" {
+  local calls fake_plan fake_preflight fake_build fake_serve fake_drain fake_evict fake_delete fake_apply fake_join fake_host_services fake_cleanup fake_ssh
+  add_reimage_identity k3s-master-0 10000000deadbeef nvme-deadbeef
+  write_reimage_full_kubectl
+  write_fake_ansible
+
+  calls="${tmp}/reimage-full-calls"
+  fake_plan="${tmp}/plan"
+  fake_preflight="${tmp}/preflight"
+  fake_build="${tmp}/build"
+  fake_serve="${tmp}/serve"
+  fake_drain="${tmp}/drain"
+  fake_evict="${tmp}/evict"
+  fake_delete="${tmp}/delete"
+  fake_apply="${tmp}/apply"
+  fake_join="${tmp}/join"
+  fake_host_services="${tmp}/host-services"
+  fake_cleanup="${tmp}/cleanup"
+  fake_ssh="${tmp}/ssh"
+
+  cat > "$fake_plan" <<'EOF'
+#!/usr/bin/env bash
+printf 'plan %s\n' "$*" >>"${CALLS_FILE:?}"
+printf 'profile: live\n'
+EOF
+  cat > "$fake_preflight" <<'EOF'
+#!/usr/bin/env bash
+printf 'preflight %s\n' "$*" >>"${CALLS_FILE:?}"
+printf 'preflight_result: pass\n'
+EOF
+  cat > "$fake_build" <<'EOF'
+#!/usr/bin/env bash
+printf 'build %s\n' "$*" >>"${CALLS_FILE:?}"
+EOF
+  cat > "$fake_serve" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'serve %s\n' "$*" >>"${CALLS_FILE:?}"
+node="${@: -2:1}"
+state_dir="${NODE_REIMAGE_OUTPUT_ROOT:?}/live/${node}/state"
+mkdir -p "$state_dir"
+jq -n \
+  --arg imageUrl "http://192.168.99.11:18080/home-ops-${node}.img.zst" \
+  '{schemaVersion:"home-ops.node-reimage-serve/v1", imageUrl:$imageUrl, sha256:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", metadataPath:"/tmp/metadata.json"}' \
+  > "${state_dir}/serve.json"
+EOF
+  for spec in \
+    "$fake_drain:drain" \
+    "$fake_evict:evict" \
+    "$fake_delete:delete" \
+    "$fake_apply:apply" \
+    "$fake_join:join" \
+    "$fake_host_services:host-services" \
+    "$fake_cleanup:cleanup" \
+    "$fake_ssh:ssh"; do
+    path="${spec%%:*}"
+    label="${spec#*:}"
+    cat > "$path" <<EOF
+#!/usr/bin/env bash
+printf '${label} %s\n' "\$*" >>"\${CALLS_FILE:?}"
+EOF
+  done
+  chmod +x "$fake_plan" "$fake_preflight" "$fake_build" "$fake_serve" "$fake_drain" "$fake_evict" "$fake_delete" "$fake_apply" "$fake_join" "$fake_host_services" "$fake_cleanup" "$fake_ssh"
+
+  run env PATH="${tmp}:${PATH}" \
+    NODE_LIVE_INVENTORY_DIR="$inventory" \
+    NODE_KUBECTL_BIN="$fake_reimage_full_kubectl" \
+    NODE_REIMAGE_OUTPUT_ROOT="${tmp}/reimage-out" \
+    NODE_REIMAGE_PLAN_BIN="$fake_plan" \
+    NODE_CONTROL_PLANE_DELETE_PREFLIGHT_BIN="$fake_preflight" \
+    NODE_REIMAGE_BUILD_BIN="$fake_build" \
+    NODE_REIMAGE_SERVE_BIN="$fake_serve" \
+    NODE_DRAIN_BIN="$fake_drain" \
+    NODE_LONGHORN_EVICT_BIN="$fake_evict" \
+    NODE_DELETE_BIN="$fake_delete" \
+    NODE_REIMAGE_APPLY_BIN="$fake_apply" \
+    NODE_JOIN_BIN="$fake_join" \
+    NODE_ANSIBLE_HOST_SERVICES_BIN="$fake_host_services" \
+    NODE_REIMAGE_CLEANUP_BIN="$fake_cleanup" \
+    HOME_OPS_RPI_REPORTER_MQTT_HOSTNAME=mqtt.example \
+    HOME_OPS_RPI_REPORTER_MQTT_USERNAME=reporter \
+    HOME_OPS_RPI_REPORTER_MQTT_PASSWORD=password \
+    HOME_OPS_NUT_MONITOR_SYSTEM=ups \
+    HOME_OPS_NUT_MONITOR_USER=upsmon \
+    HOME_OPS_NUT_MONITOR_PASSWORD=password \
+    CALLS_FILE="$calls" \
+    "${ROOT}/hack/bootstrap/nodes/reimage-full.sh" --profile live --context test --yes k3s-master-0
+  assert_success
+  assert_output_contains 'selected image serve host: k3s-master-1'
+  assert_output_contains 'final_uncordon: operator-run'
+  assert_output_contains 'next=just node-status k3s-master-0 && just node-uncordon k3s-master-0'
+  assert_file_contains "$calls" 'plan --profile live --context test k3s-master-0'
+  assert_file_contains "$calls" 'preflight --profile live --context test k3s-master-0'
+  assert_file_contains "$calls" 'build --profile live k3s-master-0'
+  assert_file_contains "$calls" 'serve --profile live --port 18080 --yes k3s-master-0 k3s-master-1'
+  assert_file_contains "$calls" 'drain --profile live --context test --yes k3s-master-0'
+  assert_file_contains "$calls" 'evict --profile live --context test --yes k3s-master-0'
+  assert_file_contains "$calls" 'delete --profile live --context test --yes k3s-master-0'
+  assert_file_contains "$calls" 'apply --profile live --context test --yes k3s-master-0'
+  assert_file_contains "$calls" 'join --profile live --context test --yes k3s-master-0'
+  assert_file_contains "$calls" 'host-services --yes k3s-master-0'
+  assert_file_contains "$calls" 'cleanup --profile live --yes k3s-master-0'
+  assert_file_not_contains "$calls" 'uncordon'
+  [[ -f "${tmp}/reimage-out/live/k3s-master-0/state/full.json" ]]
 }
 
 @test "node reimage metadata renders stage-compatible image metadata" {
@@ -1613,6 +1737,7 @@ EOF
     hack/bootstrap/nodes/reimage-plan.sh \
     hack/bootstrap/nodes/reimage-stage.sh \
     hack/bootstrap/nodes/reimage-reboot.sh \
+    hack/bootstrap/nodes/reimage-full.sh \
     hack/bootstrap/nodes/refresh-ssh-host-key.sh \
     hack/bootstrap/ansible/node-control-plane.sh; do
     run "${ROOT}/${script}" --help

--- a/hack/bootstrap/tests/helpers/nodes.bash
+++ b/hack/bootstrap/tests/helpers/nodes.bash
@@ -786,6 +786,101 @@ EOF
   chmod +x "$fake_reimage_kubectl"
 }
 
+write_reimage_full_kubectl() {
+  fake_reimage_full_kubectl="${tmp}/kubectl-reimage-full"
+  cat > "$fake_reimage_full_kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--context" ]]; then
+  shift 2
+fi
+
+node_json() {
+  local node_name="$1"
+  local role="$2"
+  local labels='{}'
+  if [[ "$role" == master ]]; then
+    labels='{"node-role.kubernetes.io/control-plane":"true"}'
+  fi
+  cat <<JSON
+{
+  "metadata": {
+    "name": "${node_name}",
+    "labels": ${labels}
+  },
+  "spec": {},
+  "status": {
+    "conditions": [
+      {"type": "Ready", "status": "True"}
+    ],
+    "nodeInfo": {
+      "kubeletVersion": "v1.35.4+k3s1"
+    }
+  }
+}
+JSON
+}
+
+if [[ "${1:-}" == "get" && "${2:-}" == "--raw=/readyz" ]]; then
+  printf 'ok\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "crd" && "${3:-}" == "volumes.longhorn.io" ]]; then
+  printf 'Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "volumes.longhorn.io" not found\n' >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "pv" ]]; then
+  cat <<'JSON'
+{
+  "items": [
+    {
+      "metadata": {"name": "pv-local"},
+      "spec": {
+        "storageClassName": "local-path",
+        "local": {"path": "/var/lib/rancher/k3s/storage/pvc-local_default_app"},
+        "claimRef": {"namespace": "default", "name": "app-pvc"},
+        "nodeAffinity": {
+          "required": {
+            "nodeSelectorTerms": [
+              {
+                "matchExpressions": [
+                  {
+                    "key": "kubernetes.io/hostname",
+                    "operator": "In",
+                    "values": ["k3s-worker-0"]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}
+JSON
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" =~ ^node/k3s-master-[0-2]$ ]]; then
+  node_json "${2#node/}" master
+  exit 0
+fi
+
+if [[ "${1:-}" == "get" && "${2:-}" == "node/k3s-worker-0" ]]; then
+  node_json k3s-worker-0 node
+  exit 0
+fi
+
+printf 'unexpected fake reimage-full kubectl args: %s\n' "$*" >&2
+exit 1
+EOF
+  chmod +x "$fake_reimage_full_kubectl"
+}
+
 write_reboot_kubectl() {
   fake_reboot_kubectl="${tmp}/kubectl-reboot"
   cat > "$fake_reboot_kubectl" <<'EOF'

--- a/justfile
+++ b/justfile
@@ -432,6 +432,11 @@ node-reimage-image-source node +args='':
 node-reimage-build node +args='':
     ./hack/bootstrap/nodes/reimage-build.sh --profile live '{{ node }}' {{ args }}
 
+# Run the full live reimage flow through join, leaving final uncordon to the operator.
+[group('node-reimage')]
+node-reimage-full node:
+    ./hack/bootstrap/nodes/reimage-full.sh --profile live --context default '{{ node }}'
+
 # Plan additive-only live node convergence from inventory.
 [group('node')]
 node-converge-plan:


### PR DESCRIPTION
## Summary
- add `node-reimage-full` to orchestrate the proven one-node reimage flow through rejoin while leaving final uncordon manual
- select a healthy image serve host automatically, validate target reachability, and record full-run state
- add best-effort ping transition logging during reimage apply, with SSH and firstboot remaining the real success gates
- update reimage docs, cluster operations docs, and offline BATS coverage

## Validation
- `just bootstrap-test`
- review agent approved the orchestration implementation
- review agent approved the ping-transition enhancement after fixes
- live-tested successfully by reimaging `k3s-worker-0` with the new wrapper