### PR TITLE
chore(renovate): temporary debug logging for drydock abort diagnosis

### DIFF
--- a/apps/renovate/manifests/renovatejob.yaml
+++ b/apps/renovate/manifests/renovatejob.yaml
@@ -11,7 +11,7 @@ spec:
     ]
   extraEnv:
     - name: LOG_LEVEL
-      value: info
+      value: debug
     - name: RENOVATE_PLATFORM_COMMIT
       value: "true"
     - name: NODE_OPTIONS


### PR DESCRIPTION
Temporary change: RenovateJob LOG_LEVEL info → debug.

sholdee/drydock has ended every renovate run with `repository-changed` since renovate 43.233.3 landed on 2026-06-21 (#3276). Diagnosis so far:

- Deterministic abort ~40s into each run, during branch processing, before any PR activity; repo cache frozen since 2026-06-21T07:20Z (aborted runs never save cache).
- Fresh-cache run (after targeted S3 cache delete) still aborts — immediately after a platform-commit branch update, in the `setBranchStatus` path.
- The bot token can POST the exact status manually (201) — not a permission issue.
- Local dry-run of the same version completes clean (dry-run skips status writes).

Debug logs will name the exact failing URL/error on the next aborting run. Will revert to info once captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)