### PR TITLE
chore: add operator CLIs to mise

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -4,75 +4,114 @@ name: Setup mise toolchain
 description: Install the locked repository toolchain with mise
 
 inputs:
-  mise-version:
-    description: mise version
-    # renovate: datasource=github-releases depName=jdx/mise extractVersion=^v(?<version>.+)$
-    default: '2026.5.12'
+  profile:
+    description: Tool profile to install. One of all, pre-commit, bootstrap-test, helm-diff, image, operator.
+    default: all
 
 runs:
   using: composite
   steps:
-    - name: Cache mise tools
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-      with:
-        path: |
-          ~/.cache/mise
-          ~/.local/share/mise
-        key: mise-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.toml', 'mise.lock') }}
-        restore-keys: |
-          mise-${{ runner.os }}-${{ runner.arch }}-
-
-    - name: Install mise
+    - name: Resolve mise profile
+      id: profile
       shell: bash
       env:
-        MISE_VERSION: ${{ inputs.mise-version }}
+        MISE_PROFILE: ${{ inputs.profile }}
       run: |
         set -euo pipefail
 
-        case "$(uname -s)-$(uname -m)" in
-          Linux-x86_64)
-            asset="linux-x64"
+        case "${MISE_PROFILE}" in
+          all)
+            tools=(
+              python just pipx pipx:pre-commit shellcheck bats actionlint kubeconform
+              kubectl argocd github:cloudnative-pg/cloudnative-pg kustomize helm yq jq
+              ansible-core pipx:ansible-lint kind lima op gh
+            )
             ;;
-          Linux-aarch64|Linux-arm64)
-            asset="linux-arm64"
+          pre-commit)
+            tools=(python pipx pipx:pre-commit shellcheck actionlint kubeconform kustomize helm yq jq)
+            ;;
+          bootstrap-test)
+            tools=(python just shellcheck bats yq jq kustomize helm ansible-core)
+            ;;
+          helm-diff)
+            tools=(helm kustomize yq jq)
+            ;;
+          image)
+            tools=(python jq)
+            ;;
+          operator)
+            tools=(kubectl argocd github:cloudnative-pg/cloudnative-pg)
             ;;
           *)
-            echo "unsupported runner platform: $(uname -s)-$(uname -m)" >&2
+            echo "unsupported mise profile: ${MISE_PROFILE}" >&2
             exit 1
             ;;
         esac
 
-        mkdir -p "${HOME}/.local/bin"
-        curl -fsSLo /tmp/mise "https://github.com/jdx/mise/releases/download/v${MISE_VERSION}/mise-v${MISE_VERSION}-${asset}"
-        install -m 0755 /tmp/mise "${HOME}/.local/bin/mise"
-        export PATH="${HOME}/.local/bin:${PATH}"
-        echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-        mise --version
+        printf 'tools=%s\n' "${tools[*]}" >> "${GITHUB_OUTPUT}"
+        printf 'HOME_OPS_MISE_TOOLS=%s\n' "${tools[*]}" >> "${GITHUB_ENV}"
+
+    - name: Restore mise tools cache
+      id: mise-cache
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ~/.cache/mise
+          ~/.local/share/mise
+        key: mise-${{ runner.os }}-${{ runner.arch }}-${{ inputs.profile }}-${{ hashFiles('mise.toml', 'mise.lock', '.github/actions/setup-mise/action.yml') }}
+        restore-keys: |
+          mise-${{ runner.os }}-${{ runner.arch }}-${{ inputs.profile }}-
+
+    - name: Setup mise
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+      with:
+        install: false
+        install_args: ${{ steps.profile.outputs.tools }}
+        cache: false
+        experimental: true
+        github_token: ${{ github.token }}
 
     - name: Install locked toolchain
       shell: bash
       run: |
         set -euo pipefail
-        export PATH="${HOME}/.local/share/mise/shims:${PATH}"
-        mise install --locked --yes pipx
+        read -r -a tools <<< "${HOME_OPS_MISE_TOOLS}"
+
+        requires_pipx=false
+        for tool in "${tools[@]}"; do
+          if [[ "${tool}" == "pipx" || "${tool}" == pipx:* ]]; then
+            requires_pipx=true
+          fi
+        done
+
+        if [[ "${requires_pipx}" == "true" ]]; then
+          mise install --locked --yes python pipx
+          mise reshim
+        fi
+
+        mise install --locked --yes "${tools[@]}"
         mise reshim
