### PR TITLE
fix: refresh mise binary in ci

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -71,6 +71,10 @@ runs:
         experimental: true
         github_token: ${{ github.token }}
 
+    - name: Update mise binary
+      shell: bash
+      run: mise self-update --yes --no-plugins
+
     - name: Install locked toolchain
       shell: bash
       run: |


### PR DESCRIPTION
## Summary
- run mise self-update after the pinned mise action prepares the binary
- use --no-plugins so this only refreshes mise itself
- preserve mise install/download caches and avoid deleting the binary every run

## Validation
- pre-commit run --files .github/actions/setup-mise/action.yml
- git diff --check