### PR TITLE
ci: avoid duplicate drydock image comments

### DIFF
--- a/.github/workflows/drydock-gitops.yml
+++ b/.github/workflows/drydock-gitops.yml
@@ -36,6 +36,7 @@ jobs:
           github-app-client-id: ${{ secrets.BOT_APP_CLIENT_ID }}
           github-app-id: ${{ secrets.BOT_APP_ID }}
           github-app-private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          comment-mode: diff
           version: v0.1.7
 
   verify-new-images:


### PR DESCRIPTION
## Summary
- limit the drydock PR action to the rendered diff comment
- leave image verification results to the existing home-ops pull-results comment

## Validation
- pre-commit run --files .github/workflows/drydock-gitops.yml