### PR TITLE
ci: track drydock pr-action main

### DIFF
--- a/.github/workflows/drydock-gitops.yml
+++ b/.github/workflows/drydock-gitops.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run drydock pull request validation
         id: drydock
-        uses: sholdee/drydock/pr-action@05ef4a85a234e5ad6826dbf16de4c89a79110d86 # main
+        uses: sholdee/drydock/pr-action@main
         with:
           checkout: "false"
           install: "false"


### PR DESCRIPTION
## Summary

- update the drydock PR action reference to track main instead of a commit digest
- keep the existing mise-provided drydock binary and PR action settings unchanged

## Rationale

This action is controlled by the same operator, so tracking the main branch is acceptable here and avoids noisy digest-only maintenance for drydock PR action changes.

## Testing

- git diff --check