### PR TITLE
fix: allow argocd internal pod cidr

### DIFF
--- a/apps/argocd/manifests/httproute.yaml
+++ b/apps/argocd/manifests/httproute.yaml
@@ -86,6 +86,7 @@ spec:
         principal:
           clientCIDRs:
             - 10.6.0.0/24
+            - 10.52.0.0/16
             - 192.168.99.0/24
       - name: allow-ui
         action: Allow


### PR DESCRIPTION
## Summary
- allow the Cilium pod CIDR in the ArgoCD Envoy SecurityPolicy private CIDR rule
- fixes node-local Envoy hairpin traffic from workers where the source appears as a pod/Cilium IP

## Validation
- pre-commit run --files apps/argocd/manifests/httproute.yaml
- kustomize build --enable-helm --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard apps/argocd/
- just app-dry-run argocd