### PR TITLE
fix: trust mise config for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -140,6 +140,12 @@
       allowedVersions: '<4',
     },
     {
+      description: 'Keep 1Password CLI pinned until Renovate can resolve its mise backend cleanly',
+      matchManagers: ['mise'],
+      matchPackageNames: ['1password/cli', 'op'],
+      enabled: false,
+    },
+    {
       description: 'Automerge mise-managed tool minor/patch updates',
       matchManagers: ['mise'],
       matchUpdateTypes: ['minor','patch'],

--- a/apps/renovate/manifests/renovatejob.yaml
+++ b/apps/renovate/manifests/renovatejob.yaml
@@ -25,6 +25,8 @@ spec:
       value: enabled
     - name: RENOVATE_REPOSITORY_CACHE_TYPE
       value: "s3://renovate-cache"
+    - name: RENOVATE_CUSTOM_ENV_VARIABLES
+      value: '{"MISE_TRUSTED_CONFIG_PATHS":"/tmp/repos/github/sholdee/home-ops"}'
     - name: AWS_REGION
       value: garage
     - name: AWS_ENDPOINT_URL


### PR DESCRIPTION
## Summary
- pass MISE_TRUSTED_CONFIG_PATHS through Renovate custom env so mise lock artifact updates can run in Renovate's checkout
- disable Renovate updates for the 1Password CLI mise tool until Renovate can resolve that backend cleanly

## Validation
- mise exec -- pre-commit run --files .github/renovate.json5 apps/renovate/manifests/renovatejob.yaml
- git diff --check