### PR TITLE
fix(ci): enforce generic mise locks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,7 @@
   },
   mise: {
     postUpgradeTasks: {
-      commands: ["mise lock --yes github:sholdee/drydock"],
+      commands: ["mise lock --yes"],
       fileFilters: ["mise.lock"],
       executionMode: "branch",
       installTools: {

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       authorized: ${{ steps.author.outputs.authorized }}
       gitops: ${{ steps.paths.outputs.gitops }}
-      drydock-toolchain: ${{ steps.paths.outputs.drydock-toolchain }}
+      mise-toolchain: ${{ steps.paths.outputs.mise-toolchain }}
       renovate: ${{ steps.paths.outputs.renovate }}
     steps:
       - name: Check PR author
@@ -48,7 +48,7 @@ jobs:
               - '.github/workflows/drydock-gitops.yml'
               - 'apps/**'
               - 'components/**'
-            drydock-toolchain:
+            mise-toolchain:
               - '.github/actions/setup-mise/action.yml'
               - 'mise.toml'
               - 'mise.lock'
@@ -61,21 +61,36 @@ jobs:
   bootstrap-test:
     uses: ./.github/workflows/bootstrap-test.yml
 
-  drydock-toolchain:
+  mise-toolchain:
     needs: detect
-    if: needs.detect.outputs.drydock-toolchain == 'true'
+    if: needs.detect.outputs.mise-toolchain == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Install drydock mise profile
+      - name: Setup mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
+        with:
+          install: false
+          cache: false
+          experimental: true
+          github_token: ${{ github.token }}
+
+      - name: Update mise binary
+        run: mise self-update --yes --no-plugins
+
+      - name: Verify mise lockfile is current
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          mise lock --yes
+          git diff --exit-code -- mise.lock
+
+      - name: Install full locked mise toolchain
         uses: ./.github/actions/setup-mise
         with:
-          profile: drydock
-
-      - name: Verify drydock version
-        run: drydock version
+          profile: all
 
   renovate:
     needs: detect
@@ -109,20 +124,20 @@ jobs:
   gate:
     runs-on: ubuntu-latest
     if: always()
-    needs: [detect, validation, bootstrap-test, drydock-toolchain, renovate, drydock-gitops]
+    needs: [detect, validation, bootstrap-test, mise-toolchain, renovate, drydock-gitops]
     steps:
       - name: Evaluate results
         run: |
           DETECT="${{ needs.detect.result }}"
           VALIDATION="${{ needs.validation.result }}"
           BOOTSTRAP="${{ needs.bootstrap-test.result }}"
-          DRYDOCK_TOOLCHAIN="${{ needs.drydock-toolchain.result }}"
+          MISE_TOOLCHAIN="${{ needs.mise-toolchain.result }}"
           RENOVATE="${{ needs.renovate.result }}"
           DRYDOCK="${{ needs.drydock-gitops.result }}"
 
-          echo "detect=$DETECT validation=$VALIDATION bootstrap-test=$BOOTSTRAP drydock-toolchain=$DRYDOCK_TOOLCHAIN renovate=$RENOVATE drydock-gitops=$DRYDOCK"
+          echo "detect=$DETECT validation=$VALIDATION bootstrap-test=$BOOTSTRAP mise-toolchain=$MISE_TOOLCHAIN renovate=$RENOVATE drydock-gitops=$DRYDOCK"
 
-          if [[ "$DETECT" == "failure" || "$VALIDATION" == "failure" || "$BOOTSTRAP" == "failure" || "$DRYDOCK_TOOLCHAIN" == "failure" || "$RENOVATE" == "failure" || "$DRYDOCK" == "failure" ]]; then
+          if [[ "$DETECT" == "failure" || "$VALIDATION" == "failure" || "$BOOTSTRAP" == "failure" || "$MISE_TOOLCHAIN" == "failure" || "$RENOVATE" == "failure" || "$DRYDOCK" == "failure" ]]; then
             echo "CI failed"
             exit 1
           fi

--- a/apps/renovate/manifests/renovatejob.yaml
+++ b/apps/renovate/manifests/renovatejob.yaml
@@ -21,6 +21,11 @@ spec:
         secretKeyRef:
           name: renovate-dragonfly-auth
           key: RENOVATE_REDIS_URL
+    - name: GITHUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: renovate-secret
+          key: RENOVATE_TOKEN
     - name: RENOVATE_REPOSITORY_CACHE
       value: enabled
     - name: RENOVATE_REPOSITORY_CACHE_TYPE
@@ -30,7 +35,7 @@ spec:
     - name: RENOVATE_ALLOWED_UNSAFE_EXECUTIONS
       value: '["mise"]'
     - name: RENOVATE_ALLOWED_COMMANDS
-      value: '["^go run \\./scripts/sync-argocd-gitops-engine\\.go$","^mise lock --yes github:sholdee/drydock$"]'
+      value: '["^go run \\./scripts/sync-argocd-gitops-engine\\.go$","^mise lock --yes$"]'
     - name: AWS_REGION
       value: garage
     - name: AWS_ENDPOINT_URL

--- a/mise.lock
+++ b/mise.lock
@@ -300,9 +300,19 @@ url = "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/
 version = "2.1.9"
 backend = "aqua:evilmartians/lefthook"
 
+[tools.lefthook."platforms.linux-arm64"]
+checksum = "sha256:d1bae1c9c26b35270dd675c93c33cecead885368ed078b3976ec23cdcedd28e8"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.9/lefthook_2.1.9_Linux_aarch64.gz"
+provenance = "github-attestations"
+
 [tools.lefthook."platforms.linux-x64"]
 checksum = "sha256:e938f34bd05bafe1155888879a045ef4ee8cf5b4a56c9e5e9b0c2649f295636e"
 url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.9/lefthook_2.1.9_Linux_x86_64.gz"
+provenance = "github-attestations"
+
+[tools.lefthook."platforms.macos-arm64"]
+checksum = "sha256:808f8ef81a61e01eb41c1a2951e5639804f2372dc6a484bbeff726406745c77f"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.9/lefthook_2.1.9_MacOS_arm64.gz"
 provenance = "github-attestations"
 
 [[tools.lima]]
@@ -366,18 +376,18 @@ version = "3.14.5"
 backend = "core:python"
 
 [tools.python."platforms.linux-arm64"]
-checksum = "sha256:bea1aa66159eaf97ade1225e40b7060d709154da961aa37792bb8066d8f6af49"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.14.5+20260510-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:1d3ea1b3cd9b8f3d53afb629e82e9bc8f6dab6cbb1a7d23524bd86ba5bc22570"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260602/cpython-3.14.5+20260602-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.linux-x64"]
-checksum = "sha256:dc10977b0db3bef1ee2275107fde6fe9c148135b556fa352e83c6baa67d17ed6"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.14.5+20260510-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:982a60fc7f11bbe405ab54afcd4eb145f1134797bbbffac9f5c49df4ec98b13e"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260602/cpython-3.14.5+20260602-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.macos-arm64"]
-checksum = "sha256:1bb0b3d45448dfe7e916dc62144cfd7d7a611dc6ccf05b8bb71662cc5c2a1ad2"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260510/cpython-3.14.5+20260510-aarch64-apple-darwin-install_only_stripped.tar.gz"
+checksum = "sha256:3a0373cc39fefd494754ef555267f245c720cddbaaabf63a7c9a4269f1e56532"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260602/cpython-3.14.5+20260602-aarch64-apple-darwin-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [[tools.shellcheck]]


### PR DESCRIPTION
## Summary
- replace the drydock-specific Renovate mise lock refresh with generic `mise lock --yes`
- pass `GITHUB_TOKEN` to Renovate/mise and the CI lock check to avoid unauthenticated GitHub API limits
- rename and strengthen the CI toolchain check so `mise.toml`, `mise.lock`, and setup-mise changes verify the full lockfile and install the full locked toolchain
- refresh current `mise.lock` output from `mise lock --yes`

## Validation
- `mise lock --yes`
- `mise exec -- lefthook run pre-commit --no-auto-install --file .github/renovate.json5 --file apps/renovate/manifests/renovatejob.yaml --file .github/workflows/ci.yaml --file mise.lock`
- `mise install --locked --yes`
- `mise exec -- drydock test app renovate --path .`
- `docker run --rm --volume /Users/ethan.shold/git/home-ops:/repo --workdir /repo renovate/renovate:43.214.2@sha256:94ea97399b0dfba2e42b9571fc5bca6e1fbf5e72ecf6062cfe6aba5bec76b19e renovate-config-validator .github/renovate.json5`
