### PR TITLE
fix(renovate): install npm for mise lock tasks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,8 @@
     executionMode: "branch",
     installTools: {
       mise: {},
+      node: {},
+      npm: {},
     },
   },
   kubernetes: {


### PR DESCRIPTION
## Summary
- install node and npm for Renovate post-upgrade tasks alongside mise
- fixes npm-backed mise tools such as oxfmt being pruned from mise.lock during Renovate lockfile regeneration

## Validation
- renovate-config-validator --no-global --strict .github/renovate.json5
- mise exec -- lefthook run pre-commit --file .github/renovate.json5
- Renovate dry-run with patched config kept oxfmt@0.54.0 in mise.lock and processed it during mise lock --yes