### PR TITLE
ci(drydock): clear stale base tracking ref before drydock (stopgap)

### DIFF
--- a/.github/workflows/drydock-gitops.yml
+++ b/.github/workflows/drydock-gitops.yml
@@ -43,6 +43,20 @@ jobs:
           # the remote actions/cache restore is redundant; rely on local mise.
           cache: "false"
 
+      # STOPGAP — remove once pinned to drydock pr-action >= v0.2.1. The v0.2.0
+      # fetch-base step updates refs/remotes/origin/<base> with a non-forced
+      # refspec. On these persistent runners a prior run leaves that ref at a
+      # stale, shallow tip, so the depth-1 fetch is rejected as non-fast-forward
+      # and every PR fails. Deleting the ref lets fetch-base recreate it fresh.
+      # Fixed upstream in drydock fetch-base.sh via a force ('+') refspec.
+      - name: Clear stale base remote-tracking ref (drydock fetch-base stopgap)
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          if [ -n "${BASE_REF}" ]; then
+            git update-ref -d "refs/remotes/origin/${BASE_REF}" 2>/dev/null || true
+          fi
+
       - name: Run drydock pull request validation
         id: drydock
         uses: sholdee/drydock/pr-action@45f1cb9d648370f27a791b1f019b7d093dd23969 # v0.2.0


### PR DESCRIPTION
## Problem
Every PR's self-hosted `drydock-diff` job currently fails:

```
! [rejected]        master     -> origin/master  (non-fast-forward)
Error: Process completed with exit code 1.
```

drydock pr-action **v0.2.0**'s `fetch-base.sh` updates `refs/remotes/origin/<base>` with a non-forced refspec. Because the self-hosted runner workspace persists between runs, a prior run leaves that ref at a stale, **shallow** tip; when the base branch advances, the `--depth=1` fetch can't prove a fast-forward and git rejects it → exit 1. This started with the move of drydock to the persistent self-hosted runners.

## Stopgap
Delete `refs/remotes/origin/<base>` before the drydock step so `fetch-base` recreates it fresh — a fresh ref create is never a non-fast-forward. The step is guarded and best-effort, so it can never fail the job, and nothing else in the job reads the ref.

## Removal
This is temporary. The real fix is upstream — sholdee/drydock#153 force-updates the ref (`+` refspec). Once that releases as **v0.2.1**, a follow-up will re-pin `pr-action@<v0.2.1>` and delete this step (flagged in the step's comment).