### PR TITLE
fix(dragonfly): drop operator-managed app label from the Dragonfly CR

### DIFF
--- a/components/dragonfly/dragonfly.yaml
+++ b/components/dragonfly/dragonfly.yaml
@@ -13,11 +13,11 @@ spec:
   args:
     - --maxmemory=256mb
     - --cache_mode=true
-  labels:
-    app: dragonfly
-  ownedObjectsMetadata:
-    labels:
-      app: dragonfly
+  # Do NOT set spec.labels / spec.ownedObjectsMetadata with `app: dragonfly`:
+  # dragonfly-operator v1.6+ manages the `app` label itself and rejects a CR that
+  # sets an operator-managed label ("failed to generate dragonfly resources"). The
+  # operator still applies `app: dragonfly` to the owned StatefulSet/pods/objects,
+  # so label selectors (incl. the topology spread below) keep working.
   networkPolicyEnabled: false
   enableReplicationReadinessGate: true
   pdb:


### PR DESCRIPTION
## Problem

dragonfly-operator v1.6.0 (rolled out by the bump to v1.6.1 in #3215) added protection for operator-managed labels. Its resource generation now rejects a `Dragonfly` CR that sets an operator-managed label (`app`) via `spec.labels` or `spec.ownedObjectsMetadata`, aborting reconciliation with the opaque error:

```
failed to reconcile dragonfly resources: failed to generate dragonfly resources
```

No StatefulSet or pods are created and the operator hot-loops. `components/dragonfly/dragonfly.yaml` set `app: dragonfly` in both fields, so the v1.6.1 operator can no longer reconcile any of our Dragonfly instances.

This component is consumed by `apps/argocd` and `apps/renovate` (their redis) as well as the offline bootstrap, so #3215 broke dragonfly in the live cluster — not only in bootstrap.

## Fix

Remove `spec.labels` and `spec.ownedObjectsMetadata` (the `app: dragonfly` overrides). The operator applies `app: dragonfly` to the owned StatefulSet/pods/objects itself, so label selectors — including the `topologySpreadConstraints` selector and the bootstrap's `kubectl wait -l app=dragonfly` — keep working. `metadata.labels` (the CR object's own label, not operator-guarded) is kept.

## Validation

Verified on a kind cluster running operator v1.6.1: with the overrides removed the operator reconciles cleanly — StatefulSet 2/2, master + replica pods Running, pods labelled `app=dragonfly`. A full `just kind-fresh` bootstrap completes through argocd with the dragonfly redis healthy.
