### PR TITLE
fix(renovate): run mise lock after tool updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,14 @@
   extends: ["config:recommended", "docker:enableMajor", ":semanticCommits"],
   platformAutomerge: true,
   dependencyDashboardTitle: "Dependency Dashboard :robot:",
+  postUpgradeTasks: {
+    commands: ["mise lock --yes"],
+    fileFilters: ["mise.lock"],
+    executionMode: "branch",
+    installTools: {
+      mise: {},
+    },
+  },
   kubernetes: {
     managerFilePatterns: ["/apps/.*\\.ya?ml$/", "/components/.*\\.ya?ml$/"],
   },
@@ -11,16 +19,6 @@
       "/apps/argocd/manifests/apps\\.ya?ml$/",
       "/apps/argocd/manifests/cilium-preflight\\.ya?ml$/",
     ],
-  },
-  mise: {
-    postUpgradeTasks: {
-      commands: ["mise lock --yes"],
-      fileFilters: ["mise.lock"],
-      executionMode: "branch",
-      installTools: {
-        mise: {},
-      },
-    },
   },
   packageRules: [
     {


### PR DESCRIPTION
## Summary
- move the mise lock post-upgrade task to Renovate's top-level postUpgradeTasks config
- keep the exact allowed command unchanged so all mise-managed tool updates regenerate mise.lock

## Validation
- docker run --rm --volume "/Users/ethan.shold/git/home-ops:/repo" --workdir /repo renovate/renovate:43.207.4@sha256:087bab575172b1926bbc57124d988015d899b0a82d45028514377b10a392f69d renovate-config-validator .github/renovate.json5
- mise exec -- lefthook run pre-commit --file .github/renovate.json5

## Follow-up
After this lands, let Renovate rebase/force-push PR #3163 so it regenerates mise.lock instead of manually patching the bot branch.