### PR TITLE
fix(renovate): delay Python toolchain updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -98,6 +98,12 @@
       enabled: false,
     },
     {
+      description: "Wait for mise Python standalone artifacts",
+      matchManagers: ["mise"],
+      matchPackageNames: ["python"],
+      minimumReleaseAge: "3 days",
+    },
+    {
       description: "Automerge mise-managed tool minor/patch updates",
       matchManagers: ["mise"],
       matchUpdateTypes: ["minor", "patch"],


### PR DESCRIPTION
## Summary
- add a Python-specific Renovate delay for mise-managed updates
- wait 3 days so CPython tags have time to appear in python-build-standalone/mise install artifacts
- keep the existing broad mise minor/patch automerge rule for other tools

## Context
PR #3191 saw CPython v3.14.6 before mise could lock/install it from python-build-standalone. Renovate updated the version and pruned the old Python lock URLs, but  failed because no platform URL existed for python@3.14.6.

## Validation
- git diff --check
- mise exec -- lefthook run pre-commit --file .github/renovate.json5