### PR TITLE
fix: deduplicate k3s component metrics

### DIFF
--- a/apps/monitoring/kromgo/manifests/config.yaml
+++ b/apps/monitoring/kromgo/manifests/config.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kashalls/kromgo/main/config.schema.json
 metrics:
   - name: kubernetes_version
-    query: max by(git_version) (kubernetes_build_info{job="apiserver"})
+    query: max by(git_version) (kubernetes_build_info{job="k3s-server"})
     label: git_version
   - name: cluster_node_count
     query: count(kube_node_info)

--- a/apps/monitoring/values.yaml
+++ b/apps/monitoring/values.yaml
@@ -2,6 +2,14 @@ crds:
   enabled: false
   upgradeJob:
     enabled: false
+defaultRules:
+  disabled:
+    KubeAPIDown: true
+    KubeAPIInstanceUnreachable: true
+    KubeControllerManagerDown: true
+    KubeControllerManagerInstanceUnreachable: true
+    KubeSchedulerDown: true
+    KubeSchedulerInstanceUnreachable: true
 prometheus:
   prometheusSpec:
     replicas: 2
@@ -62,8 +70,12 @@ grafana:
       dashboards: grafana
 kubelet:
   enabled: true
+  jobNameOverride: k3s-server
   serviceMonitor:
     relabelings:
+      - targetLabel: job
+        replacement: k3s-server
+        action: replace
       # Fix default kubelet dashboard using wrong instance label value
       - sourceLabels:
           [
@@ -79,11 +91,21 @@ kubelet:
       - sourceLabels: [__metrics_path__]
         targetLabel: metrics_path
         action: replace
+    cAdvisorRelabelings:
+      - targetLabel: job
+        replacement: k3s-server
+        action: replace
+      - sourceLabels: [__metrics_path__]
+        targetLabel: metrics_path
+        action: replace
+    probesRelabelings:
+      - targetLabel: job
+        replacement: k3s-server
+        action: replace
+      - sourceLabels: [__metrics_path__]
+        targetLabel: metrics_path
+        action: replace
     metricRelabelings:
-      # Remove duplicate labels provided by k3s
-      - action: keep
-        sourceLabels: ["__name__"]
-        regex: (apiserver_audit|apiserver_client|apiserver_delegated|apiserver_envelope|apiserver_storage|apiserver_webhooks|authentication_token|cadvisor_version|container_blkio|container_cpu|container_fs|container_last|container_memory|container_network|container_oom|container_processes|container|csi_operations|disabled_metric|get_token|go|hidden_metric|kubelet_certificate|kubelet_cgroup|kubelet_container|kubelet_containers|kubelet_cpu|kubelet_device|kubelet_graceful|kubelet_http|kubelet_lifecycle|kubelet_managed|kubelet_node|kubelet_pleg|kubelet_pod|kubelet_run|kubelet_running|kubelet_runtime|kubelet_server|kubelet_started|kubelet_volume|kubernetes_build|kubernetes_feature|machine_cpu|machine_memory|machine_nvm|machine_scrape|node_namespace|plugin_manager|prober_probe|process_cpu|process_max|process_open|process_resident|process_start|process_virtual|registered_metric|rest_client|scrape_duration|scrape_samples|scrape_series|storage_operation|volume_manager|volume_operation|workqueue|spegel)_(.+)
       - action: replace
         sourceLabels: ["node"]
         targetLabel: instance
@@ -94,22 +116,18 @@ kubelet:
         regex: (id|name)
       - action: drop
         sourceLabels: ["__name__"]
-        regex: (rest_client_request_duration_seconds_bucket|rest_client_request_duration_seconds_sum|rest_client_request_duration_seconds_count)
-kubeApiServer:
-  enabled: true
-  serviceMonitor:
-    metricRelabelings:
-      # Remove duplicate labels provided by k3s
-      - action: keep
-        sourceLabels: ["__name__"]
-        regex: (aggregator_openapi|aggregator_unavailable|apiextensions_openapi|apiserver_admission|apiserver_audit|apiserver_cache|apiserver_cel|apiserver_client|apiserver_crd|apiserver_current|apiserver_envelope|apiserver_flowcontrol|apiserver_init|apiserver_kube|apiserver_longrunning|apiserver_request|apiserver_requested|apiserver_response|apiserver_selfrequest|apiserver_storage|apiserver_terminated|apiserver_tls|apiserver_watch|apiserver_webhooks|authenticated_user|authentication|disabled_metric|etcd_bookmark|etcd_lease|etcd_request|field_validation|get_token|go|grpc_client|hidden_metric|kube_apiserver|kubernetes_build|kubernetes_feature|node_authorizer|pod_security|process_cpu|process_max|process_open|process_resident|process_start|process_virtual|registered_metric|rest_client|scrape_duration|scrape_samples|scrape_series|serviceaccount_legacy|serviceaccount_stale|serviceaccount_valid|watch_cache|workqueue)_(.+)
-      # Drop high cardinality labels
-      - action: drop
-        sourceLabels: ["__name__"]
-        regex: (apiserver|etcd|rest_client)_request(|_sli|_slo)_duration_seconds_bucket
+        regex: (apiserver_request_duration_seconds_bucket|apiserver_request_slo_duration_seconds_bucket|etcd_request_duration_seconds_bucket)
       - action: drop
         sourceLabels: ["__name__"]
         regex: (apiserver_response_sizes_bucket|apiserver_watch_events_sizes_bucket)
+      - action: drop
+        sourceLabels: ["__name__"]
+        regex: (rest_client_request_duration_seconds_bucket|rest_client_request_duration_seconds_sum|rest_client_request_duration_seconds_count)
+kubeApiServer:
+  enabled: true
+  jobNameOverride: k3s-server
+  serviceMonitor:
+    enabled: false
 kubeEtcd:
   enabled: true
   endpoints:
@@ -117,8 +135,18 @@ kubeEtcd:
     - 192.168.99.11
     - 192.168.99.12
 kubeControllerManager:
-  enabled: false
+  enabled: true
+  jobNameOverride: k3s-server
+  service:
+    enabled: false
+  serviceMonitor:
+    enabled: false
 kubeScheduler:
-  enabled: false
+  enabled: true
+  jobNameOverride: k3s-server
+  service:
+    enabled: false
+  serviceMonitor:
+    enabled: false
 kubeProxy:
   enabled: false


### PR DESCRIPTION
## Summary
- use the kubelet ServiceMonitor as the canonical K3s metrics scrape with job="k3s-server"
- enable apiserver, scheduler, and controller-manager rules/dashboards via jobNameOverride while disabling duplicate component scrapes
- update Kromgo's Kubernetes version query to the canonical K3s job

## Validation
- pre-commit run --files apps/monitoring/values.yaml apps/monitoring/kromgo/manifests/config.yaml
- just app-dry-run monitoring
- review agent approved

## Note
- generated scheduler/controller-manager dashboard "up" stat panels may count kubelet scrape endpoints; rules and primary metric panels render against the expected component metric names