### PR TITLE
ci(drydock): run diff on self-hosted runners with local render cache

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -7,6 +7,12 @@ inputs:
   profile:
     description: Tool profile to install. One of all, validation, bootstrap-test, drydock, image, operator.
     default: all
+  cache:
+    description: >-
+      Restore and save the mise tools cache via actions/cache. Set to "false" on
+      persistent self-hosted runners, where the toolchain already persists on
+      local disk and the remote cache restore is redundant.
+    default: "true"
 
 runs:
   using: composite
@@ -55,6 +61,7 @@ runs:
 
     - name: Restore mise tools cache
       id: mise-cache
+      if: inputs.cache == 'true'
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
@@ -101,7 +108,7 @@ runs:
         mise reshim
 
     - name: Save mise tools cache
-      if: steps.mise-cache.outputs.cache-hit != 'true'
+      if: inputs.cache == 'true' && steps.mise-cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |

--- a/.github/workflows/drydock-gitops.yml
+++ b/.github/workflows/drydock-gitops.yml
@@ -39,6 +39,9 @@ jobs:
         uses: ./.github/actions/setup-mise
         with:
           profile: drydock
+          # Persistent self-hosted runners keep the toolchain on local disk, so
+          # the remote actions/cache restore is redundant; rely on local mise.
+          cache: "false"
 
       - name: Run drydock pull request validation
         id: drydock

--- a/.github/workflows/drydock-gitops.yml
+++ b/.github/workflows/drydock-gitops.yml
@@ -13,17 +13,20 @@ on:
         required: false
 
 jobs:
+  # Render diff and the conditional image-pull verification run in one job on
+  # the persistent self-hosted runners. drydock keeps its render cache on local
+  # disk (cache-mode: local), so it warms across pull requests without
+  # actions/cache round-trips, and the image pull reads the rendered image list
+  # directly instead of via an artifact handoff.
   drydock-diff:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, ARM64, home-ops, image-pull]
     permissions:
       contents: read
       pull-requests: write
       issues: write
