### PR TITLE
chore(kromgo): migrate to 0.11 config schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
         args:
           [
             "--schemafile",
-            "https://raw.githubusercontent.com/kashalls/kromgo/main/config.schema.json",
+            "https://raw.githubusercontent.com/home-operations/kromgo/0.11.1/config.schema.json",
           ]
       - id: check-jsonschema
         name: validate external-dns values

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@
 
 <div align="center">
 
-[![Age-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fcluster_age_days&style=flat-square&label=Age)](https://github.com/kashalls/kromgo/)&nbsp;&nbsp;
-[![Uptime-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fcluster_uptime_days&style=flat-square&label=Uptime)](https://github.com/kashalls/kromgo/)&nbsp;&nbsp;
-[![Node-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fcluster_node_count&style=flat-square&label=Nodes)](https://github.com/kashalls/kromgo/)&nbsp;&nbsp;
-[![Pod-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fcluster_pod_count&style=flat-square&label=Pods)](https://github.com/kashalls/kromgo/)&nbsp;&nbsp;
-[![CPU-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fcluster_cpu_usage&style=flat-square&label=CPU)](https://github.com/kashalls/kromgo/)&nbsp;&nbsp;
-[![Memory-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fcluster_memory_usage&style=flat-square&label=Memory)](https://github.com/kashalls/kromgo/)&nbsp;&nbsp;
+[![Age-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fcluster_age_days&style=flat-square&label=Age)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![Uptime-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fcluster_uptime_days&style=flat-square&label=Uptime)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![Node-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fcluster_node_count&style=flat-square&label=Nodes)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![Pod-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fcluster_pod_count&style=flat-square&label=Pods)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![CPU-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fcluster_cpu_usage&style=flat-square&label=CPU)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![Memory-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fcluster_memory_usage&style=flat-square&label=Memory)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
 
 </div>
 

--- a/apps/monitoring/kromgo/manifests/config.yaml
+++ b/apps/monitoring/kromgo/manifests/config.yaml
@@ -1,40 +1,41 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/kashalls/kromgo/main/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/home-operations/kromgo/0.11.1/config.schema.json
+defaults:
+  hidden: true
+  cacheSeconds: 300
+  timeseries:
+    enabled: false
+    maxDuration: "1h"
 metrics:
   - name: kubernetes_version
     query: max by(git_version) (kubernetes_build_info{job="k3s-server"})
-    label: git_version
+    value: 'labels[?"git_version"].orValue("unknown")'
+    cacheSeconds: 3600
   - name: cluster_node_count
     query: count(kube_node_info)
-    colors:
-      - { color: "green", min: 0, max: 9999 }
+    value: "humanizeNumber(result)"
+    color: '"green"'
   - name: cluster_pod_count
     query: sum(kube_pod_info)
-    colors:
-      - { color: "green", min: 0, max: 9999 }
+    value: "humanizeNumber(result)"
+    color: '"green"'
   - name: cluster_cpu_usage
     query: round(avg(100 - avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) by (instance) * 100), 0.01)
-    suffix: "%"
-    colors:
-      - { color: "green", min: 0, max: 35 }
-      - { color: "orange", min: 35, max: 75 }
-      - { color: "red", min: 75, max: 9999 }
+    value: 'humanizeFloat(result) + "%"'
+    color: 'result <= 35.0 ? "green" : result <= 75.0 ? "orange" : "red"'
+    cacheSeconds: 60
   - name: cluster_memory_usage
     query: round((sum(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes)) * 100, 0.1)
-    suffix: "%"
-    colors:
-      - { color: "green", min: 0, max: 75 }
-      - { color: "orange", min: 75, max: 85 }
-      - { color: "red", min: 85, max: 9999 }
+    value: 'humanizeFloat(result) + "%"'
+    color: 'result <= 75.0 ? "green" : result <= 85.0 ? "orange" : "red"'
+    cacheSeconds: 60
   - name: cluster_age_days
     query: round((time() - max(kube_namespace_created{namespace="kube-system"})) / 86400)
-    suffix: "d"
-    colors:
-      - { color: "green", min: 0, max: 9999 }
+    value: 'humanizeFloat(result) + "d"'
+    color: '"green"'
+    cacheSeconds: 3600
   - name: cluster_uptime_days
     query: round(avg(node_time_seconds - node_boot_time_seconds) / 86400)
-    suffix: "d"
-    colors:
-      - { color: "green", min: 0, max: 180 }
-      - { color: "orange", min: 180, max: 360 }
-      - { color: "red", min: 360, max: 9999 }
+    value: 'humanizeFloat(result) + "d"'
+    color: 'result <= 180.0 ? "green" : result <= 360.0 ? "orange" : "red"'
+    cacheSeconds: 3600

--- a/apps/monitoring/kromgo/manifests/config.yaml
+++ b/apps/monitoring/kromgo/manifests/config.yaml
@@ -19,16 +19,17 @@ metrics:
     query: sum(kube_pod_info)
     value: "humanizeNumber(result)"
     color: '"green"'
+    cacheSeconds: 30
   - name: cluster_cpu_usage
     query: round(avg(100 - avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) by (instance) * 100), 0.01)
     value: 'humanizeFloat(result) + "%"'
     color: 'result <= 35.0 ? "green" : result <= 75.0 ? "orange" : "red"'
-    cacheSeconds: 60
+    cacheSeconds: 30
   - name: cluster_memory_usage
     query: round((sum(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes)) * 100, 0.1)
     value: 'humanizeFloat(result) + "%"'
     color: 'result <= 75.0 ? "green" : result <= 85.0 ? "orange" : "red"'
-    cacheSeconds: 60
+    cacheSeconds: 30
   - name: cluster_age_days
     query: round((time() - max(kube_namespace_created{namespace="kube-system"})) / 86400)
     value: 'humanizeFloat(result) + "d"'

--- a/apps/monitoring/kromgo/manifests/deployment.yaml
+++ b/apps/monitoring/kromgo/manifests/deployment.yaml
@@ -34,7 +34,7 @@ spec:
               app: kromgo
       containers:
         - name: kromgo
-          image: ghcr.io/kashalls/kromgo:v0.10.0@sha256:965ecc92d68dc1a4a969397855367bbc70da03227a941ea607b73bb7e0b78fd6
+          image: ghcr.io/home-operations/kromgo:0.11.1@sha256:1c9d2fd0c01a5ded7bf5327a51645c80f6d12bb16215a47ba45ac75938e8aa88
           env:
             - name: PROMETHEUS_URL
               value: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"


### PR DESCRIPTION
## Summary
- migrate Kromgo config to the home-operations 0.11 schema with CEL value/color expressions
- update the Kromgo image to ghcr.io/home-operations/kromgo:0.11.1 and pin the new validation schema
- tune cacheSeconds by metric freshness and update stale README links

## Test Plan
- pre-commit run --files .pre-commit-config.yaml README.md apps/monitoring/kromgo/manifests/config.yaml apps/monitoring/kromgo/manifests/deployment.yaml
- kustomize build apps/monitoring/kromgo
- drydock test app monitoring --path .
- docker run smoke test for the pinned Kromgo image with the migrated config