### PR TITLE
fix(ci): pin mise on both lock writers; platform-agnostic lockfile check

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -4,6 +4,10 @@ name: Setup mise toolchain
 description: Install the locked repository toolchain with mise
 
 inputs:
+  mise-version:
+    description: mise version
+    # renovate: datasource=github-releases depName=jdx/mise extractVersion=^v(?<version>.+)$
+    default: "2026.7.16"
   profile:
     description: Tool profile to install. One of all, validation, bootstrap-test, drydock, image, operator.
     default: all
@@ -67,22 +71,19 @@ runs:
         path: |
           ~/.cache/mise
           ~/.local/share/mise
-        key: mise-${{ runner.os }}-${{ runner.arch }}-${{ inputs.profile }}-${{ hashFiles('mise.toml', 'mise.lock', '.github/actions/setup-mise/action.yml') }}
+        key: mise-${{ runner.os }}-${{ runner.arch }}-${{ inputs.profile }}-v${{ inputs.mise-version }}-${{ hashFiles('mise.toml', 'mise.lock', '.github/actions/setup-mise/action.yml') }}
         restore-keys: |
-          mise-${{ runner.os }}-${{ runner.arch }}-${{ inputs.profile }}-
+          mise-${{ runner.os }}-${{ runner.arch }}-${{ inputs.profile }}-v${{ inputs.mise-version }}-
 
     - name: Setup mise
       uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
       with:
+        version: ${{ inputs.mise-version }}
         install: false
         install_args: ${{ steps.profile.outputs.tools }}
         cache: false
         experimental: true
         github_token: ${{ github.token }}
-
-    - name: Update mise binary
-      shell: bash
-      run: mise self-update --yes --no-plugins
 
     - name: Install locked toolchain
       shell: bash
@@ -114,7 +115,7 @@ runs:
         path: |
           ~/.cache/mise
           ~/.local/share/mise
-        key: mise-${{ runner.os }}-${{ runner.arch }}-${{ inputs.profile }}-${{ hashFiles('mise.toml', 'mise.lock', '.github/actions/setup-mise/action.yml') }}
+        key: mise-${{ runner.os }}-${{ runner.arch }}-${{ inputs.profile }}-v${{ inputs.mise-version }}-${{ hashFiles('mise.toml', 'mise.lock', '.github/actions/setup-mise/action.yml') }}
 
     - name: Verify mise toolchain
       shell: bash

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,14 @@
       npm: {},
     },
   },
+  // Pin the mise that postUpgradeTasks installs to the SAME version CI pins in
+  // .github/actions/setup-mise/action.yml — the two mise.lock writers must not
+  // skew or the lockfile drift check fails on every renovate PR. The custom
+  // regex manager bumps both sites in one PR.
+  constraints: {
+    // renovate: datasource=github-releases depName=jdx/mise extractVersion=^v(?<version>.+)$
+    mise: "2026.7.16",
+  },
   kubernetes: {
     managerFilePatterns: ["/apps/.*\\.ya?ml$/", "/components/.*\\.ya?ml$/"],
   },
@@ -218,10 +226,14 @@
     },
     {
       customType: "regex",
-      description: ["Process mise installer version in setup action"],
-      managerFilePatterns: ["/^\\.github/actions/setup-mise/action\\.ya?ml$/"],
+      description: ["Process mise installer version in setup action and renovate constraints"],
+      managerFilePatterns: [
+        "/^\\.github/actions/setup-mise/action\\.ya?ml$/",
+        "/^\\.github/renovate\\.json5$/",
+      ],
       matchStrings: [
-        "# renovate: datasource=(?<datasource>[\\w-]+) depName=(?<depName>[\\w./-]+) extractVersion=(?<extractVersion>[^\\s]+)\\n\\s+default: '(?<currentValue>[\\d.]+)'",
+        "# renovate: datasource=(?<datasource>[\\w-]+) depName=(?<depName>[\\w./-]+) extractVersion=(?<extractVersion>[^\\s]+)\\n\\s+default: ['\"](?<currentValue>[\\d.]+)['\"]",
+        "// renovate: datasource=(?<datasource>[\\w-]+) depName=(?<depName>[\\w./-]+) extractVersion=(?<extractVersion>[^\\s]+)\\n\\s+mise: ['\"](?<currentValue>[\\d.]+)['\"]",
       ],
       versioningTemplate: "semver-coerced",
       extractVersionTemplate: "{{{extractVersion}}}",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,28 +69,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Setup mise
-        uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4
+      - name: Install full locked mise toolchain
+        uses: ./.github/actions/setup-mise
         with:
-          install: false
-          cache: false
-          experimental: true
-          github_token: ${{ github.token }}
+          profile: all
 
-      - name: Update mise binary
-        run: mise self-update --yes --no-plugins
-
+      # provenance_verified stamps are host-platform-dependent (mise verifies only
+      # the current platform's artifact at lock time), so the renovate container
+      # (linux-arm64) and this runner (linux-x64) can never produce identical
+      # stamps — exclude them from the drift check.
       - name: Verify mise lockfile is current
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           mise lock --yes
-          git diff --exit-code -- mise.lock
-
-      - name: Install full locked mise toolchain
-        uses: ./.github/actions/setup-mise
-        with:
-          profile: all
+          git diff -I '^provenance_verified = ' --exit-code -- mise.lock
 
   renovate:
     needs: detect

--- a/mise.lock
+++ b/mise.lock
@@ -138,6 +138,7 @@ url = "https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.30.
 checksum = "sha256:88bb6da8ca5b63b5a4e60dae88b320bdcba3a8843536ad86e0fe077765ff2bbc"
 url = "https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.30.0/kubectl-cnpg_1.30.0_darwin_arm64.tar.gz"
 url_api = "https://api.github.com/repos/cloudnative-pg/cloudnative-pg/releases/assets/461307837"
+provenance_verified = true
 
 [tools."github:cloudnative-pg/cloudnative-pg"."platforms.macos-arm64".provenance.slsa]
 url = "https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.30.0/multiple.intoto.jsonl"
@@ -163,6 +164,7 @@ checksum = "sha256:961769d4af345972ac6ab4cf7f806d25bb854e36137c4d7900a917bf59e5f
 url = "https://github.com/sholdee/drydock/releases/download/v0.2.8/drydock_darwin-arm64.tar.gz"
 url_api = "https://api.github.com/repos/sholdee/drydock/releases/assets/486247514"
 provenance = "github-attestations"
+provenance_verified = true
 
 [[tools.gitleaks]]
 version = "8.30.1"
@@ -421,18 +423,18 @@ version = "3.14.6"
 backend = "core:python"
 
 [tools.python."platforms.linux-arm64"]
-checksum = "sha256:c2a2caa03aa9beb77a5bbb5a009c8fe77b96a56925da2dba18095237e30faf04"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260718/cpython-3.14.6+20260718-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:44f86d58f3bbc1aa6c95ee90f03226e0fdbd22475a98c4410e5a20042b7f40d3"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.14.6+20260728-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.linux-x64"]
-checksum = "sha256:86bf107f65fc30b56f2b263b26797fcbb1661f5315910cdbf27f733eb8738b74"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260718/cpython-3.14.6+20260718-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:d6254462d5fe066810a472d286861f6a18f66400008bfa9688e202a5672e88cb"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.14.6+20260728-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.macos-arm64"]
-checksum = "sha256:5e8e0746cb0108d138f510cfbb28c4b031b9ed63bbbe3e43a34c77d4663c4fa1"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260718/cpython-3.14.6+20260718-aarch64-apple-darwin-install_only_stripped.tar.gz"
+checksum = "sha256:f4b47659e2da4b97f38cefdf5ad19f0042946099d843cde60de308708e5b1ac5"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260728/cpython-3.14.6+20260728-aarch64-apple-darwin-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [[tools.rush]]


