### PR TITLE
feat: adopt reimaged nodes into os plan

### DIFF
--- a/docs/cluster-operations.md
+++ b/docs/cluster-operations.md
@@ -642,8 +642,9 @@ inspection. The full command runs read-only reimage and storage preflights,
 builds the image before node downtime, automatically selects a healthy serve
 host, verifies the target can reach the image URL, drains, evicts Longhorn,
 deletes the Kubernetes Node, applies the one-shot network reimage, rejoins the
-node, runs host services, and cleans up the image server. It intentionally
-leaves the final uncordon manual.
+node, labels it with the current system-upgrade Plan hash, runs host services,
+and cleans up the image server. It intentionally leaves the final uncordon
+manual.
 
 The primitive/debug path is build, serve, drain, Longhorn eviction when needed,
 `node-delete`, `node-reimage-apply`, `node-join`, `node-uncordon`, and

--- a/hack/bootstrap/README.md
+++ b/hack/bootstrap/README.md
@@ -313,8 +313,11 @@ on Linux it can run directly. `node-reimage-serve` hosts the recorded artifact
 from an explicit healthy inventory node, `node-reimage-apply` stages and
 tryboot-reboots the deleted node from recorded serve state, and
 waits for SSH plus the generated-image firstboot marker before reporting
-success. `node-reimage-cleanup` removes the node-specific remote hosting
-directory. By default the payload is built on the target from its current
+success. The full reimage flow labels the rejoined node with the current
+system-upgrade Plan hash so it is adopted by future OS updates without
+rerunning the already-applied revision. `node-reimage-cleanup` removes the
+node-specific remote hosting directory. By default the payload is built on the
+target from its current
 Raspberry Pi initramfs, so it keeps the matching kernel modules and
 boot-network tooling.
 

--- a/hack/bootstrap/nodes/lib/reimage-orchestrate.sh
+++ b/hack/bootstrap/nodes/lib/reimage-orchestrate.sh
@@ -20,6 +20,7 @@ NODE_REIMAGE_PING_UP_TIMEOUT_SECONDS="${NODE_REIMAGE_PING_UP_TIMEOUT_SECONDS:-90
 NODE_REIMAGE_PING_FINAL_DOWN_TIMEOUT_SECONDS="${NODE_REIMAGE_PING_FINAL_DOWN_TIMEOUT_SECONDS:-120}"
 NODE_REIMAGE_FIRSTBOOT_TIMEOUT_SECONDS="${NODE_REIMAGE_FIRSTBOOT_TIMEOUT_SECONDS:-300}"
 NODE_REIMAGE_FIRSTBOOT_POLL_SECONDS="${NODE_REIMAGE_FIRSTBOOT_POLL_SECONDS:-10}"
+NODE_REIMAGE_OS_PLAN_MANIFEST="${NODE_REIMAGE_OS_PLAN_MANIFEST:-${REPO_ROOT}/apps/system-upgrade/manifests/os-plan.yaml}"
 NODE_REIMAGE_STAGE_BIN="${NODE_REIMAGE_STAGE_BIN:-${NODE_SCRIPT_DIR}/reimage-stage.sh}"
 NODE_REIMAGE_REBOOT_BIN="${NODE_REIMAGE_REBOOT_BIN:-${NODE_SCRIPT_DIR}/reimage-reboot.sh}"
 NODE_REFRESH_SSH_HOST_KEY_BIN="${NODE_REFRESH_SSH_HOST_KEY_BIN:-${NODE_SCRIPT_DIR}/refresh-ssh-host-key.sh}"