-        mise install --locked --yes
-        mise reshim
-        echo "${HOME}/.local/share/mise/shims" >> "${GITHUB_PATH}"
+
+    - name: Save mise tools cache
+      if: steps.mise-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ~/.cache/mise
+          ~/.local/share/mise
+        key: mise-${{ runner.os }}-${{ runner.arch }}-${{ inputs.profile }}-${{ hashFiles('mise.toml', 'mise.lock', '.github/actions/setup-mise/action.yml') }}
 
     - name: Verify mise toolchain
       shell: bash
       run: |
         set -euo pipefail
-        mise exec -- just --version
-        mise exec -- python3 --version
-        mise exec -- helm version --short
-        mise exec -- kustomize version
-        mise exec -- kubectl version --client=true
-        mise exec -- yq --version
-        mise exec -- jq --version
-        mise exec -- ansible --version
-        mise exec -- ansible-lint --version
-        mise exec -- pre-commit --version
-        mise exec -- shellcheck --version
-        mise exec -- bats --version
+        read -r -a tools <<< "${HOME_OPS_MISE_TOOLS}"
+
+        missing="$(mise ls --missing --current --no-header "${tools[@]}")"
+        if [[ -n "${missing}" ]]; then
+          echo "missing mise tools after install:" >&2
+          echo "${missing}" >&2
+          exit 1
+        fi
+
+        mise ls --installed --current --no-header "${tools[@]}"

--- a/.github/workflows/bootstrap-test.yml
+++ b/.github/workflows/bootstrap-test.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Install mise toolchain
         uses: ./.github/actions/setup-mise
+        with:
+          profile: bootstrap-test
 
       - name: Check justfile formatting
         run: just --fmt --check

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -13,14 +13,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  warm-caches:
+  warm-pre-commit:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install mise toolchain
+      - name: Warm pre-commit mise tools
         uses: ./.github/actions/setup-mise
+        with:
+          profile: pre-commit
 
       - name: Warm pre-commit environment cache
         shell: bash
@@ -30,3 +32,14 @@ jobs:
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-4|${{ runner.os }}-${{ runner.arch }}|${{ hashFiles('.pre-commit-config.yaml', 'mise.toml', 'mise.lock') }}
+
+  warm-bootstrap-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Warm bootstrap-test mise tools
+        uses: ./.github/actions/setup-mise
+        with:
+          profile: bootstrap-test

--- a/.github/workflows/helm-diff.yml
+++ b/.github/workflows/helm-diff.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Install mise toolchain
         uses: ./.github/actions/setup-mise
+        with:
+          profile: helm-diff
 
       - name: Prepare base worktree
         run: |
@@ -126,6 +128,8 @@ jobs:
 
       - name: Install mise toolchain
         uses: ./.github/actions/setup-mise
+        with:
+          profile: image
 
       - name: Extract Image Updates from Helm Diff
         id: extract_helm_images

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Install mise toolchain
         uses: ./.github/actions/setup-mise
+        with:
+          profile: pre-commit
 
       - name: Run pre-commit
         uses: ./.github/actions/run-pre-commit

--- a/.github/workflows/pull-image.yml
+++ b/.github/workflows/pull-image.yml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Install mise toolchain
         uses: ./.github/actions/setup-mise
+        with:
+          profile: image
 
       - name: Extract Image, Tag, and Digest from PR Diff
         id: extract_image_tag_digest

--- a/mise.lock
+++ b/mise.lock
@@ -23,6 +23,31 @@ provenance = "github-attestations"
 version = "2.21.0"
 backend = "pipx:ansible-core"
 
