### PR TITLE
fix(renovate): bump to 43.256.2 — GitHub 422 error-shape crash aborting drydock runs

### DIFF
--- a/apps/renovate/manifests/renovatejob.yaml
+++ b/apps/renovate/manifests/renovatejob.yaml
@@ -11,7 +11,7 @@ spec:
     ]
   extraEnv:
     - name: LOG_LEVEL
-      value: debug
+      value: info
     - name: RENOVATE_PLATFORM_COMMIT
       value: "true"
     - name: NODE_OPTIONS
@@ -46,7 +46,7 @@ spec:
       value: "true"
   provider:
     name: github
-  image: renovate/renovate:43.233.3@sha256:498de63b02c02b49c34dfe0119b59da8e5232e701c813960bcbee80760b148dd
+  image: renovate/renovate:43.256.2@sha256:39182d1ab9fbf428bd702cb737c49197aa18930de666d7d57336468c5ecb8d63
   parallelism: 3
   schedule: "0 * * * *"
   secretRef: renovate-secret


### PR DESCRIPTION
Closes out the drydock RenovateJob failure investigation. Also reverts the temporary debug logging from #3369.

## Root cause (from the debug run)

Every sholdee/drydock renovate run since 2026-06-21 ended `repository-changed`. The captured debug log shows the exact chain on `renovate/golang-1.26.4`:

1. Platform commit updates the branch, then Renovate immediately POSTs the `renovate/stability-days` status to the fresh commit.
2. GitHub replies **422** (read-after-write propagation lag on the just-created commit; the same POST replayed manually against an older commit returns 201).
3. Renovate's 422 handler crashes: `TypeError: err.body?.errors?.find is not a function` at `util/http/github.ts:183` — GitHub's 422 body no longer always carries `errors` as an array.
4. `setBranchStatus`'s catch-all converts the TypeError into `REPOSITORY_CHANGED`, aborting the whole repo — and aborted runs never save the repository cache, so the repo re-wedges identically every hour (cache was frozen at 2026-06-21T07:20Z).

## Fix

Upstream normalizes GitHub error bodies in newer 43.x via the `GithubErrors` zod schema (["GitHub usually returns `errors` as an array, but not always"](https://github.com/renovatebot/renovate/compare/43.233.3...43.256.2)) — the 422 becomes a recoverable error again. Bumping the image to 43.256.2 (digest pinned). GitLab twin of the bug class: renovatebot/renovate#44110.

Renovate's image self-updates have also been stalled since 2026-06-21; this bump should let them resume.

## Expectations after merge

- drydock completes its first full run in 18 days and flushes a backlog of ~16 updates (many automerge-eligible action/gomod bumps), plus refreshes stale PR #160.
- Repo cache re-saves on first success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)