### PR TITLE
chore(monitoring): use upstream Prom++ v0.8.0

### DIFF
--- a/apps/monitoring/values.yaml
+++ b/apps/monitoring/values.yaml
@@ -14,10 +14,10 @@ prometheus:
   prometheusSpec:
     replicas: 2
     image:
-      registry: docker.io
-      repository: sholdee/prompp
-      tag: "0.7.10-jemalloc-aarch64-fix-arm64"
-      sha: df1285d2da16952348de8b094f5332cb68b8241399941b6c2c7c3dc03b284481
+      registry: ghcr.io
+      repository: deckhouse/prompp
+      tag: "0.8.0"
+      sha: 31b2b76059cc9eab4e62445d1c8c4913b9e16939dc88590b0e270fa9825b4a76
       pullPolicy: IfNotPresent
     version: v3.11.3
     serviceMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
## Summary

- switch kube-prometheus-stack Prometheus from the temporary custom Prom++ image to upstream `ghcr.io/deckhouse/prompp:0.8.0`
- pin the upstream multi-arch manifest digest `sha256:31b2b76059cc9eab4e62445d1c8c4913b9e16939dc88590b0e270fa9825b4a76`
- keep `prometheusSpec.version: v3.11.3` explicit for Prometheus Operator compatibility handling

Release: https://github.com/deckhouse/prompp/releases/tag/v0.8.0

## Validation

- `docker manifest inspect ghcr.io/deckhouse/prompp:0.8.0`
- `docker manifest inspect ghcr.io/deckhouse/prompp@sha256:31b2b76059cc9eab4e62445d1c8c4913b9e16939dc88590b0e270fa9825b4a76`
- `docker run --rm ghcr.io/deckhouse/prompp:0.8.0@sha256:31b2b76059cc9eab4e62445d1c8c4913b9e16939dc88590b0e270fa9825b4a76 --version`
- `mise exec -- kustomize build --enable-helm apps/monitoring | yq -r 'select(.kind == "Prometheus") | [.metadata.name, .spec.image, .spec.version] | @tsv' -`
- `git diff --check`
- `mise exec -- lefthook run pre-commit --file apps/monitoring/values.yaml`
- `mise exec -- drydock test app monitoring --path .`
- live cluster smoke on `k3s-worker-0`: `kubectl -n monitoring run prompp-v080-arm64-check --image=ghcr.io/deckhouse/prompp:0.8.0@sha256:31b2b76059cc9eab4e62445d1c8c4913b9e16939dc88590b0e270fa9825b4a76 --restart=Never --attach --rm --overrides='{"spec":{"nodeName":"k3s-worker-0"}}' -- --version`
