### PR TITLE
fix(ci): alias op to the aqua backend to end the vfox install race

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -32,3 +32,10 @@ kind = "0.32.0"
 lima = "2.2.0"
 op = "2.34.0"
 gh = "2.97.0"
+
+[tool_alias]
+# The registry default for op is the vfox-1password plugin, whose plugin-clone
+# step is not concurrency-safe: parallel `mise exec` lefthook tasks race the
+# clone and fail with "module 'metadata' not found". The aqua backend has no
+# plugin step and installs safely in parallel.
+op = "aqua:1password/cli"


### PR DESCRIPTION
## Problem

Roughly half of all `CI / validation` runs since early August flake with:

```
mise ERROR Failed to install vfox:op@2.34.0: runtime error: crates/vfox/src/plugin.rs:292:2: module 'metadata' not found
```

The validation job pre-installs only the `validation` mise profile, which excludes `op`. The nine parallel lefthook commands each run bare `mise exec --`, which ensures the entire `mise.toml` toolset — so all nine processes race to install the missing tools. The registry default for `op` is the `vfox:mise-plugins/vfox-1password` plugin, and its plugin-clone step is not concurrency-safe: losers of the race load a partially-cloned plugin directory and die on the missing `metadata.lua`. The same logs show one process winning the race and installing `op` successfully, which is why re-runs often pass. The error appears on both mise 2026.8.1 and 2026.8.2, so it is a latent race, not a version regression (currently blocking #3568 and #3569, among others).

## Fix

Alias `op` to `aqua:1password/cli` (also listed for `op` in the mise registry). The aqua backend resolves the same agilebits release URLs from registry metadata with no plugin step, so parallel installs are safe. The tool name is unchanged, so the `setup-mise` profiles and all scripts keep working.

## Validation

- Full `mise lock --yes` under the pinned mise 2026.8.2 against this branch: **zero drift** — the aqua http package locks to byte-identical platform URLs, so `mise.lock` is untouched and the CI lockfile drift check passes.
- Isolated cold install (`mise install --locked op` with a fresh `MISE_DATA_DIR`) uses the aqua download/checksum/extract path with an empty `plugins/` directory — no plugin clone remains in the flow.
- Incidentally reproduced the race class locally: the first `lefthook run pre-commit` on this commit ran nine parallel `mise exec` lazy installs and they collided (symlink-rebuild variant under mise 2026.5.13). The retry with tools present passed all nine checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)