### PR TITLE
fix(argocd): serialize repo-server rendering (kustomize-helm pull race)

### DIFF
--- a/apps/argocd/manifests/values.yaml
+++ b/apps/argocd/manifests/values.yaml
@@ -176,3 +176,8 @@ configs:
     users.anonymous.enabled: "true"
   rbac:
     policy.default: "role:readonly"
+  params:
+    # Serialize repo-server manifest generation. With unlimited parallelism, two
+    # concurrent `kustomize build --enable-helm` renders of the same app race on the
+    # shared `helm pull --untar` dir (err: ".../charts/<chart>/<chart> already exists").
+    reposerver.parallelism.limit: 1


### PR DESCRIPTION
### Fixes the intermittent monitoring sync error

After #3288/#3308, the monitoring app intermittently failed to render:
```
failed to untar: …/apps/monitoring/charts/kube-prometheus-stack-87.2.1/kube-prometheus-stack already exists
: helm pull --untar --untardir …/charts/kube-prometheus-stack-87.2.1 …
```

**Not a stale cache** — repo-server pods are `emptyDir` and restarting them didn't help. It's a **concurrency race**: `reposerver.parallelism.limit: 0` (unlimited) let two `kustomize build --enable-helm` renders of the same app overlap on the shared cloned source. Each checks "chart not present → pull", and one creates the chart dir a beat before the other's `helm pull --untar` lands → "already exists". Single app (no duplicate), so it's purely the unlimited-parallelism overlap.

**Fix:** `reposerver.parallelism.limit: 1` serializes manifest generation so two renders can't collide. ArgoCD self-applies it (cmd-params-cm change → repo-server rollout). Cost is minor — a mass refresh renders the 31 apps one at a time (~a minute worst case); negligible in steady state.

The Prometheus retention fix (#3308) is already applied and healthy; this just stops the render error from flapping.