### PR TITLE
fix(kromgo): bump bridge image to the shadow-fixed build

### DIFF
--- a/apps/monitoring/kromgo/manifests/deployment.yaml
+++ b/apps/monitoring/kromgo/manifests/deployment.yaml
@@ -34,7 +34,7 @@ spec:
               app: kromgo
       containers:
         - name: kromgo
-          image: docker.io/sholdee/kromgo:for-the-badge@sha256:024fc0a9961875d21a336eb25f0bfd00ecf9367cc4e00e20bc9a40e744a8906f
+          image: docker.io/sholdee/kromgo:for-the-badge@sha256:7804ba87c6f4a6c0a5c6f99d9cfbd7a54744103c92349e34ba0d1b7dd0c2e1e5
           env:
             - name: PROMETHEUS_URL
               value: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"


### PR DESCRIPTION
Follow-up to #3245. That PR cut the badges over on the pre-shadow-fix image; this swaps the deployment to the rebuilt `sholdee/kromgo:for-the-badge` (digest `sha256:7804ba87…`) which renders **for-the-badge text flat** (no drop shadow), matching how shields.io renders it — so the direct Kubernetes badge sits cleanly next to the shields healthchecks for-the-badge badges.

Image-only change; config/README from #3245 are unaffected. Switches to `ghcr.io/home-operations/kromgo:<release>` once the upstream for-the-badge/palette change releases.