### PR TITLE
fix(renovate): allow drydock post-upgrade sync

### DIFF
--- a/apps/renovate/manifests/renovatejob.yaml
+++ b/apps/renovate/manifests/renovatejob.yaml
@@ -27,6 +27,8 @@ spec:
       value: "s3://renovate-cache"
     - name: RENOVATE_CUSTOM_ENV_VARIABLES
       value: '{"MISE_TRUSTED_CONFIG_PATHS":"/tmp/repos/github/sholdee/home-ops"}'
+    - name: RENOVATE_ALLOWED_COMMANDS
+      value: '["^go run \\./scripts/sync-argocd-gitops-engine\\.go$"]'
     - name: AWS_REGION
       value: garage
     - name: AWS_ENDPOINT_URL


### PR DESCRIPTION
## Summary

- allow the exact drydock Argo CD/GitOps Engine post-upgrade sync command in self-hosted Renovate
- keep shell executor disabled by only using RENOVATE_ALLOWED_COMMANDS

## Validation

- pre-commit run --files apps/renovate/manifests/renovatejob.yaml
- kustomize build --enable-helm apps/renovate
