### PR TITLE
fix(monitoring): pin prometheus version < 3.11.0 for prompp compat

### DIFF
--- a/apps/monitoring/values.yaml
+++ b/apps/monitoring/values.yaml
@@ -20,7 +20,12 @@ prometheus:
       tag: "0.8.0"
       sha: 31b2b76059cc9eab4e62445d1c8c4913b9e16939dc88590b0e270fa9825b4a76
       pullPolicy: IfNotPresent
-    version: v3.11.3
+    # Keep < 3.11.0: at >= 3.11.0 prometheus-operator writes storage.tsdb.retention into
+    # the config file, but prompp 0.8.0's parser has no such field (err: "field retention
+    # not found in type config.plain") -- below 3.11.0 the operator uses the
+    # --storage.tsdb.retention.time flag instead, which prompp accepts. Revisit if a
+    # prompp release adds storage.tsdb.retention config support.
+    version: v3.10.0
     serviceMonitorSelectorNilUsesHelmValues: false
     ruleSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
### Fixes Prometheus crashloop after #3288 (kube-prometheus-stack v87)

**Root cause:** v87 bumped prometheus-operator to **v0.92.0**, which for a declared Prometheus version **≥ 3.11.0** writes retention into the **config file** (`storage.tsdb.retention`) instead of the `--storage.tsdb.retention.time` flag. Our `prometheusSpec.version: v3.11.3` tripped it, but the binary is **prompp 0.8.0** (Deckhouse Prometheus++, the latest release) whose parser has no such field:

```
err="… line 3802: field retention not found in type config.plain"
```

**Fix:** declare `version: v3.10.0` (< 3.11.0). The prompp **image stays 0.8.0** — only the version hint the operator gates on changes, reverting it to the retention **flag**, which prompp accepts. The only operator behavior gated at 3.11.0 is this retention move, so nothing else regresses.

**Verified live** (patched the CR ahead of merge to restore the down service): the `storage.tsdb.retention` block is gone from the generated config, `--storage.tsdb.retention.time=10d` is back on the StatefulSet, and both Prometheus pods are `2/2 Running`.

**Long-term:** prompp gap — keep `version < 3.11.0` until a prompp release adds `storage.tsdb.retention` config support (inline comment notes this).