### PR TITLE
fix: kromgo 0.15.0 breaking changes + mongodb-kubernetes 1.9.1 missing CRDs

### DIFF
--- a/apps/mongodb-operator/kustomization.yaml
+++ b/apps/mongodb-operator/kustomization.yaml
@@ -12,6 +12,7 @@ helmCharts:
     version: 1.9.1
     releaseName: mongodb-kubernetes-operator
     namespace: mongodb-operator
+    includeCRDs: true
     valuesInline:
       operator:
         replicas: 1

--- a/apps/monitoring/kromgo/manifests/config.yaml
+++ b/apps/monitoring/kromgo/manifests/config.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/home-operations/kromgo/0.14.10/config.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/home-operations/kromgo/0.15.0/config.schema.json
 cache:
   enabled: true
   maxAge: 60

--- a/apps/monitoring/kromgo/manifests/deployment.yaml
+++ b/apps/monitoring/kromgo/manifests/deployment.yaml
@@ -36,29 +36,25 @@ spec:
         - name: kromgo
           image: ghcr.io/home-operations/kromgo:0.15.0@sha256:f3c01a0624c95db0f50a65ef901661774da5d2922a3187a2741e7149dee45f2a
           env:
-            - name: PROMETHEUS_URL
+            - name: KROMGO_PROMETHEUS_URL
               value: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
-            - name: SERVER_HOST
+            - name: KROMGO_SERVER_HOST
               value: "0.0.0.0"
-            - name: SERVER_PORT
+            - name: KROMGO_SERVER_PORT
               value: "80"
-            - name: HEALTH_HOST
-              value: "0.0.0.0"
-            - name: HEALTH_PORT
-              value: "88"
+            - name: KROMGO_METRICS_ENABLED
+              value: "false"
           ports:
             - containerPort: 80
               name: http
-            - containerPort: 88
-              name: health
           livenessProbe:
             httpGet:
               path: /healthz
-              port: health
+              port: http
           readinessProbe:
             httpGet:
               path: /readyz
-              port: health
+              port: http
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
Fixes two CrashLoopBackOffs left behind by Renovate version bumps.

## kromgo 0.15.0 (#3355) — monitoring

New pods die instantly with `no prometheus url provided`; rollout stuck, old 0.14.10 RS still serving. [0.15.0 breaking changes](https://github.com/home-operations/kromgo/releases/tag/0.15.0):

- All env vars now require the `KROMGO_` prefix → renamed `PROMETHEUS_URL`/`SERVER_HOST`/`SERVER_PORT`.
- `/healthz` and `/readyz` moved to the main port; the separate health listener is gone (port 88 is now a metrics-only optional listener) → probes point at `http`, port 88 dropped, `KROMGO_METRICS_ENABLED=false` since nothing scrapes it (Service only exposes 80, no ServiceMonitor, netpol only allows the gateway).
- Bumped the config.yaml schema comment 0.14.10 → 0.15.0 (cosmetic).

## mongodb-kubernetes 1.9.1 (#3341) — mongodb-operator

Operator down 6 days (~1750 restarts), crashing at startup:

```
failed to index VoyageAI by TLS cert secret name: no matches for kind "VoyageAI" in version "ai.mongodb.com/v1"
```

1.9.x requires the new `voyageais.ai.mongodb.com` CRD. Our `helmCharts` entry never rendered chart CRDs (the existing ones were applied out-of-band; `mongodb.com` CRDs date from May), which is the same crashloop that forced the 1.9.0 revert in #3340 before Renovate re-landed it as 1.9.1.

Fix: `includeCRDs: true` — keeps CRDs in lockstep with future chart bumps. Verified the 1.9.1 chart renders 8 CRDs including `voyageais.ai.mongodb.com`. ApplicationSet already syncs with `ServerSideApply=true`, so adopting the large existing CRDs is safe (precedent: envoy-gateway-system).

## Validation

- `kustomize build apps/monitoring/kromgo` ✅
- `kustomize build --enable-helm apps/mongodb-operator` ✅ (8 CRDs rendered, voyageais present)
- lefthook pre-commit suite green on both commits (kubeconform, jsonschema, yaml-parse, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)