### PR TITLE
feat(crd-schema-publisher): include all schema sources

### DIFF
--- a/apps/argocd/manifests/apps.yaml
+++ b/apps/argocd/manifests/apps.yaml
@@ -123,6 +123,9 @@ spec:
       valuesObject:
         annotations:
           reloader.stakater.com/auto: "true"
+        config:
+          includeBuiltins: true
+          includeKustomize: true
         externalSecret:
           enabled: true
           secretStoreRef:


### PR DESCRIPTION
Summary:
- Enables Kubernetes built-in schema publishing for the crd-schema-publisher Helm install.
- Enables Kustomize schema publishing for the same install.
- Leaves kubeconform schema-site and kustomization modeline migrations for a follow-up after this rolls out.

Validation:
- pre-commit run --files apps/argocd/manifests/apps.yaml
- drydock test app argocd --path .