### PR TITLE
feat(kromgo): health badges, 7-day graphs, and per-node temps

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,35 @@
 
 </div>
 
+<div align="center">
+
+[![Apps](https://kromgo.sholdee.net:8443/badges/argocd_health)](https://github.com/argoproj/argo-cd)&nbsp;&nbsp;
+[![Alerts](https://kromgo.sholdee.net:8443/badges/alerts_firing)](https://github.com/prometheus/alertmanager)&nbsp;&nbsp;
+[![Certs](https://kromgo.sholdee.net:8443/badges/cert_expiry)](https://github.com/cert-manager/cert-manager)&nbsp;&nbsp;
+[![Storage](https://kromgo.sholdee.net:8443/badges/storage_usage)](https://github.com/longhorn/longhorn)&nbsp;&nbsp;
+
+</div>
+
+<div align="center">
+
+<details>
+<summary>📈 7-day trends</summary>
+<br />
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://kromgo.sholdee.net:8443/graphs/cpu_trend?last=7d&amp;theme=catppuccin-mocha">
+  <img alt="CPU Usage — 7 days" src="https://kromgo.sholdee.net:8443/graphs/cpu_trend?last=7d&amp;theme=catppuccin-latte">
+</picture>
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://kromgo.sholdee.net:8443/graphs/pods_trend?last=7d&amp;theme=catppuccin-mocha">
+  <img alt="Running Pods — 7 days" src="https://kromgo.sholdee.net:8443/graphs/pods_trend?last=7d&amp;theme=catppuccin-latte">
+</picture>
+
+</details>
+
+</div>
+
 ## Overview 📔
 
 This repository defines my Raspberry Pi K3s self-hosting platform, including
@@ -206,12 +235,12 @@ erDiagram
 
 ### Hardware 🖥️
 
-| Node         | Role          | RAM  | Storage        |
-| ------------ | ------------- | ---- | -------------- |
-| k3s-master-0 | Control plane | 16GB | 512GB NVMe SSD |
-| k3s-master-1 | Control plane | 16GB | 512GB NVMe SSD |
-| k3s-master-2 | Control plane | 16GB | 512GB NVMe SSD |
-| k3s-worker-0 | Worker        | 8GB  | 512GB NVMe SSD |
-| k3s-worker-1 | Worker        | 8GB  | 512GB NVMe SSD |
+| Node         | Role          | RAM  | Storage        | Temp                                                               |
+| ------------ | ------------- | ---- | -------------- | ------------------------------------------------------------------ |
+| k3s-master-0 | Control plane | 16GB | 512GB NVMe SSD | ![](https://kromgo.sholdee.net:8443/badges/node_temp_k3s_master_0) |
+| k3s-master-1 | Control plane | 16GB | 512GB NVMe SSD | ![](https://kromgo.sholdee.net:8443/badges/node_temp_k3s_master_1) |
+| k3s-master-2 | Control plane | 16GB | 512GB NVMe SSD | ![](https://kromgo.sholdee.net:8443/badges/node_temp_k3s_master_2) |
+| k3s-worker-0 | Worker        | 8GB  | 512GB NVMe SSD | ![](https://kromgo.sholdee.net:8443/badges/node_temp_k3s_worker_0) |
+| k3s-worker-1 | Worker        | 8GB  | 512GB NVMe SSD | ![](https://kromgo.sholdee.net:8443/badges/node_temp_k3s_worker_1) |
 
 All nodes are Raspberry Pi 5 boards with NVMe SSDs attached via PCIe HAT.

--- a/apps/monitoring/kromgo/manifests/config.yaml
+++ b/apps/monitoring/kromgo/manifests/config.yaml
@@ -1,10 +1,19 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/home-operations/kromgo/0.14.0/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/home-operations/kromgo/0.14.10/config.schema.json
 cache:
   enabled: true
   maxAge: 60
 defaults:
   badge:
+    gallery:
+      hidden: true
+  graph:
+    theme: catppuccin-latte
+    width: 600
+    height: 180
+    legend: false
+    fill: true
+    maxDuration: 30d
     gallery:
       hidden: true
 badges:
@@ -56,3 +65,74 @@ badges:
     style: flat-square
     title: Uptime
     icon: mdi:timer-outline
+  - id: argocd_health
+    query: count(argocd_app_info{health_status!="Healthy", name!="cilium-preflight"}) or vector(0)
+    valueExpr: 'result == 0.0 ? "healthy" : humanizeFloat(result) + " degraded"'
+    colorExpr: 'result == 0.0 ? "green" : "red"'
+    style: flat-square
+    title: Apps
+    icon: si:argo
+  - id: alerts_firing
+    query: count(ALERTS{alertstate="firing", alertname!~"Watchdog|InfoInhibitor"}) or vector(0)
+    valueExpr: 'result == 0.0 ? "0 firing" : humanizeFloat(result) + " firing"'
+    colorExpr: 'result == 0.0 ? "green" : "red"'
+    style: flat-square
+    title: Alerts
+    icon: mdi:bell-alert
+  - id: cert_expiry
+    query: round((min(certmanager_certificate_expiration_timestamp_seconds) - time()) / 86400)
+    valueExpr: 'humanizeFloat(result) + "d"'
+    colorExpr: 'colorScale(result, [7.0, 21.0], ["red", "orange", "green"])'
+    style: flat-square
+    title: Certs
+    icon: mdi:certificate
+  - id: storage_usage
+    query: round(sum(longhorn_node_storage_usage_bytes) / sum(longhorn_node_storage_capacity_bytes) * 100, 0.1)
+    valueExpr: 'humanizeFloat(result) + "%"'
+    colorExpr: 'colorScale(result, [70.0, 85.0], ["green", "orange", "red"])'
+    style: flat-square
+    title: Storage
+    icon: mdi:harddisk
+  - id: node_temp_k3s_master_0
+    query: round(max(node_hwmon_temp_celsius * on(instance) group_left() node_uname_info{nodename="k3s-master-0"}))
+    valueExpr: 'humanizeFloat(result) + "°C"'
+    colorExpr: 'colorScale(result, [65.0, 80.0], ["green", "orange", "red"])'
+    style: flat-square
+    icon: mdi:thermometer
+  - id: node_temp_k3s_master_1
+    query: round(max(node_hwmon_temp_celsius * on(instance) group_left() node_uname_info{nodename="k3s-master-1"}))
+    valueExpr: 'humanizeFloat(result) + "°C"'
+    colorExpr: 'colorScale(result, [65.0, 80.0], ["green", "orange", "red"])'
+    style: flat-square
+    icon: mdi:thermometer
+  - id: node_temp_k3s_master_2
+    query: round(max(node_hwmon_temp_celsius * on(instance) group_left() node_uname_info{nodename="k3s-master-2"}))
+    valueExpr: 'humanizeFloat(result) + "°C"'
+    colorExpr: 'colorScale(result, [65.0, 80.0], ["green", "orange", "red"])'
+    style: flat-square
+    icon: mdi:thermometer
+  - id: node_temp_k3s_worker_0
+    query: round(max(node_hwmon_temp_celsius * on(instance) group_left() node_uname_info{nodename="k3s-worker-0"}))
+    valueExpr: 'humanizeFloat(result) + "°C"'
+    colorExpr: 'colorScale(result, [65.0, 80.0], ["green", "orange", "red"])'
+    style: flat-square
+    icon: mdi:thermometer
+  - id: node_temp_k3s_worker_1
+    query: round(max(node_hwmon_temp_celsius * on(instance) group_left() node_uname_info{nodename="k3s-worker-1"}))
+    valueExpr: 'humanizeFloat(result) + "°C"'
+    colorExpr: 'colorScale(result, [65.0, 80.0], ["green", "orange", "red"])'
+    style: flat-square
+    icon: mdi:thermometer
+graphs:
+  - id: cpu_trend
+    query: avg(100 - avg(rate(node_cpu_seconds_total{mode="idle"}[5m])) by (instance) * 100)
+    title: CPU Usage
+    valueExpr: 'string(int(result)) + "%"'
+    yMin: 0
+    yMax: 100
+    markLine: [average]
+  - id: pods_trend
+    query: sum(kube_pod_status_phase{phase="Running"})
+    title: Running Pods
+    valueExpr: "string(int(result))"
+    markLine: [average]

--- a/apps/monitoring/kromgo/manifests/netpol.yaml
+++ b/apps/monitoring/kromgo/manifests/netpol.yaml
@@ -34,3 +34,28 @@ spec:
                 path: '^/badges/cluster_age_days(\?format=shields)?$'
               - method: GET
                 path: '^/badges/cluster_uptime_days(\?format=shields)?$'
+              # health badges
+              - method: GET
+                path: "^/badges/argocd_health$"
+              - method: GET
+                path: "^/badges/alerts_firing$"
+              - method: GET
+                path: "^/badges/cert_expiry$"
+              - method: GET
+                path: "^/badges/storage_usage$"
+              # per-node temperature badges
+              - method: GET
+                path: "^/badges/node_temp_k3s_master_0$"
+              - method: GET
+                path: "^/badges/node_temp_k3s_master_1$"
+              - method: GET
+                path: "^/badges/node_temp_k3s_master_2$"
+              - method: GET
+                path: "^/badges/node_temp_k3s_worker_0$"
+              - method: GET
+                path: "^/badges/node_temp_k3s_worker_1$"
+              # 7-day trend graphs (range queries; allow ?last=…&theme=… params)
+              - method: GET
+                path: '^/graphs/cpu_trend(\?.*)?$'
+              - method: GET
+                path: '^/graphs/pods_trend(\?.*)?$'

--- a/hack/validate/jsonschema.sh
+++ b/hack/validate/jsonschema.sh
@@ -47,7 +47,7 @@ run_jsonschema() {
 
 if validate_has_file apps/monitoring/kromgo/manifests/config.yaml; then
   if ! run_jsonschema \
-    'https://raw.githubusercontent.com/home-operations/kromgo/0.14.0/config.schema.json' \
+    'https://raw.githubusercontent.com/home-operations/kromgo/0.14.10/config.schema.json' \
     apps/monitoring/kromgo/manifests/config.yaml; then
     failed=1
   fi


### PR DESCRIPTION
Builds on the direct-badge cutover with operational-health badges, two trend graphs, and live per-node temps — all verified against the live Prometheus before opening.

### Badges (health row)
| Badge | Query | Notes |
|-------|-------|-------|
| **Apps** | `argocd_app_info` healthy-count | excludes the intentionally-Missing `cilium-preflight`; green `healthy` / red `N degraded` |
| **Alerts** | `ALERTS{alertstate="firing"}` | excludes always-on `Watchdog`/`InfoInhibitor`; green `0 firing` / red `N firing` |
| **Certs** | soonest `certmanager_…_expiration` | days to expiry, `colorScale` red<7 / orange<21 / green |
| **Storage** | Longhorn node disk % | `colorScale` green<70 / orange<85 / red |

Count badges use `… or vector(0)` so they read `0`/`healthy` instead of erroring when the set is empty (the all-clear state).

### Graphs (collapsible `📈 7-day trends`)
7-day CPU and running-pods trends, served light/dark via `<picture>` + `prefers-color-scheme` (kromgo's per-request `?theme=`), so they look native in both GitHub modes.

### Hardware table — live Temp column
Per-node peak temp (Pi 5 + PCIe/NVMe sensors) via an `instance→node` join, `colorScale` green<65 / orange<80 / red — worker-1 already tips orange under load.

### CiliumNetworkPolicy
The netpol is a strict L7 allowlist of badge paths — **extended with all 11 new badge/graph paths**, or Cilium would 403 them and they'd render broken. Graph rules allow the `?last=…&theme=…` query string.

### Validation script
Bumped the hardcoded kromgo config schema `0.14.0 → 0.14.10` (the deployed version); the graph `fill` option postdates 0.14.0, so the stale pin rejected the new config.