### PR TITLE
chore(renovate): exclude poweradmin from automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -82,6 +82,12 @@
       automerge: false,
     },
     {
+      description: "Exclude poweradmin from automerge - releases can require manual DB migrations (no auto-migrate on pgsql)",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/poweradmin/"],
+      automerge: false,
+    },
+    {
       matchManagers: ["github-actions"],
       matchDatasources: ["github-tags"],
       matchUpdateTypes: ["minor", "patch", "digest"],


### PR DESCRIPTION
## Why

poweradmin does not auto-run DB migrations on pgsql — image upgrades that ship a `sql/poweradmin-pgsql-update-to-X.sql` must wait for the migration to be applied manually. The v4.4.0 automerge (#3469) broke zone editing this way (missing `zone_templ.is_default`; the 4.3.0 migration had also been silently skipped).

## What

Adds a packageRule excluding `/poweradmin/` (docker datasource) from automerge, placed after the blanket docker/helm automerge rule so its `automerge: false` wins. All update types are excluded — patch releases can carry migrations too (4.0.2 did). Renovate still opens the PRs; they just wait for a human who checks for a pending migration first (companion: #3470 adds the parity marker to check against).

## Validation

- `renovate-config-validator` output diff vs master: no new errors
- lefthook validators pass
- Review-gated: 3-lens review + adversarial verification — APPROVE, no blocking findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)