-    outputs:
-      HAS_DIFF: ${{ steps.drydock.outputs.has-diff }}
-      HAS_IMAGES: ${{ steps.drydock.outputs.has-images }}
-      DIFF_ARTIFACT_NAME: ${{ steps.drydock.outputs.diff-artifact-name }}
-      IMAGE_ARTIFACT_NAME: ${{ steps.drydock.outputs.image-artifact-name }}
+    env:
+      HAS_BOT_APP_CLIENT_ID: ${{ secrets.BOT_APP_CLIENT_ID != '' }}
+      HAS_BOT_APP_ID: ${{ secrets.BOT_APP_ID != '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -44,6 +47,7 @@ jobs:
           checkout: "false"
           install: "false"
           drydock-bin: drydock
+          cache-mode: local
           github-app-client-id: ${{ secrets.BOT_APP_CLIENT_ID }}
           github-app-id: ${{ secrets.BOT_APP_ID }}
           github-app-private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
@@ -52,32 +56,10 @@ jobs:
             components/**
           comment-mode: diff
 
-  verify-new-images:
-    needs: drydock-diff
-    if: needs.drydock-diff.outputs.HAS_IMAGES == 'true'
-    runs-on: [self-hosted, Linux, ARM64, home-ops, image-pull]
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-    env:
-      HAS_BOT_APP_CLIENT_ID: ${{ secrets.BOT_APP_CLIENT_ID != '' }}
-      HAS_BOT_APP_ID: ${{ secrets.BOT_APP_ID != '' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Download rendered image diff
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ needs.drydock-diff.outputs.IMAGE_ARTIFACT_NAME }}
-
-      - name: Install mise toolchain
-        uses: ./.github/actions/setup-mise
-        with:
-          profile: image
-
       - name: Attempt to pull images and verify platform
+        if: steps.drydock.outputs.has-images == 'true'
+        env:
+          IMAGES_FILE: ${{ steps.drydock.outputs.images-path }}
         run: |
           : > pull_results.txt
           PULL_FAILED=0
@@ -115,14 +97,14 @@ jobs:
             fi
 
             printf "%s\t%s\t%s\n" "${PULL_STATUS}" "${PLATFORM_STATUS}" "${IMAGE_FULL}" >> pull_results.txt
-          done < added-images.txt
+          done < "${IMAGES_FILE}"
 
           if [ "${PULL_FAILED}" -ne 0 ]; then
             exit 1
           fi
 
       - name: Format image pull status
-        if: always()
+        if: always() && steps.drydock.outputs.has-images == 'true'
         run: |
           if [ ! -s pull_results.txt ]; then
             echo "No image pull results were produced. Skipping PR comment."
@@ -140,7 +122,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Generate Token
-        if: always() && env.IMAGE_PULL_COMMENT != ''
+        if: always() && steps.drydock.outputs.has-images == 'true' && env.IMAGE_PULL_COMMENT != ''
           && env.HAS_BOT_APP_CLIENT_ID == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token-client
@@ -151,7 +133,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Generate Token from legacy App ID
-        if: always() && env.IMAGE_PULL_COMMENT != ''
+        if: always() && steps.drydock.outputs.has-images == 'true' && env.IMAGE_PULL_COMMENT != ''
           && env.HAS_BOT_APP_CLIENT_ID != 'true'
           && env.HAS_BOT_APP_ID == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -163,7 +145,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Add image pull comment
-        if: always() && env.IMAGE_PULL_COMMENT != ''
+        if: always() && steps.drydock.outputs.has-images == 'true' && env.IMAGE_PULL_COMMENT != ''
         continue-on-error: true
         uses: mshick/add-pr-comment@8e4927817251f1ff60c001f04568532b38e0b4a0 # v3.11
         with:

--- a/.github/workflows/drydock-gitops.yml
+++ b/.github/workflows/drydock-gitops.yml
@@ -48,6 +48,7 @@ jobs:
           install: "false"
           drydock-bin: drydock
           cache-mode: local
+          cache-path: ${{ runner.tool_cache }}/drydock-cache
           github-app-client-id: ${{ secrets.BOT_APP_CLIENT_ID }}
           github-app-id: ${{ secrets.BOT_APP_ID }}
           github-app-private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
@@ -153,3 +154,20 @@ jobs:
           message-id: "${{ github.event.pull_request.number }}/pull-results"
           message: |
             ${{ env.IMAGE_PULL_COMMENT }}
+
+      # Age out cache entries not used within the window. Source caches (Git,
+      # charts, remote Kustomize) have no automatic eviction, so this bounds
+      # their growth. The render cache is use-based LRU (and 512Mi-capped), so
+      # active renders stay fresh and only stale entries age out. Best-effort:
+      # never fails the job.
+      - name: Prune stale local caches
+        if: always()
+        continue-on-error: true
+        env:
+          CACHE_ROOT: ${{ runner.tool_cache }}/drydock-cache
+        run: |
+          drydock cache prune --older-than 720h --yes \
+            --git-cache-dir "${CACHE_ROOT}/git" \
+            --chart-cache-dir "${CACHE_ROOT}/charts" \
+            --remote-cache-dir "${CACHE_ROOT}/remotes" \
+            --render-cache-dir "${CACHE_ROOT}/renders"


### PR DESCRIPTION
## Summary

Run the drydock render diff on the persistent self-hosted runners (where the image-pull verification already runs) and keep its render cache on local disk, instead of on GitHub-hosted runners with the remote `actions/cache` backend.

## What changed

Merge `drydock-diff` and `verify-new-images` into a single job on `[self-hosted, Linux, ARM64, home-ops, image-pull]`:

- **`cache-mode: local`** — drydock's render cache (new in pr-action v0.2.0) persists on the node's disk. No `actions/cache` upload/download round-trips, and no branch-scoped cache misses; the cache is shared and content-addressed across all PRs on each node.
- **Image pull reads the rendered image list locally** (`steps.drydock.outputs.images-path`) instead of an `upload-artifact`/`download-artifact` handoff between two jobs.
- The conditional pull/verify/comment steps are gated on `steps.drydock.outputs.has-images == 'true'` within the same job.

## Why this is the right shape

- The `verify-new-images` work already had to run on these node-level runners (`sudo home-ops-crictl` against the node containerd), so colocating the diff removes a second job spin-up and the artifact handoff.
- The render cache's heavy consumer is `drydock test apps` (renders every app each PR; `changed-only` only narrows the diff). On a warm local cache it re-renders only changed apps — so persistence is a real speedup that the remote backend couldn't provide here (it was cold on most PRs).

## No extra plumbing needed

- **No prune job:** the render store self-bounds at its 512Mi default LRU cap, enforced on every run (eviction-on-save), which is ample for the app set.
- **No warm-from-master job:** the local cache warms from the first PR's `test apps` render on each node, then stays warm; `cache-warm.yml` is unchanged.

## Notes

- 2 persistent runners → the cache is per-node; both warm independently over the first few PRs.
- The diff now exercises the linux/arm64 drydock binary (installed via mise), matching the runners.
