### PR TITLE
chore(renovate): manage Prom++ image digest

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -69,6 +69,13 @@
       automerge: true,
     },
     {
+      description: "Use the custom manager for Prom++ tag and kube-prometheus-stack sha",
+      matchManagers: ["helm-values"],
+      matchFileNames: ["apps/monitoring/values.yaml"],
+      matchPackageNames: ["ghcr.io/deckhouse/prompp", "deckhouse/prompp"],
+      enabled: false,
+    },
+    {
       description: "Exclude apps with Recreate strategy and no health probes from automerge",
       matchDatasources: ["docker"],
       matchPackageNames: ["/home-assistant/", "/appdaemon/", "/goofball222\/unifi/"],
@@ -128,6 +135,18 @@
       depNameTemplate: "{{depName}}",
       versioningTemplate: "docker",
       datasourceTemplate: "docker",
+    },
+    {
+      customType: "regex",
+      description: ["Process Prom++ image tag and kube-prometheus-stack sha"],
+      managerFilePatterns: ["/^apps/monitoring/values\\.ya?ml$/"],
+      matchStrings: [
+        '(?<indentation>[ \\t]*)# renovate: datasource=docker depName=ghcr\\.io/deckhouse/prompp digest=(?<currentDigest>sha256:[a-f0-9]{64})\\n\\s+registry: ghcr\\.io\\n\\s+repository: deckhouse/prompp\\n\\s+tag: "(?<currentValue>[^"]+)"\\n\\s+sha: [a-f0-9]{64}',
+      ],
+      depNameTemplate: "ghcr.io/deckhouse/prompp",
+      datasourceTemplate: "docker",
+      versioningTemplate: "docker",
+      autoReplaceStringTemplate: '{{{indentation}}}# renovate: datasource=docker depName=ghcr.io/deckhouse/prompp digest={{#if newDigest}}{{{newDigest}}}{{else}}{{{currentDigest}}}{{/if}}\n{{{indentation}}}registry: ghcr.io\n{{{indentation}}}repository: deckhouse/prompp\n{{{indentation}}}tag: "{{{newValue}}}"\n{{{indentation}}}sha: {{#if newDigest}}{{replace "^sha256:" "" newDigest}}{{else}}{{replace "^sha256:" "" currentDigest}}{{/if}}',
     },
     {
       customType: "regex",

--- a/apps/monitoring/values.yaml
+++ b/apps/monitoring/values.yaml
@@ -14,6 +14,7 @@ prometheus:
   prometheusSpec:
     replicas: 2
     image:
+      # renovate: datasource=docker depName=ghcr.io/deckhouse/prompp digest=sha256:31b2b76059cc9eab4e62445d1c8c4913b9e16939dc88590b0e270fa9825b4a76
       registry: ghcr.io
       repository: deckhouse/prompp
       tag: "0.8.0"


### PR DESCRIPTION
## Summary

- add a targeted Renovate custom manager for `ghcr.io/deckhouse/prompp`
- update the Prom++ manager to replace both `tag` and kube-prometheus-stack's raw `sha` field together
- disable native `helm-values` updates for this one image so Renovate cannot bump the tag while leaving `sha` stale

`prometheusSpec.version` remains manual because it is Prometheus Operator compatibility metadata, not the Prom++ image version.

## Validation

- `mise exec -- lefthook run pre-commit --file .github/renovate.json5 --file apps/monitoring/values.yaml`
- `mise exec -- drydock test app monitoring --path .`
- `docker run --rm --volume "${PWD}:/repo" --workdir /repo renovate/renovate:43.207.4@sha256:087bab575172b1926bbc57124d988015d899b0a82d45028514377b10a392f69d renovate-config-validator .github/renovate.json5`
- `docker run --rm --volume "${PWD}:/repo" --workdir /repo renovate/renovate:43.207.4@sha256:087bab575172b1926bbc57124d988015d899b0a82d45028514377b10a392f69d renovate --platform=local --dry-run=extract --enabled-managers=regex`
