### PR TITLE
fix: trust renovate mise checkout root

### DIFF
--- a/apps/renovate/manifests/renovatejob.yaml
+++ b/apps/renovate/manifests/renovatejob.yaml
@@ -26,7 +26,7 @@ spec:
     - name: RENOVATE_REPOSITORY_CACHE_TYPE
       value: "s3://renovate-cache"
     - name: RENOVATE_CUSTOM_ENV_VARIABLES
-      value: '{"MISE_TRUSTED_CONFIG_PATHS":"/tmp/repos/github/sholdee/home-ops"}'
+      value: '{"MISE_TRUSTED_CONFIG_PATHS":"/tmp/repos/github/sholdee"}'
     - name: RENOVATE_ALLOWED_COMMANDS
       value: '["^go run \\./scripts/sync-argocd-gitops-engine\\.go$"]'
     - name: AWS_REGION


### PR DESCRIPTION
## Summary
- trust the Renovate sholdee checkout root for mise config loading
- fixes native Renovate mise lock updates for drydock and other selected sholdee repos

## Validation
- git diff --check
- pre-commit run --files apps/renovate/manifests/renovatejob.yaml
- go run ./cmd/drydock test app renovate --path /Users/ethan.shold/git/home-ops