### PR TITLE
ci: scope drydock changed-only paths

### DIFF
--- a/.github/workflows/drydock-gitops.yml
+++ b/.github/workflows/drydock-gitops.yml
@@ -36,6 +36,9 @@ jobs:
           github-app-client-id: ${{ secrets.BOT_APP_CLIENT_ID }}
           github-app-id: ${{ secrets.BOT_APP_ID }}
           github-app-private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          changed-only-include: |
+            apps/**
+            components/**
           comment-mode: diff
 
   verify-new-images:


### PR DESCRIPTION
## Summary
- add drydock PR action changed-only include filters for GitOps render inputs
- limit changed-only diff ownership to apps/** and components/** so non-GitOps changes do not force full-fleet diffs

## Validation
- mise exec -- actionlint .github/workflows/drydock-gitops.yml
- pre-commit run --files .github/workflows/drydock-gitops.yml
- git diff --check