### PR TITLE
fix(renovate): pass GitHub token to mise lock

### DIFF
--- a/apps/renovate/manifests/renovatejob.yaml
+++ b/apps/renovate/manifests/renovatejob.yaml
@@ -30,8 +30,10 @@ spec:
       value: enabled
     - name: RENOVATE_REPOSITORY_CACHE_TYPE
       value: "s3://renovate-cache"
+    - name: RENOVATE_SECRETS
+      value: '{"MISE_GITHUB_TOKEN":"$(GITHUB_TOKEN)"}'
     - name: RENOVATE_CUSTOM_ENV_VARIABLES
-      value: '{"MISE_TRUSTED_CONFIG_PATHS":"/tmp/repos/github/sholdee"}'
+      value: '{"MISE_TRUSTED_CONFIG_PATHS":"/tmp/repos/github/sholdee","MISE_GITHUB_TOKEN":"{{ secrets.MISE_GITHUB_TOKEN }}"}'
     - name: RENOVATE_ALLOWED_UNSAFE_EXECUTIONS
       value: '["mise"]'
     - name: RENOVATE_ALLOWED_COMMANDS


### PR DESCRIPTION
## Summary
- pass the existing Renovate GitHub token to mise child processes as MISE_GITHUB_TOKEN
- use Renovate secrets templating so the token remains redacted and scoped to child commands
- fixes Renovate mise-lock post-upgrade tasks producing unauthenticated/non-canonical aqua lock entries

## Validation
- git diff --check
- mise exec -- lefthook run pre-commit --file apps/renovate/manifests/renovatejob.yaml
- targeted Renovate dry-run for renovate/oxfmt-0.x confirmed the post-upgrade mise lock task no longer emits GitHub rate-limit/version-tag fetch failures