### PR TITLE
docs: document drydock validation workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ a PR with passing `CI / gate`.
 - `components/`: reusable Kustomize components such as namespace and VolSync
 - `docs/`: operational docs and templates
 - `hack/bootstrap/`: local bootstrap runner for fresh clusters before ArgoCD takeover
-- `.github/`: CI, Renovate, and helper scripts
+- `.github/`: CI workflows, composite actions, and Renovate config
 
 Key files:
 
@@ -33,12 +33,17 @@ Use the smallest validation that covers the change:
 
 ```bash
 pre-commit run --files <changed-files>
-kustomize build --enable-helm \
-  --helm-api-versions grafana.integreatly.org/v1beta1/GrafanaDashboard \
-  apps/<name>/
+drydock test app <name> --path .
+drydock test apps --path .
+drydock diff apps --repo . --ref HEAD --ref-orig origin/master --skip-secrets --exit-code=false
 ```
 
-For ArgoCD server-side apply/diff behavior, match ArgoCD's field manager:
+`drydock` is the default local and CI renderability/diff tool for steady-state
+ArgoCD GitOps validation. It renders desired state without requiring a live
+ArgoCD or Kubernetes runtime. Use the full `apps` commands for cross-app or
+shared-component changes, and single-app commands for narrow app-local changes.
+
+For live ArgoCD server-side apply/diff behavior, match ArgoCD's field manager:
 
 ```bash
 kustomize build --enable-helm \

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ Renovate continuously scans the repository and submits pull requests for depende
 
 A unified CI pipeline runs on all pull requests, conditionally triggering the appropriate checks:
 
-- **Helm updates** — diffs inflated manifests between old and new versions, pulls new container images to verify ARM64 compatibility
-- **Image updates** — pulls the new image and verifies ARM64 platform support
-- **Pre-commit** — validates YAML syntax, Kubernetes schemas, and code quality
+- **Drydock GitOps validation** — uses [drydock](https://github.com/sholdee/drydock) to render and test ArgoCD Applications, produce desired-state diffs, and identify newly rendered container images
+- **ARM64 image verification** — pulls drydock-detected new images on a self-hosted ARM64 runner and verifies `linux/arm64` platform support
+- **Pre-commit** — validates YAML syntax, Kubernetes schemas, workflow syntax, shell scripts, Markdown, Renovate config, and code quality
+- **Bootstrap tests** — shellchecks and exercises the offline bootstrap, Ansible, Lima, and node lifecycle test suite
 
 All checks feed into a single required status gate for branch protection and automerge.
 
@@ -62,7 +63,7 @@ All checks feed into a single required status gate for branch protection and aut
 📁 components/        # Reusable Kustomize Components (namespace pull secrets, Dragonfly, VolSync backups)
 📁 docs/              # Operational documentation
 📁 hack/bootstrap/    # Bootstrap, node lifecycle, and Raspberry Pi reimage tooling
-📁 .github/           # CI workflows, composite actions, Renovate config, helper scripts
+📁 .github/           # CI workflows, composite actions, and Renovate config
 ```
 
 ### Cluster Bootstrap & Lifecycle 🚀


### PR DESCRIPTION
## Summary
- update README CI description to describe drydock-powered GitOps validation and ARM64 image verification
- link README directly to https://github.com/sholdee/drydock
- update AGENTS validation guidance so drydock is the default steady-state render/diff check
- remove stale references to old GitHub helper scripts from top-level docs

## Findings
- README still described the removed Helm diff and image-only workflow split.
- AGENTS still presented kustomize build as the default app validation command even though drydock now owns steady-state renderability and diff validation in CI.
- Top-level layout text still described .github helper scripts after the helper scripts were removed.

## Validation
- mise exec -- pre-commit run --files README.md AGENTS.md
- git diff --check