### PR TITLE
fix: bootstrap pipx before mise toolchain

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -53,6 +53,9 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        export PATH="${HOME}/.local/share/mise/shims:${PATH}"
+        mise install --locked --yes pipx
+        mise reshim
         mise install --locked --yes
         mise reshim
         echo "${HOME}/.local/share/mise/shims" >> "${GITHUB_PATH}"

--- a/mise.lock
+++ b/mise.lock
@@ -202,6 +202,22 @@ url = "https://cache.agilebits.com/dist/1P/op2/pkg/v2.34.0/op_linux_amd64_v2.34.
 [tools.op."platforms.macos-arm64"]
 url = "https://cache.agilebits.com/dist/1P/op2/pkg/v2.34.0/op_darwin_arm64_v2.34.0.zip"
 
+[[tools.pipx]]
+version = "1.12.0"
+backend = "aqua:pypa/pipx"
+
+[tools.pipx."platforms.linux-arm64"]
+checksum = "sha256:f7492089d576f1ed04a56ab60d3f8918da4a3c951fa5c6631ce3f5a804deac51"
+url = "https://github.com/pypa/pipx/releases/download/1.12.0/pipx.pyz"
+
+[tools.pipx."platforms.linux-x64"]
+checksum = "sha256:f7492089d576f1ed04a56ab60d3f8918da4a3c951fa5c6631ce3f5a804deac51"
+url = "https://github.com/pypa/pipx/releases/download/1.12.0/pipx.pyz"
+
+[tools.pipx."platforms.macos-arm64"]
+checksum = "sha256:f7492089d576f1ed04a56ab60d3f8918da4a3c951fa5c6631ce3f5a804deac51"
+url = "https://github.com/pypa/pipx/releases/download/1.12.0/pipx.pyz"
+
 [[tools."pipx:ansible-lint"]]
 version = "26.4.0"
 backend = "pipx:ansible-lint"

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,7 @@
 # Core validation and command UX.
 python = "3.14"
 just = "1.51.0"
+pipx = "1.12.0"
 "pipx:pre-commit" = "4.6.0"
 shellcheck = "0.11.0"
 bats = "1.13.0"


### PR DESCRIPTION
## Summary
- add pipx as a pinned mise-managed tool
- install and reshim pipx before the full locked toolchain so pipx-backed tools work on self-hosted runners

## Validation
- mise exec -- pre-commit run --files .github/actions/setup-mise/action.yml mise.toml mise.lock
- git diff --check