### PR TITLE
fix(ci): point the op lock record at aqua and add pipx to the bootstrap-test profile

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -44,7 +44,7 @@ runs:
             )
             ;;
           bootstrap-test)
-            tools=(python just shellcheck bats rush actionlint zizmor yq jq kustomize helm ansible-core)
+            tools=(python pipx just shellcheck bats rush actionlint zizmor yq jq kustomize helm ansible-core)
             ;;
           drydock)
             tools=(github:sholdee/drydock jq)

--- a/mise.lock
+++ b/mise.lock
@@ -381,7 +381,7 @@ provenance = "github-attestations"
 
 [[tools.op]]
 version = "2.34.0"
-backend = "vfox:op"
+backend = "aqua:1password/cli"
 
 [tools.op."platforms.linux-arm64"]
 url = "https://cache.agilebits.com/dist/1P/op2/pkg/v2.34.0/op_linux_arm64_v2.34.0.zip"


### PR DESCRIPTION
## Summary

Unblocks the jdx/mise 2026.9.x bump (#3663), which fails `validation`, `mise-toolchain`, and `bootstrap-test` on 2026.8.10 → 2026.9.3. Both breakages are in this repo, not upstream, and both fixes also work on the current 2026.8.10, so this can land first and #3663 should go green once renovate rebases it.

### 1. `mise.lock` still records `op` as `backend = "vfox:op"`

The record was written by #2998 (2026-05-20) when the registry default for `op` was the vfox plugin. #3571 aliased `op` to `aqua:1password/cli` in `mise.toml`, but the lock was never re-pointed, and `mise lock op` does not rewrite the `backend` field (verified on both 2026.8.10 and 2026.9.3: the file comes back byte-identical).

mise 2026.8.10 resolved through the alias. Since 2026.8.11 the lock's recorded backend wins, even without `--locked`, so `op` is routed to the asdf/vfox plugin path:

- `mise-toolchain`: `Failed to install aqua:1password/cli@2.34.0: ... asdf plugin op is not installed`
- `validation`: lefthook's `mise exec` auto-install tries `plugin:op clone https://github.com/1password/cli.git` and fails with an IO error

Fix: one-line lock edit to `backend = "aqua:1password/cli"`.

### 2. `bootstrap-test` profile lists `ansible-core` without `pipx`

mise 2026.8.11+ (jdx/mise#12234) hard-errors when a pipx tool's install dependency is not already installed:

```
tool 'ansible-core@2.21.4' requires configured install dependency 'pipx@1.17.2', but its selected version is not installed
```

Fix: add `pipx` to the profile array so the action's existing `requires_pipx` pre-step installs python + pipx first.

## Verification

Isolated mise environments (`MISE_DATA_DIR`/`MISE_CACHE_DIR`/`MISE_CONFIG_DIR`, empty global config), real 2026.8.10 and 2026.9.3 release binaries, this repo's `mise.toml` + `mise.lock`:

| Check | 2026.8.10 | 2026.9.3 |
|---|---|---|
| `mise install --locked --yes op`, lock as on master | pass | fails exactly as CI |
| `mise install --locked --yes op`, lock as in this PR | pass | pass |
| verify step `mise ls --missing --current op` | pass | pass |
| `mise exec op -- op --version` (lefthook path) | pass | pass |
| full `all` profile (25 tools), action steps verbatim | n/a | pass |
| `bootstrap-test` profile with `pipx` added | n/a | pass |

Repo hooks (`hack/validate/github.sh` → zizmor, hygiene, oxfmt, yaml-parse, etc.) pass on the changed files.

## Notes

- `mise exec` auto-install of `op` now logs a harmless `aqua package 1password/cli does not have repo_owner and/or repo_name` warning (http-type aqua package). It does not fail anything.
- Any future `[tool_alias]` change needs a matching edit of the lock's `backend` line, since `mise lock` will not refresh it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtMkczJ6Ea17FanvbbsmZA
