### PR TITLE
fix(kromgo): mount config at 0.14 path

### DIFF
--- a/apps/monitoring/kromgo/manifests/deployment.yaml
+++ b/apps/monitoring/kromgo/manifests/deployment.yaml
@@ -71,7 +71,7 @@ spec:
               memory: 64Mi
           volumeMounts:
             - name: config-volume
-              mountPath: /kromgo/config.yaml
+              mountPath: /config/config.yaml
               subPath: config.yaml
               readOnly: true
       volumes:


### PR DESCRIPTION
## Summary

- mount the Kromgo ConfigMap at `/config/config.yaml`, which is the 0.14 image config path
- fixes the 0.14 rollout crash caused by mounting into `/kromgo/config.yaml`

## Root cause

Kromgo 0.14 expects its config at `/config/config.yaml`. The Deployment still mounted the ConfigMap at `/kromgo/config.yaml`. In the 0.14 image `/kromgo` is not a config directory, so the new pod failed during container init and the Service kept routing to old 0.11 pods. Those old pods do not serve the new `/badges/{id}?format=shields` routes, producing `resource not found` badges.

## Validation

- `mise exec -- lefthook run pre-commit --file apps/monitoring/kromgo/manifests/deployment.yaml --no-auto-install`
- `mise exec -- drydock test app monitoring --path .`
- `kubectl -n monitoring apply --server-side --dry-run=server --field-manager=argocd-controller -f apps/monitoring/kromgo/manifests/deployment.yaml`
- local Docker smoke: Kromgo 0.14 starts with the repo config mounted at `/config/config.yaml`; `/readyz` returns `200 OK`; `/badges/kubernetes_version?format=shields` reaches Kromgo and returns shields JSON shape