### PR TITLE
chore(validation): use generated schema registry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,13 +72,12 @@ repos:
         entry: kubeconform
         args:
           - "-strict"
-          - "-ignore-missing-schemas"
           - "-schema-location"
-          - "default"
+          - "https://kube-schemas.shold.io/core/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
           - "-schema-location"
           - "https://kube-schemas.shold.io/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
         types: [yaml]
-        exclude: '(kustomization\.yaml|values.*\.yaml|^\.github/|^hack/bootstrap/ansible/|kromgo/manifests/config\.yaml|^\.pre-commit-config\.yaml|^\.yamllint\.yaml|^\.markdownlint-cli2\.yaml)'
+        exclude: '(values.*\.yaml|^\.github/|^hack/bootstrap/ansible/|^hack/bootstrap/kind-three-node\.yaml|kromgo/manifests/config\.yaml|^\.pre-commit-config\.yaml|^\.yamllint\.yaml|^\.markdownlint-cli2\.yaml)'
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ just bootstrap-phase argocd
 - CiliumNetworkPolicy enables enforcement for selected pods, so include all required ingress sources: gateway, metrics, database, and operator traffic as applicable
 - Use External Secrets; app credentials use `ClusterSecretStore: onepassword-connect`, while gateway TLS certs use `ClusterSecretStore: gateway`
 - Add `reloader.stakater.com/auto: "true"` to workloads consuming secrets/configmaps
-- Add `# yaml-language-server: $schema=...` only to CRD YAML files, not built-in Kubernetes resources
+- Add `# yaml-language-server: $schema=...` for manifests with generated schemas from `https://kube-schemas.shold.io`, including CRDs, built-in Kubernetes resources, and Kustomize Kustomization/Component files
 - Pin container images to tag plus digest and verify ARM64 support
 - Pin GitHub Actions to full commit SHAs with semver comments and preserve Renovate annotations/custom-manager patterns
 - Add resource requests/limits, restricted security context, and writable `emptyDir` mounts for read-only-rootfs workloads

--- a/apps/adguard/kustomization.yaml
+++ b/apps/adguard/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: adguard

--- a/apps/argocd/kustomization.yaml
+++ b/apps/argocd/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: argocd

--- a/apps/cert-manager/kustomization.yaml
+++ b/apps/cert-manager/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cert-manager

--- a/apps/cnpg-system/kustomization.yaml
+++ b/apps/cnpg-system/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: cnpg-system

--- a/apps/envoy-gateway-system/kustomization.yaml
+++ b/apps/envoy-gateway-system/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: envoy-gateway-system

--- a/apps/external-dns/kustomization.yaml
+++ b/apps/external-dns/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: external-dns

--- a/apps/external-secrets/kustomization.yaml
+++ b/apps/external-secrets/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: external-secrets

--- a/apps/gateway/kustomization.yaml
+++ b/apps/gateway/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: gateway

--- a/apps/hass/appdaemon/kustomization.yaml
+++ b/apps/hass/appdaemon/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/hass/codeserver/kustomization.yaml
+++ b/apps/hass/codeserver/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/hass/hass-db/kustomization.yaml
+++ b/apps/hass/hass-db/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/hass/hass/kustomization.yaml
+++ b/apps/hass/hass/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/hass/kustomization.yaml
+++ b/apps/hass/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: hass

--- a/apps/hass/mqtt-venstar-bridge/kustomization.yaml
+++ b/apps/hass/mqtt-venstar-bridge/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/hass/zwave/kustomization.yaml
+++ b/apps/hass/zwave/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/headlamp/kustomization.yaml
+++ b/apps/headlamp/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: headlamp

--- a/apps/hivemq/kustomization.yaml
+++ b/apps/hivemq/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: hivemq

--- a/apps/kube-system/cilium/kustomization.yaml
+++ b/apps/kube-system/cilium/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/kube-system/kube-vip/kustomization.yaml
+++ b/apps/kube-system/kube-vip/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/kube-system/kustomization.yaml
+++ b/apps/kube-system/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kube-system

--- a/apps/longhorn-system/kustomization.yaml
+++ b/apps/longhorn-system/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: longhorn-system

--- a/apps/mealie/kustomization.yaml
+++ b/apps/mealie/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: mealie

--- a/apps/mongodb-operator/kustomization.yaml
+++ b/apps/mongodb-operator/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/apps/monitoring/alertmanager/kustomization.yaml
+++ b/apps/monitoring/alertmanager/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/monitoring/grafana/kustomization.yaml
+++ b/apps/monitoring/grafana/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/monitoring/kromgo/kustomization.yaml
+++ b/apps/monitoring/kromgo/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/monitoring/kustomization.yaml
+++ b/apps/monitoring/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:

--- a/apps/monitoring/prometheus/kustomization.yaml
+++ b/apps/monitoring/prometheus/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/portainer/kustomization.yaml
+++ b/apps/portainer/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: portainer

--- a/apps/powerdns/kustomization.yaml
+++ b/apps/powerdns/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: powerdns

--- a/apps/renovate/kustomization.yaml
+++ b/apps/renovate/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: renovate

--- a/apps/system-upgrade/kustomization.yaml
+++ b/apps/system-upgrade/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: system-upgrade

--- a/apps/unifi/kustomization.yaml
+++ b/apps/unifi/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: unifi

--- a/apps/unifi/unifi-db/kustomization.yaml
+++ b/apps/unifi/unifi-db/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/unifi/unifi-guest/kustomization.yaml
+++ b/apps/unifi/unifi-guest/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/unifi/unifi/kustomization.yaml
+++ b/apps/unifi/unifi/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/apps/velero/kustomization.yaml
+++ b/apps/velero/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: velero

--- a/components/dragonfly/kustomization.yaml
+++ b/components/dragonfly/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/component_v1alpha1.json
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:

--- a/components/namespace/kustomization.yaml
+++ b/components/namespace/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/component_v1alpha1.json
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:

--- a/components/volsync/b2/kustomization.yaml
+++ b/components/volsync/b2/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/component_v1alpha1.json
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:

--- a/components/volsync/kustomization.yaml
+++ b/components/volsync/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/component_v1alpha1.json
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:

--- a/docs/howto-templates.md
+++ b/docs/howto-templates.md
@@ -7,6 +7,7 @@ Reference templates for common operations. Read this file when adding new apps, 
 1. Create `apps/<name>/kustomization.yaml`:
 
 ```yaml
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: <name>
@@ -25,6 +26,7 @@ resources:
 ## Adding a New Helm App
 
 ```yaml
+# yaml-language-server: $schema=https://kube-schemas.shold.io/kustomize.config.k8s.io/kustomization_v1beta1.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: <name>


### PR DESCRIPTION
## Summary
- validate Kubernetes resources through the generated kube-schemas registry instead of kubeconform default/static schemas
- remove `-ignore-missing-schemas` and simplify kubeconform schema locations to core plus API group paths
- add generated schema modelines for Kustomize Kustomization and Component files

## Validation
- live `component_v1alpha1.json` schema URL returned 200
- `pre-commit run --all-files`