+[[tools.argocd]]
+version = "3.4.2"
+backend = "aqua:argoproj/argo-cd"
+
+[tools.argocd."platforms.linux-arm64"]
+checksum = "sha256:d0b74511242b2b4827dea6435092ef8b1402eb26c29c00944934e546a6445944"
+url = "https://github.com/argoproj/argo-cd/releases/download/v3.4.2/argocd-linux-arm64"
+
+[tools.argocd."platforms.linux-arm64".provenance.slsa]
+url = "https://github.com/argoproj/argo-cd/releases/download/v3.4.2/argocd-cli.intoto.jsonl"
+
+[tools.argocd."platforms.linux-x64"]
+checksum = "sha256:d4cb1ac8002baab8afaca2da3de597b613df8459074bc7c6d96dc95161c2a33f"
+url = "https://github.com/argoproj/argo-cd/releases/download/v3.4.2/argocd-linux-amd64"
+
+[tools.argocd."platforms.linux-x64".provenance.slsa]
+url = "https://github.com/argoproj/argo-cd/releases/download/v3.4.2/argocd-cli.intoto.jsonl"
+
+[tools.argocd."platforms.macos-arm64"]
+checksum = "sha256:25c82417f3a487079fed4975744b3571f66ff6caf479a888246b2491ed66b680"
+url = "https://github.com/argoproj/argo-cd/releases/download/v3.4.2/argocd-darwin-arm64"
+
+[tools.argocd."platforms.macos-arm64".provenance.slsa]
+url = "https://github.com/argoproj/argo-cd/releases/download/v3.4.2/argocd-cli.intoto.jsonl"
+
 [[tools.bats]]
 version = "1.13.0"
 backend = "aqua:bats-core/bats-core"
@@ -54,6 +79,34 @@ provenance = "github-attestations"
 checksum = "sha256:b11c54f6bd7d15ed6590475079e5b2fcf36f45d3991a80041b29c9d0cc1f1d07"
 url = "https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_macOS_arm64.zip"
 provenance = "github-attestations"
+
+[[tools."github:cloudnative-pg/cloudnative-pg"]]
+version = "1.29.1"
+backend = "github:cloudnative-pg/cloudnative-pg"
+
+[tools."github:cloudnative-pg/cloudnative-pg"."platforms.linux-arm64"]
+checksum = "sha256:77e5e2e9d21be1a6a1ddecb210c63026ecd4fbd1b086d8a886af3404db5b23b2"
+url = "https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.29.1/kubectl-cnpg_1.29.1_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/cloudnative-pg/cloudnative-pg/releases/assets/415332108"
+
+[tools."github:cloudnative-pg/cloudnative-pg"."platforms.linux-arm64".provenance.slsa]
+url = "https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.29.1/multiple.intoto.jsonl"
+
+[tools."github:cloudnative-pg/cloudnative-pg"."platforms.linux-x64"]
+checksum = "sha256:2a550d5ee2224e5bb66b95602f8052fc50da50485f59f97b817a0c3b44b58581"
+url = "https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.29.1/kubectl-cnpg_1.29.1_linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/cloudnative-pg/cloudnative-pg/releases/assets/415332109"
+
+[tools."github:cloudnative-pg/cloudnative-pg"."platforms.linux-x64".provenance.slsa]
+url = "https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.29.1/multiple.intoto.jsonl"
+
+[tools."github:cloudnative-pg/cloudnative-pg"."platforms.macos-arm64"]
+checksum = "sha256:d26019d8cb4deac553a6d5c31203a6332b71c2eddf76d762f5179fe4cac8624c"
+url = "https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.29.1/kubectl-cnpg_1.29.1_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/cloudnative-pg/cloudnative-pg/releases/assets/415332105"
+
+[tools."github:cloudnative-pg/cloudnative-pg"."platforms.macos-arm64".provenance.slsa]
+url = "https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.29.1/multiple.intoto.jsonl"
 
 [[tools.helm]]
 version = "3.21.0"

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,8 @@ kubeconform = "0.7.0"
 
 # Kubernetes and GitOps CLIs.
 kubectl = "1.36.1"
+argocd = "3.4.2"
+"github:cloudnative-pg/cloudnative-pg[exe=kubectl-cnpg]" = "1.29.1"
 kustomize = "5.8.1"
 helm = "3.21.0"
 yq = "4.53.2"


### PR DESCRIPTION
## Summary
- add pinned Argo CD CLI and CloudNativePG kubectl plugin to mise
- lock both tools for macOS ARM64, Linux ARM64, and Linux x64
- verify both CLIs in the setup-mise action

## Validation
- mise install --locked --yes argocd 'github:cloudnative-pg/cloudnative-pg[exe=kubectl-cnpg]'
- mise exec -- argocd version --client
- mise exec -- kubectl cnpg version
- mise exec -- pre-commit run --files .github/actions/setup-mise/action.yml mise.toml mise.lock
- git diff --check