### PR DESCRIPTION
## Why

Every open renovate PR fails CI. Two failure modes, one root cause: **both `mise.lock` writers float on latest mise** (`mise self-update` in CI; unversioned `installTools: { mise: {} }` in renovate `postUpgradeTasks`), so mise releases break CI directly.

1. **mise-toolchain**: mise ≥2026.7.x stamps `provenance_verified = true` only for artifacts it cryptographically verifies on the *current platform*. Renovate's lock writer (linux-arm64 cluster) stamps arm64 entries; the CI runner (linux-x64) stamps x64 entries — no host can produce a lockfile the `git diff --exit-code` check accepts. Verified from #3485's job log: CI's regen adds x64 stamps on top of the branch's arm64 stamps.
2. **validation**: mise ≥2026.7.15 fails loading the `vfox-1password` plugin (`module 'metadata' not found`) from tools-cache state built by older mise, restored via the `restore-keys` prefix fallback and re-saved under new keys (self-perpetuating). Fresh installs work — verified on macos-arm64 and linux-arm64 (docker); CI's own lock step (fresh, no cache) loads the plugin fine on linux-x64. First failure 07-28 with 2026.7.15; last cache-miss pass 07-24 (≤2026.7.14 era).

## What

- **Pin mise in both writers**: restore the `mise-version` input on `setup-mise` (the orphaned renovate custom manager for this exact annotation is revived — its matchString now accepts either quote style since oxfmt enforces double) and pin the same version in renovate `constraints.mise` so the postUpgradeTasks writer can't skew from CI. The custom manager covers both pin sites, so one CI-gated renovate PR bumps them in lockstep. Both `self-update` steps removed.
- **Version-scoped tools cache**: the mise version is part of the cache key and `restore-keys`, so a mise bump never reuses state built by an older mise — kills the stale-plugin failure class.
- **Platform-agnostic lockfile check**: `git diff -I '^provenance_verified = ' --exit-code` — those stamps are host-dependent by design and can never be consistent across the arm64/x64 writer pair. Real drift in mixed hunks still fails.

**Residual** (documented in the commit): renovate reads config from the default branch, so a future mise-pin-bump PR runs postUpgradeTasks with the *old* pin — a one-PR skew window. If a pin bump ever fails the lockfile check, that's why. Optional hardening if it ever bites: `minimumReleaseAge` for jdx/mise.

## Validation

- zizmor + actionlint + yaml-parse + lefthook hooks pass on all changed files
- `renovate-config-validator` pinned to deployed 43.256.2: clean; both custom-manager regexes tested against the real files (each extracts `jdx/mise` → `2026.7.16`)
- Review-gated: 3-lens review + adversarial verification; REVISE (two-writer skew) fixed via `constraints.mise` — verified against renovate 43.256.2 source that installTools honors it — and re-verified RESOLVED
- **This PR is the end-to-end canary**: it triggers `mise-toolchain` (action.yml is in the paths filter), `validation`, and `bootstrap-test` with fresh version-scoped caches on linux-x64

After merge, the open renovate PRs need a rebase to pick up the fixed workflow (I'll tick their rebase boxes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)