### PR TITLE
ci(drydock): drop fetch-base stopgap now that v0.2.1 is pinned

### DIFF
--- a/.github/workflows/drydock-gitops.yml
+++ b/.github/workflows/drydock-gitops.yml
@@ -43,20 +43,6 @@ jobs:
           # the remote actions/cache restore is redundant; rely on local mise.
           cache: "false"
 
-      # STOPGAP — remove once pinned to drydock pr-action >= v0.2.1. The v0.2.0
-      # fetch-base step updates refs/remotes/origin/<base> with a non-forced
-      # refspec. On these persistent runners a prior run leaves that ref at a
-      # stale, shallow tip, so the depth-1 fetch is rejected as non-fast-forward
-      # and every PR fails. Deleting the ref lets fetch-base recreate it fresh.
-      # Fixed upstream in drydock fetch-base.sh via a force ('+') refspec.
-      - name: Clear stale base remote-tracking ref (drydock fetch-base stopgap)
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: |
-          if [ -n "${BASE_REF}" ]; then
-            git update-ref -d "refs/remotes/origin/${BASE_REF}" 2>/dev/null || true
-          fi
-
       - name: Run drydock pull request validation
         id: drydock
         uses: sholdee/drydock/pr-action@5205bad7e816d3ae060b53b136779848c12a15c8 # v0.2.1


### PR DESCRIPTION
## Context
The `drydock-diff` job carried a temporary stopgap that deleted `refs/remotes/origin/<base>` before the drydock step, to work around drydock pr-action **v0.2.0**'s non-forced fetch-base refspec failing on the persistent self-hosted runners (sholdee/home-ops#3228).

The upstream fix shipped in drydock **v0.2.1** (sholdee/drydock#153) — `fetch-base.sh` now force-updates the remote-tracking ref (`+` refspec) — and this workflow is already pinned to `pr-action@5205bad # v0.2.1`.

## Change
Remove the stopgap step. It is now dead weight; the v0.2.1 fetch-base handles the stale-shallow-ref case itself. The step's own comment flagged it for removal once pinned to >= v0.2.1.

No other changes — the v0.2.1 pin stays. actionlint + lefthook (zizmor, gitleaks, …) clean.