### PR TITLE
fix(ci): enforce drydock mise lock

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,16 @@
       "/apps/argocd/manifests/cilium-preflight\\.ya?ml$/",
     ],
   },
+  mise: {
+    postUpgradeTasks: {
+      commands: ["mise lock --yes github:sholdee/drydock"],
+      fileFilters: ["mise.lock"],
+      executionMode: "branch",
+      installTools: {
+        mise: {},
+      },
+    },
+  },
   packageRules: [
     {
       description: "Separate PRs for cilium",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       authorized: ${{ steps.author.outputs.authorized }}
       gitops: ${{ steps.paths.outputs.gitops }}
+      drydock-toolchain: ${{ steps.paths.outputs.drydock-toolchain }}
       renovate: ${{ steps.paths.outputs.renovate }}
     steps:
       - name: Check PR author
@@ -47,6 +48,10 @@ jobs:
               - '.github/workflows/drydock-gitops.yml'
               - 'apps/**'
               - 'components/**'
+            drydock-toolchain:
+              - '.github/actions/setup-mise/action.yml'
+              - 'mise.toml'
+              - 'mise.lock'
             renovate:
               - '.github/renovate.json5'
 
@@ -55,6 +60,22 @@ jobs:
 
   bootstrap-test:
     uses: ./.github/workflows/bootstrap-test.yml
+
+  drydock-toolchain:
+    needs: detect
+    if: needs.detect.outputs.drydock-toolchain == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install drydock mise profile
+        uses: ./.github/actions/setup-mise
+        with:
+          profile: drydock
+
+      - name: Verify drydock version
+        run: drydock version
 
   renovate:
     needs: detect
@@ -88,19 +109,20 @@ jobs:
   gate:
     runs-on: ubuntu-latest
     if: always()
-    needs: [detect, validation, bootstrap-test, renovate, drydock-gitops]
+    needs: [detect, validation, bootstrap-test, drydock-toolchain, renovate, drydock-gitops]
     steps:
       - name: Evaluate results
         run: |
           DETECT="${{ needs.detect.result }}"
           VALIDATION="${{ needs.validation.result }}"
           BOOTSTRAP="${{ needs.bootstrap-test.result }}"
+          DRYDOCK_TOOLCHAIN="${{ needs.drydock-toolchain.result }}"
           RENOVATE="${{ needs.renovate.result }}"
           DRYDOCK="${{ needs.drydock-gitops.result }}"
 
-          echo "detect=$DETECT validation=$VALIDATION bootstrap-test=$BOOTSTRAP renovate=$RENOVATE drydock-gitops=$DRYDOCK"
+          echo "detect=$DETECT validation=$VALIDATION bootstrap-test=$BOOTSTRAP drydock-toolchain=$DRYDOCK_TOOLCHAIN renovate=$RENOVATE drydock-gitops=$DRYDOCK"
 
-          if [[ "$DETECT" == "failure" || "$VALIDATION" == "failure" || "$BOOTSTRAP" == "failure" || "$RENOVATE" == "failure" || "$DRYDOCK" == "failure" ]]; then
+          if [[ "$DETECT" == "failure" || "$VALIDATION" == "failure" || "$BOOTSTRAP" == "failure" || "$DRYDOCK_TOOLCHAIN" == "failure" || "$RENOVATE" == "failure" || "$DRYDOCK" == "failure" ]]; then
             echo "CI failed"
             exit 1
           fi

--- a/apps/renovate/manifests/renovatejob.yaml
+++ b/apps/renovate/manifests/renovatejob.yaml
@@ -27,8 +27,10 @@ spec:
       value: "s3://renovate-cache"
     - name: RENOVATE_CUSTOM_ENV_VARIABLES
       value: '{"MISE_TRUSTED_CONFIG_PATHS":"/tmp/repos/github/sholdee"}'
+    - name: RENOVATE_ALLOWED_UNSAFE_EXECUTIONS
+      value: '["mise"]'
     - name: RENOVATE_ALLOWED_COMMANDS
-      value: '["^go run \\./scripts/sync-argocd-gitops-engine\\.go$"]'
+      value: '["^go run \\./scripts/sync-argocd-gitops-engine\\.go$","^mise lock --yes github:sholdee/drydock$"]'
     - name: AWS_REGION
       value: garage
     - name: AWS_ENDPOINT_URL

--- a/mise.lock
+++ b/mise.lock
@@ -128,25 +128,25 @@ url_api = "https://api.github.com/repos/cloudnative-pg/cloudnative-pg/releases/a
 url = "https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.29.1/multiple.intoto.jsonl"
 
 [[tools."github:sholdee/drydock"]]
-version = "0.1.14"
+version = "0.1.15"
 backend = "github:sholdee/drydock"
 
 [tools."github:sholdee/drydock"."platforms.linux-arm64"]
-checksum = "sha256:3ec44ff1d9745c085420f3eb342f8fa26f8027be48f155bf89ac44b04ee6a041"
-url = "https://github.com/sholdee/drydock/releases/download/v0.1.14/drydock_linux-arm64.tar.gz"
-url_api = "https://api.github.com/repos/sholdee/drydock/releases/assets/438648342"
+checksum = "sha256:132b31d4954071e9b783cd0ea9faa05babef9a0a38b1fa3a503411ec4276749e"
+url = "https://github.com/sholdee/drydock/releases/download/v0.1.15/drydock_linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/sholdee/drydock/releases/assets/439123638"
 provenance = "github-attestations"
 
 [tools."github:sholdee/drydock"."platforms.linux-x64"]
-checksum = "sha256:b577351dc19a37a6112af75fd4ba2c57856abe3648269dca8a45f2b4a8d7e851"
-url = "https://github.com/sholdee/drydock/releases/download/v0.1.14/drydock_linux-amd64.tar.gz"
-url_api = "https://api.github.com/repos/sholdee/drydock/releases/assets/438648326"
+checksum = "sha256:eef440743aa9cc4bd7f6c1eb3e75a51e4e9443f23913aa797ad1fba83bcf8afa"
+url = "https://github.com/sholdee/drydock/releases/download/v0.1.15/drydock_linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/sholdee/drydock/releases/assets/439123622"
 provenance = "github-attestations"
 
 [tools."github:sholdee/drydock"."platforms.macos-arm64"]
-checksum = "sha256:a2c71bbc1431b4661d9bfc36acd57e21eb1c903407b2b3b41ea74fb35939b7bc"
-url = "https://github.com/sholdee/drydock/releases/download/v0.1.14/drydock_darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/sholdee/drydock/releases/assets/438648311"
+checksum = "sha256:5795139c5173c422374f8ec48864fbed02875f083d92729a59b478f99a3721d9"
+url = "https://github.com/sholdee/drydock/releases/download/v0.1.15/drydock_darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/sholdee/drydock/releases/assets/439123608"
 provenance = "github-attestations"
 
 [[tools.gitleaks]]


### PR DESCRIPTION
## Summary
- refresh mise.lock for github:sholdee/drydock v0.1.15
- configure Renovate to run mise lock for drydock updates so mise.lock is included in the same PR
- add a drydock-toolchain CI job for mise.toml, mise.lock, and setup-mise changes so stale locks cannot merge

## Validation
- renovate-config-validator .github/renovate.json5
- mise exec -- lefthook run pre-commit --no-auto-install --file .github/renovate.json5 --file apps/renovate/manifests/renovatejob.yaml --file .github/workflows/ci.yaml --file mise.lock
- kustomize build --enable-helm apps/renovate
- mise exec -- drydock test app renovate --path .
- mise install --locked --yes github:sholdee/drydock jq