@@ -651,6 +652,90 @@ node_reimage_assert_host_service_inputs() {
       node_die "HOME_OPS_GITHUB_APP_PRIVATE_KEY is not a valid base64-encoded PEM private key"
     fi
   fi
+}
+
+node_reimage_system_upgrade_plan_config() {
+  local manifest="$NODE_REIMAGE_OS_PLAN_MANIFEST"
+  local name namespace keys key_count label_key
+
+  [[ -f "$manifest" ]] || {
+    printf 'missing system-upgrade Plan manifest: %s\n' "$manifest" >&2
+    return 1
+  }
+
+  name="$("$NODE_YQ_BIN" -r '
+    select(.apiVersion == "upgrade.cattle.io/v1" and .kind == "Plan")
+    | .metadata.name // ""
+  ' "$manifest")"
+  namespace="$("$NODE_YQ_BIN" -r '
+    select(.apiVersion == "upgrade.cattle.io/v1" and .kind == "Plan")
+    | .metadata.namespace // "system-upgrade"
+  ' "$manifest")"
+  keys="$(
+    "$NODE_YQ_BIN" -r '
+      select(.apiVersion == "upgrade.cattle.io/v1" and .kind == "Plan")
+      | .spec.nodeSelector.matchExpressions[]?
+      | select((.operator // "") == "Exists")
+      | .key // ""
+    ' "$manifest" |
+      awk '/^plan[.]upgrade[.]cattle[.]io\// {print}' |
+      sort -u
+  )"
+
+  [[ -n "$name" && "$name" != "null" ]] || {
+    printf 'system-upgrade Plan manifest has no Plan metadata.name: %s\n' "$manifest" >&2
+    return 1
+  }
+  [[ -n "$namespace" && "$namespace" != "null" ]] || {
+    printf 'system-upgrade Plan manifest has no namespace: %s\n' "$manifest" >&2
+    return 1
+  }
+
+  key_count="$(sed '/^$/d' <<<"$keys" | wc -l | tr -d ' ')"
+  [[ "$key_count" == 1 ]] || {
+    printf 'expected exactly one plan.upgrade.cattle.io Exists selector in %s, found %s\n' \
+      "$manifest" \
+      "$key_count" >&2
+    return 1
+  }
+  label_key="$(sed -n '1p' <<<"$keys")"
+
+  printf '%s\t%s\t%s\n' "$namespace" "$name" "$label_key"
+}
+
+node_reimage_adopt_system_upgrade_plan() {
+  local context="$1"
+  local node="$2"
+  local config namespace plan_name label_key plan_json latest_hash latest_version version_suffix output
+
+  if ! config="$(node_reimage_system_upgrade_plan_config 2>&1)"; then
+    node_warn "system-upgrade Plan adoption skipped: ${config}"
+    return 0
+  fi
+  IFS=$'\t' read -r namespace plan_name label_key <<<"$config"
+
+  if ! plan_json="$(node_get_json "$context" -n "$namespace" "plan/${plan_name}" 2>/dev/null)"; then
+    node_warn "system-upgrade Plan adoption skipped: live Plan ${namespace}/${plan_name} is not readable"
+    return 0
+  fi
+
+  latest_hash="$("$NODE_JQ_BIN" -r '.status.latestHash // ""' <<<"$plan_json")"
+  latest_version="$("$NODE_JQ_BIN" -r '.status.latestVersion // ""' <<<"$plan_json")"
+  [[ -n "$latest_hash" && "$latest_hash" != "null" ]] || {
+    node_warn "system-upgrade Plan adoption skipped: live Plan ${namespace}/${plan_name} has no status.latestHash"
+    return 0
+  }
+
+  version_suffix=""
+  if [[ -n "$latest_version" && "$latest_version" != "null" ]]; then
+    version_suffix=" (${latest_version})"
+  fi
+  node_log "adopting ${node} into system-upgrade Plan ${namespace}/${plan_name}${version_suffix}"
+  if ! output="$(node_kubectl "$context" label "node/${node}" "${label_key}=${latest_hash}" --overwrite 2>&1)"; then
+    node_warn "system-upgrade Plan adoption failed: ${output}"
+    return 0
+  fi
+  printf '%s\n' "$output"
 }
 
 node_reimage_ansible_copy() {

--- a/hack/bootstrap/nodes/reimage-full.sh
+++ b/hack/bootstrap/nodes/reimage-full.sh
@@ -212,6 +212,9 @@ node_log "phase: apply"
 node_log "phase: join"
 "$NODE_JOIN_BIN" --profile "$profile" --context "$context" --yes "$inventory_node"
 
+node_log "phase: os-plan-adopt"
+node_reimage_adopt_system_upgrade_plan "$context" "$kubernetes_node"
+
 host_services_status=0
 node_log "phase: host-services"
 if "$NODE_ANSIBLE_HOST_SERVICES_BIN" --yes "$inventory_node"; then

--- a/hack/bootstrap/reimage/README.md
+++ b/hack/bootstrap/reimage/README.md
@@ -61,8 +61,9 @@ just node-uncordon k3s-worker-0
 `node-reimage-full` runs the safety preflights, builds before node downtime,
 selects a healthy serve host automatically, verifies target-to-server
 reachability, drains, evicts Longhorn, deletes the Kubernetes Node, applies the
-network reimage, rejoins the node, runs host services, and cleans up the image
-server. It leaves final uncordon to the operator.
+network reimage, rejoins the node, labels it with the current system-upgrade
+Plan hash, runs host services, and cleans up the image server. It leaves final
+uncordon to the operator.
 
 The remaining commands are the primitive flow for debugging or manual
 resumption.

--- a/hack/bootstrap/tests/bats/offline-nodes.bats
+++ b/hack/bootstrap/tests/bats/offline-nodes.bats
@@ -319,6 +319,8 @@ EOF
     "${ROOT}/hack/bootstrap/nodes/reimage-full.sh" --profile live --context test --yes k3s-master-0
   assert_success
   assert_output_contains 'selected image serve host: k3s-master-1'
+  assert_output_contains 'phase: os-plan-adopt'
+  assert_output_contains 'adopting k3s-master-0 into system-upgrade Plan system-upgrade/raspios-trixie (trixie-2026-05-14)'
   assert_output_contains 'final_uncordon: operator-run'
   assert_output_contains 'next=just node-status k3s-master-0 && just node-uncordon k3s-master-0'
   assert_file_contains "$calls" 'plan --profile live --context test k3s-master-0'
@@ -330,6 +332,7 @@ EOF
   assert_file_contains "$calls" 'delete --profile live --context test --yes k3s-master-0'
   assert_file_contains "$calls" 'apply --profile live --context test --yes k3s-master-0'
   assert_file_contains "$calls" 'join --profile live --context test --yes k3s-master-0'
+  assert_file_contains "$calls" 'kubectl label node/k3s-master-0 plan.upgrade.cattle.io/raspios-trixie=e602e6d2122f6d49ec99bf659b5495436f6fdb75792a18f7ba1420a0 --overwrite'
   assert_file_contains "$calls" 'host-services --yes k3s-master-0'
   assert_file_contains "$calls" 'cleanup --profile live --yes k3s-master-0'
   assert_file_not_contains "$calls" 'uncordon'

--- a/hack/bootstrap/tests/helpers/nodes.bash
+++ b/hack/bootstrap/tests/helpers/nodes.bash
@@ -865,6 +865,24 @@ JSON
   exit 0
 fi
 
+if [[ "${1:-}" == "get" && "${2:-}" == "-n" && "${3:-}" == "system-upgrade" && "${4:-}" == "plan/raspios-trixie" ]]; then
+  cat <<'JSON'
+{
+  "apiVersion": "upgrade.cattle.io/v1",
+  "kind": "Plan",
+  "metadata": {
+    "name": "raspios-trixie",
+    "namespace": "system-upgrade"
+  },
+  "status": {
+    "latestHash": "e602e6d2122f6d49ec99bf659b5495436f6fdb75792a18f7ba1420a0",
+    "latestVersion": "trixie-2026-05-14"
+  }
+}
+JSON
+  exit 0
+fi
+
 if [[ "${1:-}" == "get" && "${2:-}" =~ ^node/k3s-master-[0-2]$ ]]; then
   node_json "${2#node/}" master
   exit 0
@@ -872,6 +890,14 @@ fi
 
 if [[ "${1:-}" == "get" && "${2:-}" == "node/k3s-worker-0" ]]; then
   node_json k3s-worker-0 node
+  exit 0
+fi
+
+if [[ "${1:-}" == "label" && "${2:-}" =~ ^node/k3s- && "${4:-}" == "--overwrite" ]]; then
+  if [[ -n "${CALLS_FILE:-}" ]]; then
+    printf 'kubectl %s\n' "$*" >>"$CALLS_FILE"
+  fi
+  printf '%s labeled\n' "$2"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- label reimaged nodes with the current system-upgrade Plan latestHash after node-join
- skip with a warning if the Plan manifest, live Plan, or latestHash cannot be read
- document the adoption behavior and cover it in the offline reimage-full test

## Validation
- just bootstrap-test
- review agent approval: no findings
- live test: reimaged k3s-worker-1 successfully with no issues