### PR TITLE
fix: avoid full mise install in image verification

### DIFF
--- a/.github/workflows/helm-diff.yml
+++ b/.github/workflows/helm-diff.yml
@@ -139,7 +139,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DIFF_TXT_PATH: diff.txt
         run: |
-          mise exec -- python3 .github/scripts/extract_image_info.py || { echo "❌ Script failed!"; exit 1; }
+          python3 .github/scripts/extract_image_info.py || { echo "❌ Script failed!"; exit 1; }
 
       - name: Attempt to Pull Extracted Images and Verify Platform
         id: pull_helm_images

--- a/.github/workflows/pull-image.yml
+++ b/.github/workflows/pull-image.yml
@@ -24,7 +24,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mise exec -- python3 .github/scripts/extract_image_info.py || { echo "❌ Script failed!"; exit 1; }
+          python3 .github/scripts/extract_image_info.py || { echo "❌ Script failed!"; exit 1; }
 
       - name: Attempt to pull image and verify platform
         id: pull_image
@@ -76,6 +76,11 @@ jobs:
         id: format_image_pull_status
         if: always()
         run: |
+          if [ ! -s pull_results.txt ]; then
+            echo "No image pull results were produced. Skipping PR comment."
+            exit 0
+          fi
+
           {
             echo "IMAGE_PULL_COMMENT<<EOF"
             echo "| Pulled | Platform | Image |"


### PR DESCRIPTION
## Summary
- run image extraction with the selected profile's PATH-provided python instead of unscoped `mise exec --`
- apply the same fix to Helm diff image extraction
- skip the image-pull PR comment cleanly if extraction fails before `pull_results.txt` exists

## Root cause
`mise exec -- python3 ...` evaluates the full repository `mise.toml`, so the image-only CI profile tried to install unrelated tools such as `aqua:sholdee/crd-schema-publisher`. That exposed the runner's older mise/aqua registry state and failed before image extraction.

## Validation
- python3 -B .github/scripts/test_extract_image_info.py
- pre-commit run --files .github/workflows/pull-image.yml .github/workflows/helm-diff.yml
- rg -n "mise exec -- python3" .github (no matches)
