### PR TITLE
fix(renovate): move cilium automerge exclusion below blanket automerge rule

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,15 +24,6 @@
   },
   packageRules: [
     {
-      description: "Separate PRs for cilium",
-      matchFileNames: ["**/apps.yaml"],
-      matchManagers: ["argocd"],
-      matchPackageNames: ["cilium"],
-      additionalBranchPrefix: "cilium-",
-      commitMessageSuffix: " [cilium]",
-      automerge: false,
-    },
-    {
       description: "Separate PRs for cilium-preflight",
       matchFileNames: ["**/cilium-preflight.yaml"],
       matchManagers: ["argocd"],
@@ -74,6 +65,19 @@
       matchFileNames: ["apps/monitoring/values.yaml"],
       matchPackageNames: ["ghcr.io/deckhouse/prompp", "deckhouse/prompp"],
       enabled: false,
+    },
+    // Automerge exclusions below must stay AFTER the blanket automerge rules above:
+    // later packageRules win, so an exclusion placed earlier is silently overridden
+    // (the cilium exclusion added in 2026-04 sat above the blanket rule and was
+    // overridden from day one, until relocated here in 2026-07).
+    {
+      description: "Separate PRs for cilium; never automerge the CNI app",
+      matchFileNames: ["**/apps.yaml"],
+      matchManagers: ["argocd"],
+      matchPackageNames: ["cilium"],
+      additionalBranchPrefix: "cilium-",
+      commitMessageSuffix: " [cilium]",
+      automerge: false,
     },
     {
       description: "Exclude apps with Recreate strategy and no health probes from automerge",


### PR DESCRIPTION
## Why

`[cilium]` CNI update PRs have been automerging despite the `automerge: false` rule — #2920 (v1.19.4), #3237 (v1.19.5), #3420 (v1.19.6) all went in unreviewed. Only `cilium-preflight` is supposed to automerge.

Renovate merges `packageRules` in array order with **later rules winning**. The timeline:

- 8cc1bcef (2026-03-25) appended the blanket docker/helm minor/patch/digest `automerge: true` rule; the cilium rule had no automerge field yet, so #2673 (v1.19.3) automerged.
- 45d4a865 / #2704 (2026-04-21) added `automerge: false` to the cilium rule in response — but at its position **above** the blanket rule, so the blanket rule's `automerge: true` overrode it from day one. The exclusion never worked.

Every `[cilium]` PR before the blanket rule shows `automerge=no`; every one after shows `automerge=YES`.

## What

Pure relocation: the cilium rule (all six functional fields unchanged) moves into the exclusion block after the blanket rules — the same pattern that makes the home-assistant/unifi/poweradmin exclusions work — plus a comment documenting the ordering constraint so the next exclusion doesn't get stranded. Effective config after the move: `[cilium]` automerge false for **all** update types; `cilium-preflight` automerge unchanged (true); branch/PR naming (`cilium-` prefix, `[cilium]` suffix) unchanged; no other dependency affected.

## Validation

- `renovate-config-validator` pinned to the deployed renovate version (43.256.2): output byte-identical to master's (both clean)
- lefthook validators pass
- Review-gated: rule-semantics reviewer computed effective configs for every affected dep post-move; hygiene reviewer's REVISE (root-cause misattribution in the original commit narrative) was fixed and re-verified — final RESOLVED/APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)