### PR TITLE
fix(argocd): explicit namespace on Applications so drydock discovers them as argocd/<app>

### DIFF
--- a/apps/argocd/manifests/app-project.yaml
+++ b/apps/argocd/manifests/app-project.yaml
@@ -4,6 +4,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
   name: k3s
+  namespace: argocd
 spec:
   clusterResourceWhitelist:
     - group: "*"

--- a/apps/argocd/manifests/app-set.yaml
+++ b/apps/argocd/manifests/app-set.yaml
@@ -4,6 +4,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: k3s-apps
+  namespace: argocd
 spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]

--- a/apps/argocd/manifests/apps.yaml
+++ b/apps/argocd/manifests/apps.yaml
@@ -4,6 +4,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: cilium
+  namespace: argocd
   annotations:
     argocd.argoproj.io/compare-options: ServerSideDiff=true
 spec:
@@ -109,6 +110,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: crd-schema-publisher
+  namespace: argocd
   annotations:
     argocd.argoproj.io/compare-options: ServerSideDiff=true
 spec:
@@ -161,6 +163,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: dragonfly-operator
+  namespace: argocd
 spec:
   destination:
     name: in-cluster
@@ -210,6 +213,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: grafana-operator
+  namespace: argocd
 spec:
   destination:
     name: in-cluster
@@ -254,6 +258,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: longhorn
+  namespace: argocd
 spec:
   destination:
     name: in-cluster
@@ -303,6 +308,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: reloader
+  namespace: argocd
 spec:
   destination:
     name: in-cluster
@@ -330,6 +336,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: snapshot-controller
+  namespace: argocd
   annotations:
     argocd.argoproj.io/compare-options: ServerSideDiff=true
 spec:
@@ -379,6 +386,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: volsync
+  namespace: argocd
 spec:
   destination:
     name: in-cluster

--- a/apps/argocd/manifests/cilium-preflight.yaml
+++ b/apps/argocd/manifests/cilium-preflight.yaml
@@ -4,6 +4,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: cilium-preflight
+  namespace: argocd
 spec:
   destination:
     name: in-cluster


### PR DESCRIPTION
## What
Add explicit `metadata.namespace: argocd` to the `apps/argocd` Application,
ApplicationSet, AppProject, and cilium-preflight manifests, instead of relying
solely on the kustomization's top-level `namespace: argocd` transformer.

## Why
Argo CD's namespace transformer stamps these at apply time, but tools that read
the raw manifests (without rendering `apps/argocd` through kustomize) see them
as namespace-less. In particular [drydock](https://github.com/sholdee/drydock)'s
default discovery resolved them as bare `<app>` instead of `argocd/<app>`, which
forced `--discover-kustomize apps/argocd` on every invocation — re-rendering the
full argo-cd Helm chart each run and hurting its render cache.

With this change, `drydock build app argocd/<app>`, `drydock test apps`, and the
live-parity sweep all work from a plain checkout with no `--discover-kustomize`:
warm `test apps` drops to ~0.67s (render cache 28/31) from ~3.3s.

## Safety
**Zero change to the live render.** The kustomization already stamps `argocd`, so
making it explicit is redundant — `kustomize build apps/argocd --enable-helm` is
**byte-identical before and after** (91 resources). Pre-commit gates
(kubeconform, yaml-parse, oxfmt, gitleaks) pass.

## Test plan
- [x] `kustomize build apps/argocd --enable-helm` byte-identical pre/post
- [x] `drydock get apps` (plain, no `--discover-kustomize`) → all 31 apps as `argocd/<app>`
- [x] `drydock build app argocd/cert-manager` works from a plain checkout
- [x] `drydock test apps` warm ~0.67s, 28/31 cached