### PR TITLE
feat(kromgo): render README badges directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <div align="center">
 
-[![Kubernetes](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fbadges%2Fkubernetes_version%3Fformat%3Dshields&style=for-the-badge&logo=kubernetes&logoColor=white&color=blue&label=)](https://k3s.io/)&nbsp;&nbsp;
+[![Kubernetes](https://kromgo.sholdee.net:8443/badges/kubernetes_version)](https://k3s.io/)&nbsp;&nbsp;
 
 </div>
 
@@ -22,12 +22,12 @@
 
 <div align="center">
 
-[![Age-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fbadges%2Fcluster_age_days%3Fformat%3Dshields&style=flat-square&label=Age)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
-[![Uptime-Days](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fbadges%2Fcluster_uptime_days%3Fformat%3Dshields&style=flat-square&label=Uptime)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
-[![Node-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fbadges%2Fcluster_node_count%3Fformat%3Dshields&style=flat-square&label=Nodes)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
-[![Pod-Count](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fbadges%2Fcluster_pod_count%3Fformat%3Dshields&style=flat-square&label=Pods)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
-[![CPU-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fbadges%2Fcluster_cpu_usage%3Fformat%3Dshields&style=flat-square&label=CPU)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
-[![Memory-Usage](https://img.shields.io/endpoint?url=https%3A%2F%2Fkromgo.sholdee.net%3A8443%2Fbadges%2Fcluster_memory_usage%3Fformat%3Dshields&style=flat-square&label=Memory)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![Age-Days](https://kromgo.sholdee.net:8443/badges/cluster_age_days)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![Uptime-Days](https://kromgo.sholdee.net:8443/badges/cluster_uptime_days)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![Node-Count](https://kromgo.sholdee.net:8443/badges/cluster_node_count)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![Pod-Count](https://kromgo.sholdee.net:8443/badges/cluster_pod_count)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![CPU-Usage](https://kromgo.sholdee.net:8443/badges/cluster_cpu_usage)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![Memory-Usage](https://kromgo.sholdee.net:8443/badges/cluster_memory_usage)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
 
 </div>
 

--- a/apps/monitoring/kromgo/manifests/config.yaml
+++ b/apps/monitoring/kromgo/manifests/config.yaml
@@ -11,27 +11,48 @@ badges:
   - id: kubernetes_version
     query: max by(git_version) (kubernetes_build_info{job="k3s-server"})
     valueExpr: 'labels[?"git_version"].orValue("unknown")'
+    colorExpr: '"blue"'
+    style: for-the-badge
+    icon: si:kubernetes
   - id: cluster_node_count
     query: count(kube_node_info)
     valueExpr: "humanizeCommas(result)"
     colorExpr: '"green"'
+    style: flat-square
+    title: Nodes
+    icon: mdi:server
   - id: cluster_pod_count
     query: sum(kube_pod_info)
     valueExpr: "humanizeCommas(result)"
     colorExpr: '"green"'
+    style: flat-square
+    title: Pods
+    icon: mdi:cube-outline
   - id: cluster_cpu_usage
     query: round(avg(100 - avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) by (instance) * 100), 0.01)
     valueExpr: 'humanizeFloat(result) + "%"'
     colorExpr: 'result <= 35.0 ? "green" : result <= 75.0 ? "orange" : "red"'
+    style: flat-square
+    title: CPU
+    icon: mdi:cpu-64-bit
   - id: cluster_memory_usage
     query: round((sum(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes)) * 100, 0.1)
     valueExpr: 'humanizeFloat(result) + "%"'
     colorExpr: 'result <= 75.0 ? "green" : result <= 85.0 ? "orange" : "red"'
+    style: flat-square
+    title: Memory
+    icon: mdi:memory
   - id: cluster_age_days
     query: round((time() - max(kube_namespace_created{namespace="kube-system"})) / 86400)
     valueExpr: 'humanizeFloat(result) + "d"'
     colorExpr: '"green"'
+    style: flat-square
+    title: Age
+    icon: mdi:calendar-clock
   - id: cluster_uptime_days
     query: round(avg(node_time_seconds - node_boot_time_seconds) / 86400)
     valueExpr: 'humanizeFloat(result) + "d"'
     colorExpr: 'result <= 180.0 ? "green" : result <= 360.0 ? "orange" : "red"'
+    style: flat-square
+    title: Uptime
+    icon: mdi:timer-outline

--- a/apps/monitoring/kromgo/manifests/deployment.yaml
+++ b/apps/monitoring/kromgo/manifests/deployment.yaml
@@ -34,7 +34,7 @@ spec:
               app: kromgo
       containers:
         - name: kromgo
-          image: ghcr.io/home-operations/kromgo:0.14.8@sha256:fd5e1332dee7664a70927d49574ec7580f3f6498b6319d724f4fee763120592b
+          image: docker.io/sholdee/kromgo:for-the-badge@sha256:024fc0a9961875d21a336eb25f0bfd00ecf9367cc4e00e20bc9a40e744a8906f
           env:
             - name: PROMETHEUS_URL
               value: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"


### PR DESCRIPTION
Converts the seven kromgo-backed README badges from shields.io-proxied to **direct** kromgo SVG.

- **Version badge** → `for-the-badge` with the Kubernetes logo (single-segment, blue).
- **6 cluster stats** → `flat-square` with mdi icons (server / cube / cpu / memory / calendar / timer).
- Styles, titles, icons, and colors move from the badge URLs into the configmap, so the README URLs are bare `/badges/{id}`. Drops the shields.io round-trip; colors now match the live values exactly.
- The 2 healthchecks.io badges are unchanged (different service).

### Image (temporary bridge)
This needs kromgo's `for-the-badge` style + the current-shields palette, which aren't in an upstream release yet, so the deployment temporarily pins `docker.io/sholdee/kromgo:for-the-badge` (public, linux/arm64, digest `sha256:024fc0a9…`). **Follow-up:** switch back to `ghcr.io/home-operations/kromgo:<release>` once that change releases upstream.

### Validation
Ran this exact image + config locally against a mock Prometheus seeded from the live values and compared all 7 badges against the current live README badges — labels/values/colors/styles match, icons added cleanly. All icons resolve at startup; gallery + every badge return 200.