### PR TITLE
chore(kromgo): switch back to the upstream image (0.14.9)

### DIFF
--- a/apps/monitoring/kromgo/manifests/deployment.yaml
+++ b/apps/monitoring/kromgo/manifests/deployment.yaml
@@ -34,7 +34,7 @@ spec:
               app: kromgo
       containers:
         - name: kromgo
-          image: docker.io/sholdee/kromgo:for-the-badge@sha256:7804ba87c6f4a6c0a5c6f99d9cfbd7a54744103c92349e34ba0d1b7dd0c2e1e5
+          image: ghcr.io/home-operations/kromgo:0.14.9@sha256:2843fa3178f03674959307e2b73e563499138c6304776e5d2a935a3df0bc616a
           env:
             - name: PROMETHEUS_URL
               value: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"


### PR DESCRIPTION
for-the-badge, the refreshed shields.io color palette, and the flat for-the-badge text all shipped upstream in **kromgo 0.14.9**, so the temporary `docker.io/sholdee/kromgo:for-the-badge` bridge from #3245/#3246 is no longer needed.

Swaps the deployment back to `ghcr.io/home-operations/kromgo:0.14.9` (digest `sha256:2843fa31…`, multi-arch incl. linux/arm64) — config and README are unchanged.

Verified 0.14.9 against the deployed config locally: starts clean on `style: for-the-badge`, hero renders at 28px with no drop shadow, cluster badges use the refreshed `#67ac09` green — identical to the bridge image. Back under Renovate's management going forward.